### PR TITLE
Proof of Concept: handling huge/endless response body

### DIFF
--- a/http.go
+++ b/http.go
@@ -42,6 +42,7 @@ type Request struct {
 	parsedPostArgs bool
 
 	keepBodyBuffer bool
+	HandlingBodyManually bool
 }
 
 // Response represents HTTP response.
@@ -70,6 +71,8 @@ type Response struct {
 	SkipBody bool
 
 	keepBodyBuffer bool
+
+	manualBodyReader io.ReadCloser
 }
 
 // SetHost sets host for the request.
@@ -441,6 +444,7 @@ func (resp *Response) ResetBody() {
 			resp.body = nil
 		}
 	}
+	resp.manualBodyReader = nil
 }
 
 // ReleaseBody retires the response body if it is greater than "size" bytes.
@@ -1321,6 +1325,10 @@ func (req *Request) String() string {
 // Use Write instead of String for performance-critical code.
 func (resp *Response) String() string {
 	return getHTTPString(resp)
+}
+
+func (resp *Response) ManualBodyReader() io.ReadCloser {
+	return resp.manualBodyReader
 }
 
 func getHTTPString(hw httpWriter) string {


### PR DESCRIPTION
Not to be merged yet, PoC only.
It's done by setting a flag `HandlingBodyManually` (new) into `Request`. If it's set, then the `HostClient` disables automatic response body fetch for the response by setting `SkipBody` flag on the response in it's `Do`. Then it sets a `manualBodyReadAccessor` in the response, which is to be used by user to read the data.

As the result, it's impossible to release/close resources used (the reader and the connection) inside the `doNonNilReqResp()` since they are needed to read data afterward, they leak outside.

 `manualBodyReadAccessor` holds references to and is responsible to release:
1. The `buffered reader` that had been used for reading the response header in the first place. It's the data source off which the user is meant to read data. As I get it, there is no way to throw the one away and acquire a new one later: it may have already pulled some parts of data out of the connection and buffered it.
2. The connection (for releasing).
3. ShouldClose flag: should it close the connection or just release one.
4. HostClient to release resources to it.

Usage:

``` go
    req.HandlingBodyManually = true
    _ = fasthttp.Do(req, resp)
    r := resp.ManualBodyReader()
    for {
        // r is io.ReadCloser, pass it around, read, do stuff.
    }
    _ = r.Close()
```
