### PR TITLE
Implement RequestCtx.VisitUserValues as requested

### DIFF
--- a/server.go
+++ b/server.go
@@ -481,6 +481,17 @@ func (ctx *RequestCtx) UserValueBytes(key []byte) interface{} {
 	return ctx.userValues.GetBytes(key)
 }
 
+// VisitUserValues calls visitor for each existing userValue.
+//
+// visitor must not retain references to key and value after returning.
+// Make key and/or value copies if you need storing them after returning.
+func (ctx *RequestCtx) VisitUserValues(visitor func([]byte, interface{})) {
+	for i, n := 0, len(ctx.userValues); i < n; i++ {
+		kv := &ctx.userValues[i]
+		visitor(kv.key, kv.value)
+	}
+}
+
 // IsTLS returns true if the underlying connection is tls.Conn.
 //
 // tls.Conn is an encrypted connection (aka SSL, HTTPS).

--- a/server_test.go
+++ b/server_test.go
@@ -1031,6 +1031,17 @@ func TestRequestCtxUserValue(t *testing.T) {
 			t.Fatalf("unexpected value obtained for key %q: %v. Expecting %d", k, v, i)
 		}
 	}
+	vlen := 0
+	ctx.VisitUserValues(func(key []byte, value interface{}) {
+		vlen++
+		v := ctx.UserValueBytes(key)
+		if v != value {
+			t.Fatalf("unexpected value obtained from VisitUserValues for key: %q, expecting: %#v but got: %#v", key, v, value)
+		}
+	})
+	if len(ctx.userValues) != vlen {
+		t.Fatalf("the length of user values returned from VisitUserValues is not equal to the length of the userValues, expecting: %d but got: %d", len(ctx.userValues), vlen)
+	}
 }
 
 func TestServerHeadRequest(t *testing.T) {


### PR DESCRIPTION
See this issue: https://github.com/valyala/fasthttp/issues/126.

RequestCtx.userValues are not exported, but many times is useful to get all context's user values, exporting the .userValues is not a good idea because the key/value is request lifetime, with `VisitUserValues` the developer can copy these values and use anywhere he/she wants, test added.