### PR TITLE
Fix doc for some time functions

### DIFF
--- a/server.go
+++ b/server.go
@@ -598,18 +598,13 @@ func (ctx *RequestCtx) ConnID() uint64 {
 	return ctx.connID
 }
 
-// Time returns RequestHandler call time truncated to the nearest second.
-//
-// Call time.Now() at the beginning of RequestHandler in order to obtain
-// precise RequestHandler call time.
+// Time returns RequestHandler call time.
 func (ctx *RequestCtx) Time() time.Time {
 	return ctx.time
 }
 
-// ConnTime returns the time server starts serving the connection
+// ConnTime returns the time the server started serving the connection
 // the current request came from.
-//
-// The returned time is truncated to the nearest second.
 func (ctx *RequestCtx) ConnTime() time.Time {
 	return ctx.connTime
 }


### PR DESCRIPTION
They still said the return value would be truncated to the nearest second which is false after ef10ed05a3797c2a387710e0a6d7dc62abc04290.

See: https://github.com/valyala/fasthttp/pull/379#issuecomment-414563486