### PR TITLE
use append([]byte, string) special case

### DIFF
--- a/args.go
+++ b/args.go
@@ -46,7 +46,7 @@ func (a *Args) Len() int {
 
 // Parse parses the given string containing query args.
 func (a *Args) Parse(s string) {
-	a.buf = AppendBytesStr(a.buf[:0], s)
+	a.buf = append(a.buf[:0], s...)
 	a.ParseBytes(a.buf)
 }
 
@@ -107,7 +107,7 @@ func (a *Args) WriteTo(w io.Writer) (int64, error) {
 
 // Del deletes argument with the given key from query args.
 func (a *Args) Del(key string) {
-	a.bufKV.key = AppendBytesStr(a.bufKV.key[:0], key)
+	a.bufKV.key = append(a.bufKV.key[:0], key...)
 	a.DelBytes(a.bufKV.key)
 }
 
@@ -118,19 +118,19 @@ func (a *Args) DelBytes(key []byte) {
 
 // Set sets 'key=value' argument.
 func (a *Args) Set(key, value string) {
-	a.bufKV.value = AppendBytesStr(a.bufKV.value[:0], value)
+	a.bufKV.value = append(a.bufKV.value[:0], value...)
 	a.SetBytesV(key, a.bufKV.value)
 }
 
 // SetBytesK sets 'key=value' argument.
 func (a *Args) SetBytesK(key []byte, value string) {
-	a.bufKV.value = AppendBytesStr(a.bufKV.value[:0], value)
+	a.bufKV.value = append(a.bufKV.value[:0], value...)
 	a.SetBytesKV(key, a.bufKV.value)
 }
 
 // SetBytesV sets 'key=value' argument.
 func (a *Args) SetBytesV(key string, value []byte) {
-	a.bufKV.key = AppendBytesStr(a.bufKV.key[:0], key)
+	a.bufKV.key = append(a.bufKV.key[:0], key...)
 	a.SetBytesKV(a.bufKV.key, value)
 }
 
@@ -155,7 +155,7 @@ func (a *Args) PeekBytes(key []byte) []byte {
 
 // Has returns true if the given key exists in Args.
 func (a *Args) Has(key string) bool {
-	a.bufKV.key = AppendBytesStr(a.bufKV.key[:0], key)
+	a.bufKV.key = append(a.bufKV.key[:0], key...)
 	return a.HasBytes(a.bufKV.key)
 }
 
@@ -178,7 +178,7 @@ func (a *Args) GetUint(key string) (int, error) {
 
 // SetUint sets uint value for the given key.
 func (a *Args) SetUint(key string, value int) {
-	a.bufKV.key = AppendBytesStr(a.bufKV.key[:0], key)
+	a.bufKV.key = append(a.bufKV.key[:0], key...)
 	a.SetUintBytes(a.bufKV.key, value)
 }
 

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -309,12 +309,3 @@ func EqualBytesStr(b []byte, s string) bool {
 	}
 	return true
 }
-
-// AppendBytesStr appends src to dst and returns dst
-// (which may be newly allocated).
-func AppendBytesStr(dst []byte, src string) []byte {
-	for i, n := 0, len(src); i < n; i++ {
-		dst = append(dst, src[i])
-	}
-	return dst
-}

--- a/cookie.go
+++ b/cookie.go
@@ -36,7 +36,7 @@ func (c *Cookie) Path() []byte {
 
 // SetPath sets cookie path.
 func (c *Cookie) SetPath(path string) {
-	c.buf = AppendBytesStr(c.buf[:0], path)
+	c.buf = append(c.buf[:0], path...)
 	c.path = normalizePath(c.path, c.buf)
 }
 
@@ -55,7 +55,7 @@ func (c *Cookie) Domain() []byte {
 
 // SetDomain sets cookie domain.
 func (c *Cookie) SetDomain(domain string) {
-	c.domain = AppendBytesStr(c.domain[:0], domain)
+	c.domain = append(c.domain[:0], domain...)
 }
 
 // SetDomain
@@ -93,7 +93,7 @@ func (c *Cookie) Value() []byte {
 
 // SetValue sets cookie value.
 func (c *Cookie) SetValue(value string) {
-	c.value = AppendBytesStr(c.value[:0], value)
+	c.value = append(c.value[:0], value...)
 }
 
 // SetValueBytes sets cookie value.
@@ -110,7 +110,7 @@ func (c *Cookie) Key() []byte {
 
 // SetKey sets cookie name.
 func (c *Cookie) SetKey(key string) {
-	c.key = AppendBytesStr(c.key[:0], key)
+	c.key = append(c.key[:0], key...)
 }
 
 // SetKeyBytes sets cookie name.
@@ -177,7 +177,7 @@ var errNoCookies = errors.New("no cookies found")
 
 // Parse parses Set-Cookie header.
 func (c *Cookie) Parse(src string) error {
-	c.buf = AppendBytesStr(c.buf[:0], src)
+	c.buf = append(c.buf[:0], src...)
 	return c.ParseBytes(c.buf)
 }
 

--- a/header.go
+++ b/header.go
@@ -168,7 +168,7 @@ func (h *ResponseHeader) ContentType() []byte {
 
 // SetContentType sets Content-Type header value.
 func (h *ResponseHeader) SetContentType(contentType string) {
-	h.contentType = AppendBytesStr(h.contentType[:0], contentType)
+	h.contentType = append(h.contentType[:0], contentType...)
 }
 
 // SetContentTypeBytes sets Content-Type header value.
@@ -183,7 +183,7 @@ func (h *ResponseHeader) Server() []byte {
 
 // SetServer sets Server header value.
 func (h *ResponseHeader) SetServer(server string) {
-	h.server = AppendBytesStr(h.server[:0], server)
+	h.server = append(h.server[:0], server...)
 }
 
 // SetServerBytes sets Server header value.
@@ -200,7 +200,7 @@ func (h *RequestHeader) ContentType() []byte {
 // SetContentType sets Content-Type header value.
 func (h *RequestHeader) SetContentType(contentType string) {
 	h.parseRawHeaders()
-	h.contentType = AppendBytesStr(h.contentType[:0], contentType)
+	h.contentType = append(h.contentType[:0], contentType...)
 }
 
 // SetContentTypeBytes sets Content-Type header value.
@@ -231,7 +231,7 @@ func (h *RequestHeader) Host() []byte {
 // SetHost sets Host header value.
 func (h *RequestHeader) SetHost(host string) {
 	h.parseRawHeaders()
-	h.host = AppendBytesStr(h.host[:0], host)
+	h.host = append(h.host[:0], host...)
 }
 
 // SetHostBytes sets Host header value.
@@ -249,7 +249,7 @@ func (h *RequestHeader) UserAgent() []byte {
 // SetUserAgent sets User-Agent header value.
 func (h *RequestHeader) SetUserAgent(userAgent string) {
 	h.parseRawHeaders()
-	h.userAgent = AppendBytesStr(h.userAgent[:0], userAgent)
+	h.userAgent = append(h.userAgent[:0], userAgent...)
 }
 
 // SetUserAgentBytes sets User-Agent header value.
@@ -283,7 +283,7 @@ func (h *RequestHeader) Method() []byte {
 
 // SetMethod sets HTTP request method.
 func (h *RequestHeader) SetMethod(method string) {
-	h.method = AppendBytesStr(h.method, method)
+	h.method = append(h.method, method...)
 }
 
 // SetMethod sets HTTP request method.
@@ -304,7 +304,7 @@ func (h *RequestHeader) RequestURI() []byte {
 // RequestURI must be properly encoded.
 // Use URI.RequestURI for constructing proper RequestURI if unsure.
 func (h *RequestHeader) SetRequestURI(requestURI string) {
-	h.requestURI = AppendBytesStr(h.requestURI, requestURI)
+	h.requestURI = append(h.requestURI, requestURI...)
 }
 
 // SetRequestURI sets RequestURI for the first HTTP request line.
@@ -528,7 +528,7 @@ func (h *ResponseHeader) Set(key, value string) {
 
 // SetBytesK sets the given 'key: value' header.
 func (h *ResponseHeader) SetBytesK(key []byte, value string) {
-	h.bufKV.value = AppendBytesStr(h.bufKV.value[:0], value)
+	h.bufKV.value = append(h.bufKV.value[:0], value...)
 	h.SetBytesKV(key, h.bufKV.value)
 }
 
@@ -584,13 +584,13 @@ func (h *ResponseHeader) SetCookie(cookie *Cookie) {
 
 // SetCookie sets 'key: value' cookies.
 func (h *RequestHeader) SetCookie(key, value string) {
-	h.bufKV.key = AppendBytesStr(h.bufKV.key[:0], key)
+	h.bufKV.key = append(h.bufKV.key[:0], key...)
 	h.SetCookieBytesK(h.bufKV.key, value)
 }
 
 // SetCookieBytesK sets 'key: value' cookies.
 func (h *RequestHeader) SetCookieBytesK(key []byte, value string) {
-	h.bufKV.value = AppendBytesStr(h.bufKV.value[:0], value)
+	h.bufKV.value = append(h.bufKV.value[:0], value...)
 	h.SetCookieBytesKV(key, h.bufKV.value)
 }
 
@@ -609,7 +609,7 @@ func (h *RequestHeader) Set(key, value string) {
 
 // SetBytesK sets the given 'key: value' header.
 func (h *RequestHeader) SetBytesK(key []byte, value string) {
-	h.bufKV.value = AppendBytesStr(h.bufKV.value[:0], value)
+	h.bufKV.value = append(h.bufKV.value[:0], value...)
 	h.SetBytesKV(key, h.bufKV.value)
 }
 
@@ -1399,11 +1399,11 @@ func nextLine(b []byte) ([]byte, []byte, error) {
 
 func initHeaderKV(kv *argsKV, key, value string) {
 	kv.key = getHeaderKeyBytes(kv, key)
-	kv.value = AppendBytesStr(kv.value[:0], value)
+	kv.value = append(kv.value[:0], value...)
 }
 
 func getHeaderKeyBytes(kv *argsKV, key string) []byte {
-	kv.key = AppendBytesStr(kv.key[:0], key)
+	kv.key = append(kv.key[:0], key...)
 	normalizeHeaderKey(kv.key)
 	return kv.key
 }

--- a/server.go
+++ b/server.go
@@ -430,7 +430,7 @@ func (ctx *RequestCtx) Error(msg string, statusCode int) {
 	resp.Reset()
 	resp.SetStatusCode(statusCode)
 	resp.Header.SetContentTypeBytes(defaultContentType)
-	resp.body = AppendBytesStr(resp.body[:0], msg)
+	resp.body = append(resp.body[:0], msg...)
 }
 
 // Success sets response Content-Type and body to the given values.

--- a/uri.go
+++ b/uri.go
@@ -34,7 +34,7 @@ func (x *URI) Hash() []byte {
 
 // SetHash sets URI hash.
 func (x *URI) SetHash(hash string) {
-	x.hash = AppendBytesStr(x.hash[:0], hash)
+	x.hash = append(x.hash[:0], hash...)
 }
 
 // SetHashBytes sets URI hash.
@@ -52,7 +52,7 @@ func (x *URI) QueryString() []byte {
 
 // SetQueryString sets URI query string.
 func (x *URI) SetQueryString(queryString string) {
-	x.queryString = AppendBytesStr(x.queryString[:0], queryString)
+	x.queryString = append(x.queryString[:0], queryString...)
 }
 
 // SetQueryStringBytes sets URI query string.
@@ -76,7 +76,7 @@ func (x *URI) Path() []byte {
 
 // SetPath sets URI path.
 func (x *URI) SetPath(path string) {
-	x.pathOriginal = AppendBytesStr(x.pathOriginal, path)
+	x.pathOriginal = append(x.pathOriginal, path...)
 	x.path = normalizePath(x.path, x.pathOriginal)
 }
 
@@ -108,7 +108,7 @@ func (x *URI) Scheme() []byte {
 
 // SetScheme sets URI scheme, i.e. http, https, ftp, etc.
 func (x *URI) SetScheme(scheme string) {
-	x.scheme = AppendBytesStr(x.scheme[:0], scheme)
+	x.scheme = append(x.scheme[:0], scheme...)
 	lowercaseBytes(x.scheme)
 }
 


### PR DESCRIPTION
From the specs:

> As a special case, copy also accepts a destination argument assignable to type []byte with a source  argument of a string type. This form copies the bytes from the string into the byte slice.
https://golang.org/ref/spec#Appending_and_copying_slices


Doesn't seem faster or slower, but is nice to use, and makes it easier for the compiler to be smart.