### PR TITLE
Allow elision of Server header in response

### DIFF
--- a/header.go
+++ b/header.go
@@ -1425,10 +1425,9 @@ func (h *ResponseHeader) AppendBytes(dst []byte) []byte {
 	dst = append(dst, statusLine(statusCode)...)
 
 	server := h.Server()
-	if len(server) == 0 {
-		server = defaultServerName
+	if len(server) != 0 {
+		dst = appendHeaderLine(dst, strServer, server)
 	}
-	dst = appendHeaderLine(dst, strServer, server)
 	dst = appendHeaderLine(dst, strDate, serverDate.Load().([]byte))
 
 	// Append Content-Type only for non-zero responses

--- a/http_test.go
+++ b/http_test.go
@@ -1248,7 +1248,7 @@ func TestResponseSuccess(t *testing.T) {
 
 	// response with missing server
 	testResponseSuccess(t, 500, "aaa", "", "aaadfsd",
-		500, "aaa", string(defaultServerName))
+		500, "aaa", "")
 
 	// empty body
 	testResponseSuccess(t, 200, "bbb", "qwer", "",

--- a/server.go
+++ b/server.go
@@ -265,14 +265,14 @@ type Server struct {
 	//     * cONTENT-lenGTH -> Content-Length
 	DisableHeaderNamesNormalizing bool
 
-	// ElideServerHeader, when set to true, causes the default Server header
+	// NoDefaultServerHeader, when set to true, causes the default Server header
 	// to be excluded from the Response.
 	//
 	// The default Server header value is the value of the Name field or an
 	// internal default value in its absence. With this option set to true,
 	// the only time a Server header will be sent is if a non-zero length
 	// value is explicitly provided during a request.
-	ElideServerHeader bool
+	NoDefaultServerHeader bool
 
 	// Logger, which is used by RequestCtx.Logger().
 	//
@@ -1449,7 +1449,7 @@ const DefaultMaxRequestBodySize = 4 * 1024 * 1024
 
 func (s *Server) serveConn(c net.Conn) error {
 	var serverName []byte
-	if !s.ElideServerHeader {
+	if !s.NoDefaultServerHeader {
 		serverName = s.getServerName()
 	}
 
@@ -1981,7 +1981,7 @@ func (s *Server) writeFastError(w io.Writer, statusCode int, msg string) {
 	w.Write(statusLine(statusCode))
 
 	server := ""
-	if !s.ElideServerHeader {
+	if !s.NoDefaultServerHeader {
 		server = fmt.Sprintf("Server: %s\r\n", s.getServerName())
 	}
 


### PR DESCRIPTION
Allow elision of Server header in response

This PR adds an option to the Server called `ElideServerHeader` that
allows a user to indicate that neither the Server's `Name` field nor
the `defaultServerName` should be included in the Server's responses
as a `Server` header by default.

Now when `ResponseHeader.AppendBytes` is found to have an empty `server`
field, it simply skips the `Server` header. Previously that method
would write the `defaultServerName` when no value was found. The only
code paths that took advantage of that were ones originating from
`writeErrorResponse`, which now handles setting the server name
directly.

Fixes #221

---

Note:

- This retains the ability to call `ResponseHeader.SetServerBytes()` with a desired value. The elision is only with respect to the initial "global" values.
- As a side-effect of this change, even if this option is not set, you'll be able to eliminate the `Server` header by explicitly setting an empty string during a request.
- With the previous behavior, methods that call `ResponseHeader.Reset()` would cause the `defaultServerName` to be substituted for whatever value had been given. Now this will cause the `Server` header to not be sent, which IMO is preferable.