### PR TITLE
use proper "Deprecated" comment format

### DIFF
--- a/bytebuffer.go
+++ b/bytebuffer.go
@@ -12,7 +12,7 @@ import (
 //
 // Use AcquireByteBuffer for obtaining an empty byte buffer.
 //
-// ByteBuffer is deprecated. Use github.com/valyala/bytebufferpool instead.
+// Deprecated: use github.com/valyala/bytebufferpool instead.
 type ByteBuffer bytebufferpool.ByteBuffer
 
 // Write implements io.Writer - it appends p to ByteBuffer.B

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -440,7 +440,7 @@ func appendQuotedPath(dst, src []byte) []byte {
 // This function has no performance benefits comparing to string(b) == s.
 // It is left here for backwards compatibility only.
 //
-// This function is deprecated and may be deleted soon.
+// Deprecated: may be deleted soon.
 func EqualBytesStr(b []byte, s string) bool {
 	return string(b) == s
 }
@@ -450,7 +450,7 @@ func EqualBytesStr(b []byte, s string) bool {
 // This function has no performance benefits comparing to append(dst, src...).
 // It is left here for backwards compatibility only.
 //
-// This function is deprecated and may be deleted soon.
+// Deprecated: may be deleted soon.
 func AppendBytesStr(dst []byte, src string) []byte {
 	return append(dst, src...)
 }


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#deprecatedComment-ref