### PR TITLE
Added Server.nextProtos

### DIFF
--- a/header.go
+++ b/header.go
@@ -1771,7 +1771,7 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 				if caseInsensitiveCompare(s.key, strContentType) {
 					h.contentType = append(h.contentType[:0], s.value...)
 					continue
-				} 
+				}
 				if caseInsensitiveCompare(s.key, strContentLength) {
 					if h.contentLength != -1 {
 						if h.contentLength, err = parseContentLength(s.value); err != nil {

--- a/workerpool.go
+++ b/workerpool.go
@@ -16,7 +16,7 @@ import (
 type workerPool struct {
 	// Function for serving server connections.
 	// It must leave c unclosed.
-	WorkerFunc func(c net.Conn) error
+	WorkerFunc ServeHandler
 
 	MaxWorkersCount int
 


### PR DESCRIPTION
This implementation allows user to handle crypto/tls.Config.NextProtos to use their own handlers for the negotiated TLS protos like HTTP/2.
Workerpool where changed to adapt WorkerFunc to another conns server with ServeConn type and contains the Server structure which is used to check configured protos.