### PR TITLE
Fixed bug with quoted multipart form boundaries

### DIFF
--- a/header.go
+++ b/header.go
@@ -383,6 +383,9 @@ func (h *RequestHeader) MultipartFormBoundary() []byte {
 		if n = bytes.IndexByte(b, ';'); n >= 0 {
 			b = b[:n]
 		}
+		if len(b) > 1 && b[0] == '"' && b[len(b)-1] == '"' {
+			b = b[1 : len(b)-1]
+		}
 		return b
 	}
 	return nil


### PR DESCRIPTION
[RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1.1) allows for the boundary portion of the Content-Type header to be quoted. This was not being correctly handled. 

MultipartFormBoundary will now check for wrapping quotes, and remove them if present. 