### PR TITLE
Allow removal of the Server header in responses

### DIFF
--- a/header.go
+++ b/header.go
@@ -1457,10 +1457,9 @@ func (h *ResponseHeader) AppendBytes(dst []byte) []byte {
 	dst = append(dst, statusLine(statusCode)...)
 
 	server := h.Server()
-	if len(server) == 0 {
-		server = defaultServerName
+	if len(server) != 0 {
+		dst = appendHeaderLine(dst, strServer, server)
 	}
-	dst = appendHeaderLine(dst, strServer, server)
 	dst = appendHeaderLine(dst, strDate, serverDate.Load().([]byte))
 
 	// Append Content-Type only for non-zero responses

--- a/http_test.go
+++ b/http_test.go
@@ -1372,7 +1372,7 @@ func TestResponseSuccess(t *testing.T) {
 
 	// response with missing server
 	testResponseSuccess(t, 500, "aaa", "", "aaadfsd",
-		500, "aaa", string(defaultServerName))
+		500, "aaa", "")
 
 	// empty body
 	testResponseSuccess(t, 200, "bbb", "qwer", "",


### PR DESCRIPTION
his PR adds an option to the Server called `NoDefaultServerHeader` that
allows a user to indicate that neither the Server's `Name` field nor
the `defaultServerName` should be included in the Server's responses
as a `Server` header by default.

Now when `ResponseHeader.AppendBytes` is found to have an empty `server`
field, it simply skips the `Server` header. Previously that method
would write the `defaultServerName` when no value was found. The only
code paths that took advantage of that were ones originating from
`writeErrorResponse`, which now handles setting the server name
directly.

Fixes: https://github.com/valyala/fasthttp/issues/221