### PR TITLE
Change bodyStream in Request and Response to io.ReadCloser

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -396,7 +396,7 @@ type fsFile struct {
 	bigFilesLock sync.Mutex
 }
 
-func (ff *fsFile) NewReader() (io.Reader, error) {
+func (ff *fsFile) NewReader() (io.ReadCloser, error) {
 	if ff.isBig() {
 		r, err := ff.bigFileReader()
 		if err != nil {
@@ -407,7 +407,7 @@ func (ff *fsFile) NewReader() (io.Reader, error) {
 	return ff.smallFileReader(), nil
 }
 
-func (ff *fsFile) smallFileReader() io.Reader {
+func (ff *fsFile) smallFileReader() io.ReadCloser {
 	v := ff.h.smallFileReaderPool.Get()
 	if v == nil {
 		v = &fsSmallFileReader{}
@@ -428,12 +428,12 @@ func (ff *fsFile) isBig() bool {
 	return ff.contentLength > maxSmallFileSize && len(ff.dirIndex) == 0
 }
 
-func (ff *fsFile) bigFileReader() (io.Reader, error) {
+func (ff *fsFile) bigFileReader() (io.ReadCloser, error) {
 	if ff.f == nil {
 		panic("BUG: ff.f must be non-nil in bigFileReader")
 	}
 
-	var r io.Reader
+	var r io.ReadCloser
 
 	ff.bigFilesLock.Lock()
 	n := len(ff.bigFiles)

--- a/http.go
+++ b/http.go
@@ -28,7 +28,7 @@ type Request struct {
 	body []byte
 	w    requestBodyWriter
 
-	bodyStream io.Reader
+	bodyStream io.ReadCloser
 
 	uri      URI
 	postArgs Args
@@ -158,7 +158,7 @@ func (resp *Response) SendFile(path string) error {
 // Note that GET and HEAD requests cannot have body.
 //
 // See also SetBodyStreamWriter.
-func (req *Request) SetBodyStream(bodyStream io.Reader, bodySize int) {
+func (req *Request) SetBodyStream(bodyStream io.ReadCloser, bodySize int) {
 	req.ResetBody()
 	req.bodyStream = bodyStream
 	req.Header.SetContentLength(bodySize)

--- a/http.go
+++ b/http.go
@@ -58,7 +58,7 @@ type Response struct {
 	body []byte
 	w    responseBodyWriter
 
-	bodyStream io.Reader
+	bodyStream io.ReadCloser
 
 	// Response.Read() skips reading body if set to true.
 	// Use it for reading HEAD responses.
@@ -175,7 +175,7 @@ func (req *Request) SetBodyStream(bodyStream io.Reader, bodySize int) {
 // if it implements io.Closer.
 //
 // See also SetBodyStreamWriter.
-func (resp *Response) SetBodyStream(bodyStream io.Reader, bodySize int) {
+func (resp *Response) SetBodyStream(bodyStream io.ReadCloser, bodySize int) {
 	resp.ResetBody()
 	resp.bodyStream = bodyStream
 	resp.Header.SetContentLength(bodySize)

--- a/http_test.go
+++ b/http_test.go
@@ -191,7 +191,7 @@ func TestResponseBodyStreamMultipleBodyCalls(t *testing.T) {
 	var r Response
 
 	s := "foobar baz abc"
-	r.SetBodyStream(bytes.NewBufferString(s), len(s))
+	r.SetBodyStream(ioutil.NopCloser(bytes.NewBufferString(s)), len(s))
 	for i := 0; i < 10; i++ {
 		body := r.Body()
 		if string(body) != s {
@@ -222,7 +222,7 @@ func TestResponseBodyWriteToStream(t *testing.T) {
 	var r Response
 
 	expectedS := "aaabbbccc"
-	buf := bytes.NewBufferString(expectedS)
+	buf := ioutil.NopCloser(bytes.NewBufferString(expectedS))
 	r.SetBodyStream(buf, len(expectedS))
 
 	testBodyWriteTo(t, &r, expectedS, false)
@@ -928,7 +928,7 @@ func testSetResponseBodyStream(t *testing.T, body string, chunked bool) {
 	if chunked {
 		bodySize = -1
 	}
-	resp.SetBodyStream(bytes.NewBufferString(body), bodySize)
+	resp.SetBodyStream(ioutil.NopCloser(bytes.NewBufferString(body)), bodySize)
 
 	var w bytes.Buffer
 	bw := bufio.NewWriter(&w)

--- a/http_test.go
+++ b/http_test.go
@@ -178,7 +178,7 @@ func TestRequestBodyStreamMultipleBodyCalls(t *testing.T) {
 	var r Request
 
 	s := "foobar baz abc"
-	r.SetBodyStream(bytes.NewBufferString(s), len(s))
+	r.SetBodyStream(ioutil.NopCloser(bytes.NewBufferString(s)), len(s))
 	for i := 0; i < 10; i++ {
 		body := r.Body()
 		if string(body) != s {
@@ -901,7 +901,7 @@ func testSetRequestBodyStream(t *testing.T, body string, chunked bool) {
 	if chunked {
 		bodySize = -1
 	}
-	req.SetBodyStream(bytes.NewBufferString(body), bodySize)
+	req.SetBodyStream(ioutil.NopCloser(bytes.NewBufferString(body)), bodySize)
 
 	var w bytes.Buffer
 	bw := bufio.NewWriter(&w)

--- a/server.go
+++ b/server.go
@@ -986,7 +986,7 @@ func (ctx *RequestCtx) PostBody() []byte {
 // If bodySize < 0, then bodyStream is read until io.EOF.
 //
 // See also SetBodyStreamWriter.
-func (ctx *RequestCtx) SetBodyStream(bodyStream io.Reader, bodySize int) {
+func (ctx *RequestCtx) SetBodyStream(bodyStream io.ReadCloser, bodySize int) {
 	ctx.Response.SetBodyStream(bodyStream, bodySize)
 }
 


### PR DESCRIPTION
The following comments says `bodyStream.Close() is called after ...`, so bodyStream should be `io.ReadCloser`.

* https://github.com/valyala/fasthttp/blob/ae8de36df0f996f3a2bd31c31c9e39d7b1b9fda0/server.go#L980
* https://github.com/valyala/fasthttp/blob/ae8de36df0f996f3a2bd31c31c9e39d7b1b9fda0/http.go#L155
* https://github.com/valyala/fasthttp/blob/ae8de36df0f996f3a2bd31c31c9e39d7b1b9fda0/http.go#L174
