### PR TITLE
Do not log ErrSmallBuffer for request headers

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -211,6 +211,7 @@ func (wp *workerPool) workerFunc(ch *workerChan) {
 			errStr := err.Error()
 			if wp.LogAllErrors || !(strings.Contains(errStr, "broken pipe") ||
 				strings.Contains(errStr, "reset by peer") ||
+				strings.Contains(errStr, "request headers: small read buffer") ||
 				strings.Contains(errStr, "i/o timeout")) {
 				wp.Logger.Printf("error when serving connection %q<->%q: %s", c.LocalAddr(), c.RemoteAddr(), err)
 			}


### PR DESCRIPTION
fasthttp returns a 431 error when the request headers are too large. Most other HTTP servers do not log an error when the request header exceeds the limit. When serving HTTP requests directly to browsers, it is normal to occasionally hit the limit due to broken browsers or broken sites linking to your resource. These issues are generally outside of your control in the same way the already ignored errors are.

See https://github.com/erikdubbelboer/fasthttp/commit/eb78a50320f7b625ed9553294e83bc8fb76554d1