### PR TITLE
reuseport: close Listener

### DIFF
--- a/reuseport/reuseport.go
+++ b/reuseport/reuseport.go
@@ -92,6 +92,7 @@ func Listen(network, addr string) (l net.Listener, err error) {
 	}
 
 	if err = file.Close(); err != nil {
+		l.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
If closing of an underlying File returns error, a Listener will not be returned to a user and will not be closed as well.



