### PR TITLE
Don't assume Content-Encoding: identity when request is 1xx, 204 or 304

### DIFF
--- a/header.go
+++ b/header.go
@@ -1466,7 +1466,7 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 	if h.contentLength < 0 {
 		h.contentLengthBytes = h.contentLengthBytes[:0]
 	}
-	if h.contentLength == -2 && !h.ConnectionUpgrade() {
+	if h.contentLength == -2 && !h.ConnectionUpgrade() && !h.mustSkipContentLength() {
 		h.h = setArg(h.h, strTransferEncoding, strIdentity)
 		h.connectionClose = true
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -1032,6 +1032,27 @@ func TestResponseHeaderReadSuccess(t *testing.T) {
 		t.Fatalf("unexpected connection: close")
 	}
 
+	// no content-length (informational responses)
+	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 101 OK\r\n\r\n",
+		101, -2, "text/plain; charset=utf-8", "")
+	if h.ConnectionClose() {
+		t.Fatalf("expecting connection: keep-alive for informational response")
+	}
+
+	// no content-length (no-content responses)
+	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 204 OK\r\n\r\n",
+		204, -2, "text/plain; charset=utf-8", "")
+	if h.ConnectionClose() {
+		t.Fatalf("expecting connection: keep-alive for no-content response")
+	}
+
+	// no content-length (not-modified responses)
+	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 304 OK\r\n\r\n",
+		304, -2, "text/plain; charset=utf-8", "")
+	if h.ConnectionClose() {
+		t.Fatalf("expecting connection: keep-alive for not-modified response")
+	}
+
 	// no content-length (identity transfer-encoding)
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 200 OK\r\nContent-Type: foo/bar\r\n\r\nabcdefg",
 		200, -2, "foo/bar", "abcdefg")


### PR DESCRIPTION
Should fix #37
It replicates the logic in [header.go#L200](https://github.com/valyala/fasthttp/blob/master/header.go#L200)
Another way to fix this would be to assume default content-length: 0
Transfer-Encoding: identity appears to have been deprecated anyways 