### PR TITLE
Copy file if rename fails (save multipart)

### DIFF
--- a/server.go
+++ b/server.go
@@ -775,7 +775,11 @@ func SaveMultipartFile(fh *multipart.FileHeader, path string) error {
 	defer f.Close()
 
 	if ff, ok := f.(*os.File); ok {
-		return os.Rename(ff.Name(), path)
+		// If renaming fails we try the normal copying method.
+		// Renaming could fail if the files are on different devices.
+		if os.Rename(ff.Name(), path) == nil {
+			return nil
+		}
 	}
 
 	ff, err := os.Create(path)


### PR DESCRIPTION
Renaming a file can fail when the two files are on different devices. Just copy if rename fails for any reason. If rename fails because of other reaons copy will either work or fail for the same reason as well so we won't miss any errors after this.

Fixes https://github.com/valyala/fasthttp/issues/391