### PR TITLE
Make maxAttempts in client.go configurable via HostClient.MaxAttempts

### DIFF
--- a/client.go
+++ b/client.go
@@ -511,6 +511,12 @@ type HostClient struct {
 	// DefaultMaxConnsPerHost is used if not set.
 	MaxConns int
 
+	// Maximum number of attempts to make to to connect.
+	//
+	// By default (when MaxAttempts is 0 or below), the client makes a maximum of
+	// 5 attempts.
+	MaxAttempts int
+
 	// Keep-alive connections are closed after this duration.
 	//
 	// By default connection duration is unlimited.
@@ -969,7 +975,14 @@ var errorChPool sync.Pool
 func (c *HostClient) Do(req *Request, resp *Response) error {
 	var err error
 	var retry bool
-	const maxAttempts = 5
+
+	var maxAttempts int
+	if c.MaxAttempts <= 0 {
+		maxAttempts = 5
+	} else {
+		maxAttempts = c.MaxAttempts
+	}
+
 	attempts := 0
 
 	atomic.AddUint64(&c.pendingRequests, 1)


### PR DESCRIPTION
We use fasthttp in a way that if one connection fails for any reason, we'd prefer not to attempt again.  Our time constraints make it necessary to only attempt once.

This patch makes the client max attempts configurable via the HostClient.MaxAttempts value.

If MaxAttempts is less than or equal to 0, then the client uses the default of 5 max attempts.