### PR TITLE
Fix supported redirect status codes

### DIFF
--- a/client.go
+++ b/client.go
@@ -767,7 +767,11 @@ func doRequestFollowRedirects(req *Request, dst []byte, url string, c clientDoer
 			break
 		}
 		statusCode = resp.Header.StatusCode()
-		if statusCode != StatusMovedPermanently && statusCode != StatusFound && statusCode != StatusSeeOther {
+		if statusCode != StatusMovedPermanently &&
+			statusCode != StatusFound &&
+			statusCode != StatusSeeOther &&
+			statusCode != StatusTemporaryRedirect &&
+			statusCode != StatusPermanentRedirect {
 			break
 		}
 


### PR DESCRIPTION
Support the same redirect status codes as the golang standard library
does: https://github.com/golang/go/blob/15095be9fbe726d4a3ef43b68d2fbc83e6484ded/src/net/http/client.go#L419