### PR TITLE
Optimize deletion of arg from []argsKV

### DIFF
--- a/args.go
+++ b/args.go
@@ -330,11 +330,12 @@ func delAllArgs(args []argsKV, key string) []argsKV {
 	for i, n := 0, len(args); i < n; i++ {
 		kv := &args[i]
 		if key == string(kv.key) {
-			tmp := *kv
-			copy(args[i:], args[i+1:])
 			n--
-			args[n] = tmp
-			args = args[:n]
+			if i != n { // Overwrite args[i] with the last member, unless `i` is last
+				args[i] = args[n]
+				i--
+			}
+			args = args[:n] // Shrink the array by one
 		}
 	}
 	return args

--- a/args.go
+++ b/args.go
@@ -331,11 +331,12 @@ func delAllArgs(args []argsKV, key string) []argsKV {
 		kv := &args[i]
 		if key == string(kv.key) {
 			n--
-			if i != n { // Overwrite args[i] with the last member, unless `i` is last
-				args[i] = args[n]
+			if i != n {
+				// Swap positions of the current and last member
+				args[i], args[n] = args[n], args[i]
 				i--
 			}
-			args = args[:n] // Shrink the array by one
+			args = args[:n] // Shrink the length
 		}
 	}
 	return args


### PR DESCRIPTION
The previous behavior would perform a deletion by making a temporary
copy of the arg to be deleted, reindexing the remainder of the array to
shift it back to the position of the removed item, copying the temporary
copy to the current last index, and then shrinking the length by one.

This change simplifies the operation by simply copying the last arg to
the position of the removal, and then shrinking the length.

<s>Note that this does cause there to be a duplicate arg in the array,
which is beyond the length, but within the capacity. This should only
matter if the array has its length increased without updating the newly
exposed arg. I don't believe this happens.</s>

If the duplicate item could be an issue, the same approach could be
taken but with a 2 way swap.

``` go
args[i], args[n] = args[n], args[i]
```

---

***EDIT:*** Pushed another commit that does the full swap as shown in the line of code above, so as to ensure that key/value `[]byte` slices are not shared between `argsKV` objects.

I kept the commits separate, but would be good to squash them and rephrase the message for clarity.