### PR TITLE
Add func (resp *Response) ReleaseBody(size int)

### DIFF
--- a/http.go
+++ b/http.go
@@ -375,6 +375,16 @@ func (resp *Response) ResetBody() {
 	resp.body = resp.body[:0]
 }
 
+// ReleaseBody retires the response body if it is greater than "size" bytes. 
+// This permits GC to reclaim the large buffer.  If used, must be before
+// ReleaseResponse.
+func (resp *Response) ReleaseBody(size int) {
+	if cap(resp.body) > size {
+		resp.ResetBody()
+		resp.body = []byte{}
+	}
+}
+
 // Body returns request body.
 func (req *Request) Body() []byte {
 	if req.bodyStream != nil {


### PR DESCRIPTION
This adds a method to permit explicit freeing of memory.

```go
	request := fasthttp.AcquireRequest()
	response := fasthttp.AcquireResponse()
        // ... stuff ... //

	response.ReleaseBody(1024 * 1024)
	fasthttp.ReleaseResponse(response)
	fasthttp.ReleaseRequest(request)
```
---

Background:

I spent a fair bit of time this morning trying to figure out a memory leak, that wasn't.  This was in a  load generator replaying CDN traffic, with a mix of mostly small objects but the occasional large object.  

I was primarily baffled at the increasing number of objects that were 16M or 32M each, claimed by fasthttp.appendBodyFixedSize.  

```
(pprof) top 1
8.82GB of 9.21GB total (95.72%)
Dropped 218 nodes (cum <= 0.05GB)
Showing top 1 nodes out of 22 (cum >= 8.95GB)
      flat  flat%   sum%        cum   cum%
    8.82GB 95.72% 95.72%     8.95GB 97.11%  github.com/valyala/fasthttp.appendBodyFixedSize
```

Digging into the memory allocations and counts, the bulk of the memory is lost to 16MB and 32MB chunks of memory.  Looking at the code, and rereading the fasthttp's documentation, this is clearly a feature, not a bug.  I understand very much why the code does this.

Yet, it still hurts in my case case.

With the attached PR, a new function is exposed to allow "large" backing stores to get cleared.  I don't think this is a one-size-fits-all thing; I don't think there is a good default value.  It very much depends on what you're doing; and whether you're just *occasionally* dealing with video-sized HTTP segments versus page assets.

Putting this change to use, and setting the cutoff at 1 meg, I saw no reduction in the load generator performance. I did however see my memory footprint much more stable, much more sane.

It might be *nicer* if this could be a client or request setting; but I didn't want to make a huge sweeping change.  This PR is minimal change, and won't change anything for people who don't opt to use it.

---

**PS:**  Thank you for this excellent http client module.  Within a couple hours I had a basic load generator working that could pull 25 gigabit of traffic on a single host, in a single process.  This exceeded my expectations by an order of magnitude.  
