### PR TITLE
misc typo fixes

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -153,7 +153,7 @@ func ParseUint(buf []byte) (int, error) {
 var (
 	errEmptyInt               = errors.New("empty integer")
 	errUnexpectedFirstChar    = errors.New("unexpected first char found. Expecting 0-9")
-	errUnexpectedTrailingChar = errors.New("unexpected traling char found. Expecting 0-9")
+	errUnexpectedTrailingChar = errors.New("unexpected trailing char found. Expecting 0-9")
 	errTooLongInt             = errors.New("too long int")
 )
 

--- a/lbclient.go
+++ b/lbclient.go
@@ -59,7 +59,7 @@ type LBClient struct {
 // DefaultLBClientTimeout is the default request timeout used by LBClient
 // when calling LBClient.Do.
 //
-// The timeout may be overriden via LBClient.Timeout.
+// The timeout may be overridden via LBClient.Timeout.
 const DefaultLBClientTimeout = time.Second
 
 // DoDeadline calls DoDeadline on the least loaded client

--- a/server.go
+++ b/server.go
@@ -595,7 +595,7 @@ func (ctx *RequestCtx) ConnID() uint64 {
 // Time returns RequestHandler call time truncated to the nearest second.
 //
 // Call time.Now() at the beginning of RequestHandler in order to obtain
-// percise RequestHandler call time.
+// precise RequestHandler call time.
 func (ctx *RequestCtx) Time() time.Time {
 	return ctx.time
 }


### PR DESCRIPTION
a couple of these came from
https://goreportcard.com/report/github.com/valyala/fasthttp#misspell --
might as well get 100%, right? ;)