### PR TITLE
fix DoDeadline side effect when no free connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -956,6 +956,7 @@ func clientDoDeadlineFreeConn(req *Request, resp *Response, deadline time.Time, 
 			respCopy.copyToSkipBody(resp)
 			swapResponseBody(resp, respCopy)
 		}
+		swapRequestBody(reqCopy, req)
 		ReleaseResponse(respCopy)
 		ReleaseRequest(reqCopy)
 		errorChPool.Put(chv)


### PR DESCRIPTION
This fix relates to concurrent `DoTimeout/DoDeadline` using a `HostClient`: when there is no more free connection, as the `Request`'s body has been swapped, all subsequent calls will have an empty body.

I originally used `req.CopyTo` instead of swapping the body until I saw 3546c31: I think this solution should have a minimal impact on performance.