### PR TITLE
fix fasthttpadaptor to work with http.ServeMux in Go 1.5

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -65,6 +65,9 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 		})
 		r.Header = hdr
 		r.Body = &netHTTPBody{body}
+		// After Go1.5 http.ServeMux uses URL field to get the path for
+		// request routing purposes.
+		r.URL = &url.URL{Path: string(ctx.Path())}
 
 		var w netHTTPResponseWriter
 		h.ServeHTTP(&w, &r)

--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -5,6 +5,7 @@ package fasthttpadaptor
 import (
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/valyala/fasthttp"
 )


### PR DESCRIPTION
I am not sure if this is the best fix for it, however without it the adaptor will just cause the process to crash.

I couldn't find string version of Path() so []byte to string conversion has to happen here.