### PR TITLE
Donot modify content-length when if header set

### DIFF
--- a/http.go
+++ b/http.go
@@ -869,7 +869,9 @@ func (resp *Response) Write(w *bufio.Writer) error {
 		return resp.closeBodyStream()
 	}
 
-	resp.Header.SetContentLength(len(resp.body))
+	if resp.Header.contentLength == 0 {
+		resp.Header.SetContentLength(len(resp.body))
+	}
 	if err = resp.Header.Write(w); err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi @valyala 

In my cases, when I send `HEAD` requests, fasthttp use body length to set `Content-Length` header.

But the `HEAD` response doesn't has body. So the `Content-Length` is always 0.

I tested in `net/http`, it doesn't modify this header. So, what do you think about?