### PR TITLE
Fix hex2intTable out of range bug

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -311,15 +311,17 @@ func hexCharUpper(c byte) byte {
 }
 
 var hex2intTable = func() []byte {
-	b := make([]byte, 255)
-	for i := byte(0); i < 255; i++ {
-		c := byte(0)
-		if i >= '0' && i <= '9' {
-			c = 1 + i - '0'
-		} else if i >= 'a' && i <= 'f' {
-			c = 1 + i - 'a' + 10
-		} else if i >= 'A' && i <= 'F' {
-			c = 1 + i - 'A' + 10
+	b := make([]byte, 256)
+	for i := 0; i < 256; i++ {
+		c := byte(i)
+		if c >= '0' && c <= '9' {
+			c = 1 + c - '0'
+		} else if c >= 'a' && c <= 'f' {
+			c = 1 + c - 'a' + 10
+		} else if c >= 'A' && c <= 'F' {
+			c = 1 + c - 'A' + 10
+		} else {
+			c = 0
 		}
 		b[i] = c
 	}


### PR DESCRIPTION
`hex2intTable` only contains 254 entries while it should be 255.
Sending for example `Transfer-Encoding: \xff` causes an out of range panic.
Because fasthttp never uses defer-recover and runs in its own goroutines, the user of this package can do nothing to defend against this bug.