### PR TITLE
Fix readme: update 3rd-party library list

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,11 +555,10 @@ uintBuf := fasthttp.AppendUint(nil, 1234)
   There are no plans to add request routing into fasthttp.
   Use third-party routers and web frameworks with fasthttp support:
 
-    * [Iris](https://github.com/kataras/iris)
-    * [fasthttp-routing](https://github.com/qiangxue/fasthttp-routing)
-    * [fasthttprouter](https://github.com/buaazp/fasthttprouter)
-    * [gramework](https://github.com/gramework/gramework)
-    * [lu](https://github.com/vincentLiuxiang/lu)
+    * [gramework](https://github.com/gramework/gramework) (framework, Apache 2.0)
+    * [fasthttp-routing](https://github.com/qiangxue/fasthttp-routing) (router, BSD 3-Clause)
+    * [fasthttprouter](https://github.com/buaazp/fasthttprouter) (router, BSD 3-Clause)
+    * [lu](https://github.com/vincentLiuxiang/lu) (router/middleware framework, MIT)
 
   See also [this issue](https://github.com/valyala/fasthttp/issues/9) for more info.
 


### PR DESCRIPTION
Remove iris, add 3rd-party lib types, sort by type

Iris doesn't use fasthttp anymore.
Also, in this list it's unclear which library does what, so I added library types. For developers that needs to use software only under certain licenses, I've also added latest licenses for each library.
Last, I sorted the list by types: you can see frameworks and then routers.

also, note that lu is currently was not updated for a year, but I didn't remove the lib because it may be just a _really_ stable and reliable project and just doesn't require any updates.