### PR TITLE
Fix client.go.

### DIFF
--- a/client.go
+++ b/client.go
@@ -1281,7 +1281,7 @@ func acquireClientConn(conn net.Conn) *clientConn {
 }
 
 func releaseClientConn(cc *clientConn) {
-	cc.c = nil
+	*cc = clientConn{}
 	clientConnPool.Put(cc)
 }
 


### PR DESCRIPTION
Fix the bug that not setting read deadline in a new connection caused by old lastReadDeadlineTime.
You have checked the cc.lastReadDeadlineTime in doNonNilReqResp(), it's good to improve performance. But, you should reset all the fields of clientConn when you release it. Or the new connection may use the lastReadDeadlineTime of the old connection to decide if it should set the read deadline.