### PR TITLE
Configuration for automatic retry for idempotent calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -443,6 +443,9 @@ const DefaultMaxConnsPerHost = 512
 // connection is closed.
 const DefaultMaxIdleConnDuration = 10 * time.Second
 
+// DefaultMaxIdemponentCallAttempts is the default idempotent calls attempts count.
+const DefaultMaxIdemponentCallAttempts = 5
+
 // DialFunc must establish connection to addr.
 //
 // There is no need in establishing TLS (SSL) connection for https.
@@ -521,6 +524,11 @@ type HostClient struct {
 	// By default idle connections are closed
 	// after DefaultMaxIdleConnDuration.
 	MaxIdleConnDuration time.Duration
+
+	// Maximum number of attempts for idempotent calls
+	//
+	// DefaultMaxIdemponentCallAttempts is used if not set.
+	MaxIdemponentCallAttempts int
 
 	// Per-connection buffer size for responses' reading.
 	// This also limits the maximum header size.
@@ -969,7 +977,10 @@ var errorChPool sync.Pool
 func (c *HostClient) Do(req *Request, resp *Response) error {
 	var err error
 	var retry bool
-	const maxAttempts = 5
+	maxAttempts := c.MaxIdemponentCallAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultMaxIdemponentCallAttempts
+	}
 	attempts := 0
 
 	atomic.AddUint64(&c.pendingRequests, 1)


### PR DESCRIPTION
The fix allows to configure retries attempts count for idempotent calls made by HostClient.
Motivation: a lot of API's do not treat PUT/DELETE/HEAD HTTP requests as idempotent that's why retrying of this calls can lead to serious behaviour issues.