### PR TITLE
Add support for named profiles like heap, goroutine, threadcreate, etc.

### DIFF
--- a/pprofhandler/pprof.go
+++ b/pprofhandler/pprof.go
@@ -2,6 +2,7 @@ package pprofhandler
 
 import (
 	"net/http/pprof"
+	rtp "runtime/pprof"
 	"strings"
 
 	"github.com/valyala/fasthttp"
@@ -30,6 +31,14 @@ func PprofHandler(ctx *fasthttp.RequestCtx) {
 	} else if strings.HasPrefix(string(ctx.Path()), "/debug/pprof/trace") {
 		trace(ctx)
 	} else {
+		for _, v := range rtp.Profiles() {
+			ppName := v.Name()
+			if strings.HasPrefix(string(ctx.Path()), "/debug/pprof/"+ppName) {
+				namedHandler := fasthttpadaptor.NewFastHTTPHandlerFunc(pprof.Handler(ppName).ServeHTTP)
+				namedHandler(ctx)
+				return
+			}
+		}
 		index(ctx)
 	}
 }


### PR DESCRIPTION
Improve #243 to support all named profiles like heap, goroutine, threadcreate, mutex, block, allocs, and possibly other names in the future.

Tested with the following to also verify the web UI:
```go
func main() {
	router := fasthttprouter.New()
	router.GET("/debug/pprof/:name", pprofhandler.PprofHandler)
	router.GET("/debug/pprof/", pprofhandler.PprofHandler)
	log.Fatal(fasthttp.ListenAndServe(":8080", router.Handler))
}
```