### PR TITLE
Add support for ResponseHeader.Peek("Set-Cookie")

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -329,6 +329,19 @@ func appendRequestCookieBytes(dst []byte, cookies []argsKV) []byte {
 	return dst
 }
 
+// For Response we can not use the above function as response cookies
+// already contain the key= in the value.
+func appendResponseCookieBytes(dst []byte, cookies []argsKV) []byte {
+	for i, n := 0, len(cookies); i < n; i++ {
+		kv := &cookies[i]
+		dst = append(dst, kv.value...)
+		if i+1 < n {
+			dst = append(dst, ';', ' ')
+		}
+	}
+	return dst
+}
+
 func parseRequestCookies(cookies []argsKV, src []byte) []argsKV {
 	var s cookieScanner
 	s.b = src

--- a/header.go
+++ b/header.go
@@ -1205,6 +1205,8 @@ func (h *ResponseHeader) peek(key []byte) []byte {
 		return peekArgBytes(h.h, key)
 	case "Content-Length":
 		return h.contentLengthBytes
+	case "Set-Cookie":
+		return appendResponseCookieBytes(nil, h.cookies)
 	default:
 		return peekArgBytes(h.h, key)
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -1393,6 +1393,50 @@ func TestRequestHeaderCookie(t *testing.T) {
 	}
 }
 
+func TestResponseHeaderCookieIssue4(t *testing.T) {
+	var h ResponseHeader
+
+	c := AcquireCookie()
+	c.SetKey("foo")
+	c.SetValue("bar")
+	h.SetCookie(c)
+
+	if string(h.Peek("Set-Cookie")) != "foo=bar" {
+		t.Fatalf("Unexpected Set-Cookie header %q. Expected %q", h.Peek("Set-Cookie"), "foo=bar")
+	}
+	cookieSeen := false
+	h.VisitAll(func(key, value []byte) {
+		switch string(key) {
+		case "Set-Cookie":
+			cookieSeen = true
+		}
+	})
+	if !cookieSeen {
+		t.Fatalf("Set-Cookie not present in VisitAll")
+	}
+
+	c = AcquireCookie()
+	c.SetKey("foo")
+	h.Cookie(c)
+	if string(c.Value()) != "bar" {
+		t.Fatalf("Unexpected cookie value %q. Exepcted %q", c.Value(), "bar")
+	}
+
+	if string(h.Peek("Set-Cookie")) != "foo=bar" {
+		t.Fatalf("Unexpected Set-Cookie header %q. Expected %q", h.Peek("Set-Cookie"), "foo=bar")
+	}
+	cookieSeen = false
+	h.VisitAll(func(key, value []byte) {
+		switch string(key) {
+		case "Set-Cookie":
+			cookieSeen = true
+		}
+	})
+	if !cookieSeen {
+		t.Fatalf("Set-Cookie not present in VisitAll")
+	}
+}
+
 func TestRequestHeaderMethod(t *testing.T) {
 	// common http methods
 	testRequestHeaderMethod(t, "GET")


### PR DESCRIPTION
See: https://github.com/erikdubbelboer/fasthttp/issues/4