### PR TITLE
Use form headers in WriteMultipartForm

### DIFF
--- a/http.go
+++ b/http.go
@@ -744,7 +744,7 @@ func WriteMultipartForm(w io.Writer, f *multipart.Form, boundary string) error {
 	// marshal files
 	for k, fvv := range f.File {
 		for _, fv := range fvv {
-			vw, err := mw.CreateFormFile(k, fv.Filename)
+			vw, err := mw.CreatePart(fv.Header)
 			if err != nil {
 				return fmt.Errorf("cannot create form file %q (%q): %s", k, fv.Filename, err)
 			}

--- a/http_test.go
+++ b/http_test.go
@@ -1792,3 +1792,32 @@ func createChunkedBody(body []byte) []byte {
 	}
 	return append(b, []byte("0\r\n\r\n")...)
 }
+
+func TestWriteMultipartForm(t *testing.T) {
+	var w bytes.Buffer
+	s := strings.Replace(`--foo
+Content-Disposition: form-data; name="key"
+
+value
+--foo
+Content-Disposition: form-data; name="file"; filename="test.json"
+Content-Type: application/json
+
+{"foo": "bar"}
+--foo--
+`, "\n", "\r\n", -1)
+	mr := multipart.NewReader(strings.NewReader(s), "foo")
+	form, err := mr.ReadForm(1024)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if err := WriteMultipartForm(&w, form, "foo"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if string(w.Bytes()) != s {
+		t.Fatalf("unexpected output %q", w.Bytes())
+	}
+}


### PR DESCRIPTION
[CreateFormFile](https://golang.org/pkg/mime/multipart/#Writer.CreateFormFile) always set `Content-Type` header to `application/octet-stream`.
Use [CreatePart](https://golang.org/pkg/mime/multipart/#Writer.CreatePart) instead so all headers in the multipart form can be used.