### PR TITLE
Add missing http methods

### DIFF
--- a/header.go
+++ b/header.go
@@ -535,6 +535,26 @@ func (h *RequestHeader) IsDelete() bool {
 	return bytes.Equal(h.Method(), strDelete)
 }
 
+// IsConnect returns true if request method is CONNECT.
+func (h *RequestHeader) IsConnect() bool {
+	return bytes.Equal(h.Method(), strConnect)
+}
+
+// IsOptions returns true if request method is OPTIONS.
+func (h *RequestHeader) IsOptions() bool {
+	return bytes.Equal(h.Method(), strOptions)
+}
+
+// IsTrace returns true if request method is TRACE.
+func (h *RequestHeader) IsTrace() bool {
+	return bytes.Equal(h.Method(), strTrace)
+}
+
+// IsPatch returns true if request method is PATCH.
+func (h *RequestHeader) IsPatch() bool {
+	return bytes.Equal(h.Method(), strPatch)
+}
+
 // IsHTTP11 returns true if the request is HTTP/1.1.
 func (h *RequestHeader) IsHTTP11() bool {
 	return !h.noHTTP11

--- a/server.go
+++ b/server.go
@@ -827,6 +827,26 @@ func (ctx *RequestCtx) IsDelete() bool {
 	return ctx.Request.Header.IsDelete()
 }
 
+// IsConnect returns true if request method is CONNECT.
+func (ctx *RequestCtx) IsConnect() bool {
+	return ctx.Request.Header.IsConnect()
+}
+
+// IsOptions returns true if request method is OPTIONS.
+func (ctx *RequestCtx) IsOptions() bool {
+	return ctx.Request.Header.IsOptions()
+}
+
+// IsTrace returns true if request method is TRACE.
+func (ctx *RequestCtx) IsTrace() bool {
+	return ctx.Request.Header.IsTrace()
+}
+
+// IsPatch returns true if request method is PATCH.
+func (ctx *RequestCtx) IsPatch() bool {
+	return ctx.Request.Header.IsPatch()
+}
+
 // Method return request method.
 //
 // Returned value is valid until returning from RequestHandler.

--- a/strings.go
+++ b/strings.go
@@ -22,11 +22,15 @@ var (
 
 	strResponseContinue = []byte("HTTP/1.1 100 Continue\r\n\r\n")
 
-	strGet    = []byte("GET")
-	strHead   = []byte("HEAD")
-	strPost   = []byte("POST")
-	strPut    = []byte("PUT")
-	strDelete = []byte("DELETE")
+	strGet     = []byte("GET")
+	strHead    = []byte("HEAD")
+	strPost    = []byte("POST")
+	strPut     = []byte("PUT")
+	strDelete  = []byte("DELETE")
+	strConnect = []byte("CONNECT")
+	strOptions = []byte("OPTIONS")
+	strTrace   = []byte("TRACE")
+	strPatch   = []byte("PATCH")
 
 	strExpect           = []byte("Expect")
 	strConnection       = []byte("Connection")


### PR DESCRIPTION
There are 9 methods, but only 5 was supported. This is very stressful when implement RESTful API.

RFC about HTTP methods:
https://tools.ietf.org/html/rfc7231#section-4
https://tools.ietf.org/html/rfc5789#section-2