### PR TITLE
Add ';' to unescaped characters

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -392,7 +392,8 @@ func AppendQuotedArg(dst, src []byte) []byte {
 func appendQuotedPath(dst, src []byte) []byte {
 	for _, c := range src {
 		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' ||
-			c == '/' || c == '.' || c == ',' || c == '=' || c == ':' || c == '&' || c == '~' || c == '-' || c == '_' {
+			c == '/' || c == '.' || c == ',' || c == '=' || c == ':' || c == '&' ||
+			c == '~' || c == '-' || c == '_' || c == ';' {
 			dst = append(dst, c)
 		} else {
 			dst = append(dst, '%', hexCharUpper(c>>4), hexCharUpper(c&15))


### PR DESCRIPTION
I need to make ctx.Redirect() to doubleclick links. Example link is:

[https://ad.doubleclick.net/bla/bla/A1.B1;param1=val1;param2=val2;redir=?www.destination.com](url)

ctx.Redirect function was encoding ; to %3B and redirect were failing.