### PR TITLE
Adding support to case-insensitive cookie attributes

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -275,7 +275,7 @@ func (c *Cookie) ParseBytes(src []byte) error {
 		if len(kv.key) == 0 && len(kv.value) == 0 {
 			continue
 		}
-		switch string(kv.key) {
+		switch string(bytes.ToLower(kv.key)) {
 		case "expires":
 			v := b2s(kv.value)
 			exptime, err := time.ParseInLocation(time.RFC1123, v, time.UTC)
@@ -288,8 +288,8 @@ func (c *Cookie) ParseBytes(src []byte) error {
 		case "path":
 			c.path = append(c.path[:0], kv.value...)
 		case "":
-			switch string(kv.value) {
-			case "HttpOnly":
+			switch string(bytes.ToLower(kv.value)) {
+			case "httponly":
 				c.httpOnly = true
 			case "secure":
 				c.secure = true

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -176,6 +176,7 @@ func TestCookieParse(t *testing.T) {
 	testCookieParse(t, `foo="bar"`, "foo=bar")
 	testCookieParse(t, `"foo"=bar`, `"foo"=bar`)
 	testCookieParse(t, "foo=bar; domain=aaa.com; path=/foo/bar", "foo=bar; domain=aaa.com; path=/foo/bar")
+	testCookieParse(t, "foo=bar; Domain=aaa.com; Path=/foo/bar", "foo=bar; domain=aaa.com; path=/foo/bar")
 	testCookieParse(t, " xxx = yyy  ; path=/a/b;;;domain=foobar.com ; expires= Tue, 10 Nov 2009 23:00:00 GMT ; ;;",
 		"xxx=yyy; expires=Tue, 10 Nov 2009 23:00:00 GMT; domain=foobar.com; path=/a/b")
 }


### PR DESCRIPTION
Accordingly to [RFC 6265](https://tools.ietf.org/html/rfc6265#section-5.2.2) - _HTTP State Management Mechanism_, `Set-Cookie` header includes cookie attributes that must be treated case-insensitively. `fasthttp` `Parse()` and `ParseBytes()` methods work only with lower case attributes, and this PR fixes that.
