### PR TITLE
Added method (*Server).GetCurrenctConcurrency()

### DIFF
--- a/server.go
+++ b/server.go
@@ -1716,6 +1716,10 @@ func (s *Server) ServeConn(c net.Conn) error {
 
 var errHijacked = errors.New("connection has been hijacked")
 
+func (s *Server) GetCurrentConcurrency() uint32 {
+	return s.concurrency
+}
+
 func (s *Server) getConcurrency() int {
 	n := s.Concurrency
 	if n <= 0 {

--- a/server.go
+++ b/server.go
@@ -1716,6 +1716,10 @@ func (s *Server) ServeConn(c net.Conn) error {
 
 var errHijacked = errors.New("connection has been hijacked")
 
+// GetCurrentConcurrency returns a number of currently served
+// connections.
+//
+// This function is intended be used by monitoring systems
 func (s *Server) GetCurrentConcurrency() uint32 {
 	return atomic.LoadUint32(&s.concurrency)
 }

--- a/server.go
+++ b/server.go
@@ -1717,7 +1717,7 @@ func (s *Server) ServeConn(c net.Conn) error {
 var errHijacked = errors.New("connection has been hijacked")
 
 func (s *Server) GetCurrentConcurrency() uint32 {
-	return s.concurrency
+	return atomic.LoadUint32(&s.concurrency)
 }
 
 func (s *Server) getConcurrency() int {


### PR DESCRIPTION
Hello.

We need to monitor how many incoming concurrent do we have at a moment. So we need a method like this one. It would be nice if you merge it :)