### PR TITLE
Handle TransferEncoding in fasthttpadaptor

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -62,7 +62,14 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 
 		hdr := make(http.Header)
 		ctx.Request.Header.VisitAll(func(k, v []byte) {
-			hdr.Set(string(k), string(v))
+			sk := string(k)
+			sv := string(v)
+			switch sk {
+			case "Transfer-Encoding":
+				r.TransferEncoding = append(r.TransferEncoding, sv)
+			default:
+				hdr.Set(sk, sv)
+			}
 		})
 		r.Header = hdr
 		r.Body = &netHTTPBody{body}

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -20,6 +20,7 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	expectedRequestURI := "/foo/bar?baz=123"
 	expectedBody := "body 123 foo bar baz"
 	expectedContentLength := len(expectedBody)
+	expectedTransferEncoding := "encoding"
 	expectedHost := "foobar.com"
 	expectedRemoteAddr := "1.2.3.4:6789"
 	expectedHeader := map[string]string{
@@ -52,6 +53,9 @@ func TestNewFastHTTPHandler(t *testing.T) {
 		}
 		if r.ContentLength != int64(expectedContentLength) {
 			t.Fatalf("unexpected contentLength %d. Expecting %d", r.ContentLength, expectedContentLength)
+		}
+		if len(r.TransferEncoding) != 1 || r.TransferEncoding[0] != expectedTransferEncoding {
+			t.Fatalf("unexpected transferEncoding %d. Expecting %d", r.TransferEncoding, expectedTransferEncoding)
 		}
 		if r.Host != expectedHost {
 			t.Fatalf("unexpected host %q. Expecting %q", r.Host, expectedHost)
@@ -91,6 +95,7 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	req.Header.SetMethod(expectedMethod)
 	req.SetRequestURI(expectedRequestURI)
 	req.Header.SetHost(expectedHost)
+	req.Header.Add("Transfer-Encoding", expectedTransferEncoding)
 	req.BodyWriter().Write([]byte(expectedBody))
 	for k, v := range expectedHeader {
 		req.Header.Set(k, v)


### PR DESCRIPTION
When incoming http.Request is constructed, "Transfer-Encoding" header is removed, and http.Request.TransferEncoding is set instead. See [`fixTransferEncoding()`](https://golang.org/src/net/http/transfer.go?h=fixTransferEncoding#L432).

This behaviour is now emulated in `fasthttpadaptor`.