### PR TITLE
Fix data race errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,6 @@ script:
 
   # run tests on a standard platform
   - go test -v ./...
+
+  # run tests with the race detector as well
+  - go test -race -v ./...


### PR DESCRIPTION
Server.Shutdown was causing data race errors. One issue was that it was possible for sync.WaitGroup.Add() to be called while Shutdown was already calling .Wait(). To fix this I have removed the WaitGroup and replaced it with atomic counters and a semi busy wait loop.

Fixes #416