### PR TITLE
Case-insensitively cookie attributes

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -370,6 +370,26 @@ func lowercaseBytes(b []byte) {
 	}
 }
 
+// compareLowerCaseA returns true if a converted to lower
+// case anc b are the same.
+//
+// B needs to be lower case already!
+//
+// Only works for ASCII strings.
+func compareLowerCaseA(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := 0; i < len(a); i++ {
+		if toLowerTable[a[i]] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // b2s converts byte slice to a string without memory allocation.
 // See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
 //

--- a/cookie.go
+++ b/cookie.go
@@ -272,27 +272,40 @@ func (c *Cookie) ParseBytes(src []byte) error {
 	c.value = append(c.value[:0], kv.value...)
 
 	for s.next(kv) {
-		if len(kv.key) == 0 && len(kv.value) == 0 {
-			continue
-		}
-		switch string(kv.key) {
-		case "expires":
-			v := b2s(kv.value)
-			exptime, err := time.ParseInLocation(time.RFC1123, v, time.UTC)
-			if err != nil {
-				return err
+		if len(kv.key) == 0 {
+			if len(kv.value) == 0 {
+				continue
 			}
-			c.expire = exptime
-		case "domain":
-			c.domain = append(c.domain[:0], kv.value...)
-		case "path":
-			c.path = append(c.path[:0], kv.value...)
-		case "":
-			switch string(kv.value) {
-			case "HttpOnly":
-				c.httpOnly = true
-			case "secure":
-				c.secure = true
+
+			switch kv.value[0] {
+			case 'h', 'H':
+				if compareLowerCaseA(kv.value, strHttponly) {
+					c.httpOnly = true
+				}
+			case 's', 'S':
+				if compareLowerCaseA(kv.value, strSecure) {
+					c.secure = true
+				}
+			}
+		} else {
+			switch kv.key[0] {
+			case 'e', 'E':
+				if compareLowerCaseA(kv.key, strExpires) {
+					v := b2s(kv.value)
+					exptime, err := time.ParseInLocation(time.RFC1123, v, time.UTC)
+					if err != nil {
+						return err
+					}
+					c.expire = exptime
+				}
+			case 'd', 'D':
+				if compareLowerCaseA(kv.key, strDomain) {
+					c.domain = append(c.domain[:0], kv.value...)
+				}
+			case 'p', 'P':
+				if compareLowerCaseA(kv.key, strPath) {
+					c.path = append(c.path[:0], kv.value...)
+				}
 			}
 		}
 	}

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -109,6 +109,17 @@ func TestCookieHttpOnly(t *testing.T) {
 	if strings.Contains(s, "HttpOnly") {
 		t.Fatalf("unexpected HttpOnly flag in cookie %q", s)
 	}
+
+	if err := c.Parse("foo=bar; hTTPoNLY"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !c.HTTPOnly() {
+		t.Fatalf("HTTPOnly must be set")
+	}
+	s = c.String()
+	if !strings.Contains(s, "; HttpOnly") {
+		t.Fatalf("missing HttpOnly flag in cookie %q", s)
+	}
 }
 
 func TestCookieAcquireReleaseSequential(t *testing.T) {
@@ -264,5 +275,14 @@ func testAppendRequestCookieBytes(t *testing.T, s, expectedS string) {
 	result = result[len(prefix):]
 	if result != expectedS {
 		t.Fatalf("Unexpected result %q. Expecting %q for cookie %q", result, expectedS, s)
+	}
+}
+
+func BenchmarkCookieParseBytes(b *testing.B) {
+	cookie := []byte("foo=bar; httponly")
+	c := Cookie{}
+	for i := 0; i < b.N; i++ {
+		c.ParseBytes(cookie)
+		c.Reset()
 	}
 }

--- a/strings.go
+++ b/strings.go
@@ -74,4 +74,11 @@ var (
 	strBytes               = []byte("bytes")
 	strTextSlash           = []byte("text/")
 	strApplicationSlash    = []byte("application/")
+
+	// Cookie related strings.
+	strDomain   = []byte("domain")
+	strExpires  = []byte("expires")
+	strHttponly = []byte("httponly")
+	strPath     = []byte("path")
+	strSecure   = []byte("secure")
 )


### PR DESCRIPTION
Accordingly to RFC 6265 - HTTP State Management Mechanism, Set-Cookie header includes cookie attributes that must be treated case-insensitively.

This fixes https://github.com/valyala/fasthttp/pull/183 without causing any additional heap allocations by calling `strings.ToLower`.