### PR TITLE
Redirect 307 instead of 302

### DIFF
--- a/server.go
+++ b/server.go
@@ -650,7 +650,8 @@ func (ctx *RequestCtx) redirect(uri []byte, statusCode int) {
 }
 
 func getRedirectStatusCode(statusCode int) int {
-	if statusCode == StatusMovedPermanently || statusCode == StatusFound || statusCode == StatusSeeOther {
+	if statusCode == StatusMovedPermanently || statusCode == StatusFound ||
+		statusCode == StatusSeeOther || statusCode == StatusTemporaryRedirect {
 		return statusCode
 	}
 	return StatusFound


### PR DESCRIPTION
Hi @valyala 

When I test my fasthttprouter, I want to redirect a 307 request while you return a 302 response. I don't know what you consider about that. Wish your reply.