### PR TITLE
Do case insensitive comparison of cookie fields

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -256,6 +256,22 @@ func (c *Cookie) Parse(src string) error {
 	return c.ParseBytes(c.buf)
 }
 
+// Case insensitive equality comparison of two []byte. Assumes only
+// letters need to be matched.
+func alphaOnlyCIEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := 0; i < len(a); i++ {
+		if a[i]|0x20 != b[i]|0x20 {
+			return false
+		}
+	}
+
+	return true
+}
+
 // ParseBytes parses Set-Cookie header.
 func (c *Cookie) ParseBytes(src []byte) error {
 	c.Reset()
@@ -272,29 +288,44 @@ func (c *Cookie) ParseBytes(src []byte) error {
 	c.value = append(c.value[:0], kv.value...)
 
 	for s.next(kv) {
-		if len(kv.key) == 0 && len(kv.value) == 0 {
-			continue
-		}
-		switch string(kv.key) {
-		case "expires":
-			v := b2s(kv.value)
-			exptime, err := time.ParseInLocation(time.RFC1123, v, time.UTC)
-			if err != nil {
-				return err
+		if len(kv.key) != 0 {
+			// Case insensitive switch on first char
+			switch kv.key[0] | 0x20 {
+			case 'e': // "expires"
+				if alphaOnlyCIEqual(strCookieExpires, kv.key) {
+					v := b2s(kv.value)
+					exptime, err := time.ParseInLocation(time.RFC1123, v, time.UTC)
+					if err != nil {
+						return err
+					}
+					c.expire = exptime
+				}
+
+			case 'd': // "domain"
+				if alphaOnlyCIEqual(strCookieDomain, kv.key) {
+					c.domain = append(c.domain[:0], kv.value...)
+				}
+
+			case 'p': // "path"
+				if alphaOnlyCIEqual(strCookiePath, kv.key) {
+					c.path = append(c.path[:0], kv.value...)
+				}
 			}
-			c.expire = exptime
-		case "domain":
-			c.domain = append(c.domain[:0], kv.value...)
-		case "path":
-			c.path = append(c.path[:0], kv.value...)
-		case "":
-			switch string(kv.value) {
-			case "HttpOnly":
-				c.httpOnly = true
-			case "secure":
-				c.secure = true
+
+		} else if len(kv.value) != 0 {
+			// Case insensitive switch on first char
+			switch kv.value[0] | 0x20 {
+			case 'h': // "httponly"
+				if alphaOnlyCIEqual(strCookieHTTPOnly, kv.value) {
+					c.httpOnly = true
+				}
+
+			case 's': // "secure"
+				if alphaOnlyCIEqual(strCookieSecure, kv.value) {
+					c.secure = true
+				}
 			}
-		}
+		} // else empty or no match
 	}
 	return nil
 }

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -176,6 +176,7 @@ func TestCookieParse(t *testing.T) {
 	testCookieParse(t, `foo="bar"`, "foo=bar")
 	testCookieParse(t, `"foo"=bar`, `"foo"=bar`)
 	testCookieParse(t, "foo=bar; domain=aaa.com; path=/foo/bar", "foo=bar; domain=aaa.com; path=/foo/bar")
+	testCookieParse(t, "foo=bar; Domain=aaa.com; PATH=/foo/bar", "foo=bar; domain=aaa.com; path=/foo/bar")
 	testCookieParse(t, " xxx = yyy  ; path=/a/b;;;domain=foobar.com ; expires= Tue, 10 Nov 2009 23:00:00 GMT ; ;;",
 		"xxx=yyy; expires=Tue, 10 Nov 2009 23:00:00 GMT; domain=foobar.com; path=/a/b")
 }


### PR DESCRIPTION
The case insensitive comparison implemented in this PR avoids any new
allocation and provides improved performance over the current
case sensitive comparison.

The approach taken was to quickly narrow the possibilities down to a
single value by comparing only the first character in the key. It
then performs a full case insensitive comparison using a special
function that compares two []byte. The function is meant to only be
used to compare words that have only letters. Other uses could result
in false positives, though it would be unlikely and probably harmless.

Micro benchmarking showed this approach performing in roughly half the
time per operation over the current case sensitive implementation;
16.4 ns/op vs 29.4 ns/op.

Fixes #181 

---

*EDIT: Test failure is the Go 1.6 build only, and doesn't appear related to this PR.*