### PR TITLE
Don't try to compress 204 or 304

### DIFF
--- a/server.go
+++ b/server.go
@@ -343,6 +343,10 @@ func CompressHandler(h RequestHandler) RequestHandler {
 func CompressHandlerLevel(h RequestHandler, level int) RequestHandler {
 	return func(ctx *RequestCtx) {
 		h(ctx)
+		// Don't do anything for 204 or 304 as they never have a body.
+		if code := ctx.Response.StatusCode(); code == StatusNoContent || code == StatusNotModified {
+			return
+		}
 		ce := ctx.Response.Header.PeekBytes(strContentEncoding)
 		if len(ce) > 0 {
 			// Do not compress responses with non-empty

--- a/server_test.go
+++ b/server_test.go
@@ -1372,6 +1372,28 @@ func TestCompressHandler(t *testing.T) {
 	}
 }
 
+func TestCompressHandlerNoContent(t *testing.T) {
+	h := CompressHandler(func(ctx *RequestCtx) {
+		ctx.Response.Header.SetStatusCode(StatusNoContent)
+	})
+
+	var ctx RequestCtx
+	var resp Response
+
+	ctx.Request.Header.Set("Accept-Encoding", "gzip, deflate, sdhc")
+
+	h(&ctx)
+	s := ctx.Response.String()
+	br := bufio.NewReader(bytes.NewBufferString(s))
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	ce := resp.Header.Peek("Content-Encoding")
+	if string(ce) != "" {
+		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "")
+	}
+}
+
 func TestRequestCtxWriteString(t *testing.T) {
 	var ctx RequestCtx
 	n, err := ctx.WriteString("foo")


### PR DESCRIPTION
These responses can not have a body so trying to compress them and adding the Content-Encoding header is useless.