### PR TITLE
100-Continue support for forms

### DIFF
--- a/http.go
+++ b/http.go
@@ -389,8 +389,8 @@ func (resp *Response) resetSkipHeader() {
 // RemoveMultipartFormFiles or Reset must be called after
 // reading multipart/form-data request in order to delete temporarily
 // uploaded files.
-func (req *Request) Read(r *bufio.Reader) error {
-	return req.ReadLimitBody(r, 0)
+func (req *Request) Read(r *bufio.Reader, ctx *RequestCtx, on100Continue func(req *Request) bool) error {
+	return req.ReadLimitBody(r, 0, ctx, on100Continue)
 }
 
 const defaultMaxInMemoryFileSize = 16 * 1024 * 1024
@@ -405,11 +405,11 @@ var errGetOnly = errors.New("non-GET request received")
 // RemoveMultipartFormFiles or Reset must be called after
 // reading multipart/form-data request in order to delete temporarily
 // uploaded files.
-func (req *Request) ReadLimitBody(r *bufio.Reader, maxBodySize int) error {
-	return req.readLimitBody(r, maxBodySize, false)
+func (req *Request) ReadLimitBody(r *bufio.Reader, maxBodySize int, ctx *RequestCtx, on100Continue func(req *Request) bool) error {
+	return req.readLimitBody(r, maxBodySize, false, ctx, on100Continue)
 }
 
-func (req *Request) readLimitBody(r *bufio.Reader, maxBodySize int, getOnly bool) error {
+func (req *Request) readLimitBody(r *bufio.Reader, maxBodySize int, getOnly bool, ctx *RequestCtx, on100Continue func(req *Request) bool) error {
 	req.resetSkipHeader()
 	err := req.Header.Read(r)
 	if err != nil {
@@ -422,11 +422,33 @@ func (req *Request) readLimitBody(r *bufio.Reader, maxBodySize int, getOnly bool
 	if !req.Header.noBody() {
 		contentLength := req.Header.ContentLength()
 		if contentLength > 0 {
+			// See http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html for 100-Continue behavior
+			expect:=req.Header.Peek("Expect")
+			if(len(expect)>0){
+				lowercaseBytes(expect)
+				if(bytes.Compare(expect,[]byte("100-continue"))==0){
+					if(on100Continue==nil || on100Continue(req)){
+						ctx.c.Write([]byte("HTTP/1.1 100 Continue\r\n\r\n"))
+					} else {
+						ctx.c.Write([]byte("HTTP/1.1 417 Expectation Failed\r\n\r\n"))
+					}
+				} else {
+					ctx.c.Write([]byte("HTTP/1.1 417 Expectation Failed\r\n\r\n"))
+				}
+			}
+
+
 			// Pre-read multipart form data of known length.
 			// This way we limit memory usage for large file uploads, since their contents
 			// is streamed into temporary files if file size exceeds defaultMaxInMemoryFileSize.
 			boundary := req.Header.MultipartFormBoundary()
 			if len(boundary) > 0 {
+				if(contentLength>0){
+					//We were stalling on waiting for an ending CRLF, RFC2616/4.1 "an HTTP/1.1 client must not preface or follow request with an extra CRLF"
+					//which was causing curl to hang waiting on a post request
+					maxBodySize=contentLength
+				}
+
 				req.multipartForm, err = readMultipartFormBody(r, boundary, maxBodySize, defaultMaxInMemoryFileSize)
 				if err != nil {
 					req.Reset()

--- a/http_test.go
+++ b/http_test.go
@@ -94,9 +94,26 @@ func TestOn100Continue(t *testing.T){
 
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	if err := req.Read(br,continueBuffer,func(req *Request) bool {  return true } ); err != nil {
+	if err := req.Read(br, continueBuffer, func(req *Request) bool {  return true } ); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+
+	if(bytes.Compare(continueBuffer.Bytes(), []byte("HTTP/1.1 100 Continue\r\n\r\n"))!=0){
+		t.Fatalf("Expected 100 continue response on expect header, instead got: %s", continueBuffer.String())
+	}
+
+	continueBuffer.Reset()
+
+	r = bytes.NewBufferString(s)
+	br = bufio.NewReader(r)
+	if err := req.Read(br, continueBuffer, func(req *Request) bool {  return false} ); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if(bytes.Compare(continueBuffer.Bytes(), []byte("HTTP/1.1 417 Expectation Failed\r\n\r\n"))!=0){
+		t.Fatalf("Expected 471 expectation fail, instead got: %s", continueBuffer.String())
+	}
+
 }
 
 

--- a/http_test.go
+++ b/http_test.go
@@ -32,7 +32,7 @@ func TestRequestMultipartForm(t *testing.T) {
 
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	if err := req.Read(br); err != nil {
+	if err := req.Read(br,nil,nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -66,6 +66,39 @@ func TestRequestMultipartForm(t *testing.T) {
 		}
 	}
 }
+
+
+
+func TestOn100Continue(t *testing.T){
+	var w bytes.Buffer
+	mw := multipart.NewWriter(&w)
+	for i := 0; i < 10; i++ {
+		k := fmt.Sprintf("key_%d", i)
+		v := fmt.Sprintf("value_%d", i)
+		if err := mw.WriteField(k, v); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	}
+	boundary := mw.Boundary()
+	if err := mw.Close(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	formData := w.Bytes()
+	s := fmt.Sprintf("POST / HTTP/1.1\r\nHost: aaa\r\nContent-Type: multipart/form-data; boundary=%s\r\nExpect: 100-Continue\r\nContent-Length: %d\r\n\r\n%s",
+		boundary, len(formData), formData)
+
+
+	var req Request
+
+	continueBuffer:=&bytes.Buffer{}
+
+	r := bytes.NewBufferString(s)
+	br := bufio.NewReader(r)
+	if err := req.Read(br,continueBuffer,func(req *Request) bool {  return true } ); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
 
 func TestResponseReadLimitBody(t *testing.T) {
 	// response with content-length
@@ -122,7 +155,7 @@ func testRequestReadLimitBodyError(t *testing.T, s string, maxBodySize int) {
 	var req Request
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	err := req.ReadLimitBody(br, maxBodySize)
+	err := req.ReadLimitBody(br, maxBodySize,nil,nil)
 	if err == nil {
 		t.Fatalf("expecting error. s=%q, maxBodySize=%d", s, maxBodySize)
 	}
@@ -135,7 +168,7 @@ func testRequestReadLimitBodySuccess(t *testing.T, s string, maxBodySize int) {
 	var req Request
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	if err := req.ReadLimitBody(br, maxBodySize); err != nil {
+	if err := req.ReadLimitBody(br, maxBodySize,nil,nil); err != nil {
 		t.Fatalf("unexpected error: %s. s=%q, maxBodySize=%d", err, s, maxBodySize)
 	}
 }
@@ -186,7 +219,7 @@ func TestRequestWriteRequestURINoHost(t *testing.T) {
 
 	var req1 Request
 	br := bufio.NewReader(&w)
-	if err := req1.Read(br); err != nil {
+	if err := req1.Read(br, nil, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	if string(req1.Header.Host()) != "google.com" {
@@ -274,7 +307,7 @@ func TestRequestReadChunked(t *testing.T) {
 	s := "POST /foo HTTP/1.1\r\nHost: google.com\r\nTransfer-Encoding: chunked\r\nContent-Type: aa/bb\r\n\r\n3\r\nabc\r\n5\r\n12345\r\n0\r\n\r\ntrail"
 	r := bytes.NewBufferString(s)
 	rb := bufio.NewReader(r)
-	err := req.Read(rb)
+	err := req.Read(rb, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error when reading chunked request: %s", err)
 	}
@@ -456,7 +489,7 @@ func testRequestSuccess(t *testing.T, method, requestURI, host, userAgent, body,
 
 	var req1 Request
 	br := bufio.NewReader(w)
-	if err = req1.Read(br); err != nil {
+	if err = req1.Read(br, nil, nil); err != nil {
 		t.Fatalf("Unexpected error when calling Request.Read(): %s", err)
 	}
 	if string(req1.Header.Method()) != expectedMethod {
@@ -661,7 +694,7 @@ func TestRequestPostArgsError(t *testing.T) {
 func testRequestPostArgsError(t *testing.T, req *Request, s string) {
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	err := req.Read(br)
+	err := req.Read(br, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error when reading %q: %s", s, err)
 	}
@@ -674,7 +707,7 @@ func testRequestPostArgsError(t *testing.T, req *Request, s string) {
 func testRequestPostArgsSuccess(t *testing.T, req *Request, s string, expectedArgsLen int, expectedArgs ...string) {
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	err := req.Read(br)
+	err := req.Read(br, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error when reading %q: %s", s, err)
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -32,7 +32,7 @@ func TestRequestMultipartForm(t *testing.T) {
 
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	if err := req.Read(br,nil,nil); err != nil {
+	if err := req.Read(br, nil, nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -67,9 +67,7 @@ func TestRequestMultipartForm(t *testing.T) {
 	}
 }
 
-
-
-func TestOn100Continue(t *testing.T){
+func TestOn100Continue(t *testing.T) {
 	var w bytes.Buffer
 	mw := multipart.NewWriter(&w)
 	for i := 0; i < 10; i++ {
@@ -87,18 +85,17 @@ func TestOn100Continue(t *testing.T){
 	s := fmt.Sprintf("POST / HTTP/1.1\r\nHost: aaa\r\nContent-Type: multipart/form-data; boundary=%s\r\nExpect: 100-Continue\r\nContent-Length: %d\r\n\r\n%s",
 		boundary, len(formData), formData)
 
-
 	var req Request
 
-	continueBuffer:=&bytes.Buffer{}
+	continueBuffer := &bytes.Buffer{}
 
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	if err := req.Read(br, continueBuffer, func(req *Request) bool {  return true } ); err != nil {
+	if err := req.Read(br, continueBuffer, func(req *Request) bool { return true }); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if(bytes.Compare(continueBuffer.Bytes(), []byte("HTTP/1.1 100 Continue\r\n\r\n"))!=0){
+	if bytes.Compare(continueBuffer.Bytes(), []byte("HTTP/1.1 100 Continue\r\n\r\n")) != 0 {
 		t.Fatalf("Expected 100 continue response on expect header, instead got: %s", continueBuffer.String())
 	}
 
@@ -106,16 +103,15 @@ func TestOn100Continue(t *testing.T){
 
 	r = bytes.NewBufferString(s)
 	br = bufio.NewReader(r)
-	if err := req.Read(br, continueBuffer, func(req *Request) bool {  return false} ); err != nil {
+	if err := req.Read(br, continueBuffer, func(req *Request) bool { return false }); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if(bytes.Compare(continueBuffer.Bytes(), []byte("HTTP/1.1 417 Expectation Failed\r\n\r\n"))!=0){
+	if bytes.Compare(continueBuffer.Bytes(), []byte("HTTP/1.1 417 Expectation Failed\r\n\r\n")) != 0 {
 		t.Fatalf("Expected 471 expectation fail, instead got: %s", continueBuffer.String())
 	}
 
 }
-
 
 func TestResponseReadLimitBody(t *testing.T) {
 	// response with content-length
@@ -172,7 +168,7 @@ func testRequestReadLimitBodyError(t *testing.T, s string, maxBodySize int) {
 	var req Request
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	err := req.ReadLimitBody(br, maxBodySize,nil,nil)
+	err := req.ReadLimitBody(br, maxBodySize, nil, nil)
 	if err == nil {
 		t.Fatalf("expecting error. s=%q, maxBodySize=%d", s, maxBodySize)
 	}
@@ -185,7 +181,7 @@ func testRequestReadLimitBodySuccess(t *testing.T, s string, maxBodySize int) {
 	var req Request
 	r := bytes.NewBufferString(s)
 	br := bufio.NewReader(r)
-	if err := req.ReadLimitBody(br, maxBodySize,nil,nil); err != nil {
+	if err := req.ReadLimitBody(br, maxBodySize, nil, nil); err != nil {
 		t.Fatalf("unexpected error: %s. s=%q, maxBodySize=%d", err, s, maxBodySize)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -188,10 +188,10 @@ type Server struct {
 	GetOnly bool
 
 	// On100Continue Handler a header Expect: 100-continue
-	// 
+	//
 	// Per HTTP/1.1 on a Put or Post request the client
-  // can provide a header tag which indicates the client
-  // wants an OK from the server before sending the body.
+	// can provide a header tag which indicates the client
+	// wants an OK from the server before sending the body.
 	// By default we'll OK all requests with 100-contunue.
 	On100Continue func(req *Request) bool
 

--- a/server.go
+++ b/server.go
@@ -187,6 +187,14 @@ type Server struct {
 	// Server accepts all the requests by default.
 	GetOnly bool
 
+	// On100Continue Handler a header Expect: 100-continue
+	// 
+	// Per HTTP/1.1 on a Put or Post request the client
+  // can provide a header tag which indicates the client
+  // wants an OK from the server before sending the body.
+	// By default we'll OK all requests with 100-contunue.
+	On100Continue func(req *Request) bool
+
 	// Logger, which is used by RequestCtx.Logger().
 	//
 	// By default standard logger from log package is used.
@@ -1073,7 +1081,7 @@ func (s *Server) serveConn(c net.Conn) error {
 			if br == nil {
 				br = acquireReader(ctx)
 			}
-			err = ctx.Request.readLimitBody(br, s.MaxRequestBodySize, s.GetOnly)
+			err = ctx.Request.readLimitBody(br, s.MaxRequestBodySize, s.GetOnly, ctx, s.On100Continue)
 			if br.Buffered() == 0 || err != nil {
 				releaseReader(s, br)
 				br = nil
@@ -1081,7 +1089,7 @@ func (s *Server) serveConn(c net.Conn) error {
 		} else {
 			br, err = acquireByteReader(&ctx)
 			if err == nil {
-				err = ctx.Request.ReadLimitBody(br, s.MaxRequestBodySize)
+				err = ctx.Request.ReadLimitBody(br, s.MaxRequestBodySize, ctx, s.On100Continue)
 				if br.Buffered() == 0 || err != nil {
 					releaseReader(s, br)
 					br = nil

--- a/server.go
+++ b/server.go
@@ -1081,7 +1081,7 @@ func (s *Server) serveConn(c net.Conn) error {
 			if br == nil {
 				br = acquireReader(ctx)
 			}
-			err = ctx.Request.readLimitBody(br, s.MaxRequestBodySize, s.GetOnly, ctx, s.On100Continue)
+			err = ctx.Request.readLimitBody(br, s.MaxRequestBodySize, s.GetOnly, ctx.c, s.On100Continue)
 			if br.Buffered() == 0 || err != nil {
 				releaseReader(s, br)
 				br = nil
@@ -1089,7 +1089,7 @@ func (s *Server) serveConn(c net.Conn) error {
 		} else {
 			br, err = acquireByteReader(&ctx)
 			if err == nil {
-				err = ctx.Request.ReadLimitBody(br, s.MaxRequestBodySize, ctx, s.On100Continue)
+				err = ctx.Request.ReadLimitBody(br, s.MaxRequestBodySize, ctx.c, s.On100Continue)
 				if br.Buffered() == 0 || err != nil {
 					releaseReader(s, br)
 					br = nil


### PR DESCRIPTION
Hi, I was blocked by lack of 100-Continue support for forms. 

You can reproduce this issue by trying to upload a file using curl, like so:

curl -v -v -X POST -F file=@/etc/hosts http://bear.local:8081/upload.php

> POST /upload.php HTTP/1.1
> User-Agent: curl/7.38.0
> Host: bear.local:8081
> Accept: */*
> Content-Length: 381
> Expect: 100-continue
> Content-Type: multipart/form-data; boundary=------------------------807912e865bb9c45
>
< HTTP/1.1 100 Continue
< HTTP/1.1 200 OK

I've added a handler to Server called On100Continue which lets the user override the behavior when the client expects a 100-Continue. 

Essentially you'd be able to override this function to accept or reject requests with 100-continue.