### PR TITLE
Do case insensitive comparisons for headers and cookies

### DIFF
--- a/cookie_test.go
+++ b/cookie_test.go
@@ -175,7 +175,7 @@ func TestCookieParse(t *testing.T) {
 	testCookieParse(t, "foo=", "foo=")
 	testCookieParse(t, `foo="bar"`, "foo=bar")
 	testCookieParse(t, `"foo"=bar`, `"foo"=bar`)
-	testCookieParse(t, "foo=bar; domain=aaa.com; path=/foo/bar", "foo=bar; domain=aaa.com; path=/foo/bar")
+	testCookieParse(t, "foo=bar; Domain=aaa.com; PATH=/foo/bar", "foo=bar; domain=aaa.com; path=/foo/bar")
 	testCookieParse(t, " xxx = yyy  ; path=/a/b;;;domain=foobar.com ; expires= Tue, 10 Nov 2009 23:00:00 GMT ; ;;",
 		"xxx=yyy; expires=Tue, 10 Nov 2009 23:00:00 GMT; domain=foobar.com; path=/a/b")
 }


### PR DESCRIPTION
This adds insensitive comparisons for headers and cookies keys.

Fixes https://github.com/valyala/fasthttp/pull/230 and https://github.com/valyala/fasthttp/issues/409.