### PR TITLE
Fixed client copy resp from respCopy inversely

### DIFF
--- a/client.go
+++ b/client.go
@@ -715,7 +715,7 @@ func clientDoTimeoutFreeConn(req *Request, resp *Response, timeout time.Duration
 	var err error
 	select {
 	case err = <-ch:
-		resp.CopyTo(respCopy)
+		respCopy.CopyTo(resp)
 		releaseResponse(respCopy)
 		releaseRequest(reqCopy)
 		errorChPool.Put(chv)


### PR DESCRIPTION
When using `fasthttp.Do()`, there is no resp return because client copy resp from respCopy inversely. For example in `testClientDoTimeoutError`:

```
var req Request
	var resp Response
	req.SetRequestURI("http://foobar.com/baz")
	for i := 0; i < n; i++ {
		err := c.DoTimeout(&req, &resp, time.Millisecond)
		if err == nil {
			t.Fatalf("expecting error")
		}
		if err != ErrTimeout {
			t.Fatalf("unexpected error: %s. Expecting %s", err, ErrTimeout)
		}
	}
```

This PR fixed the bug here.