### PR TITLE
Fixed NextProto error caused by non-Handshake call.

### DIFF
--- a/server.go
+++ b/server.go
@@ -546,6 +546,7 @@ func (ctx *RequestCtx) VisitUserValues(visitor func([]byte, interface{})) {
 }
 
 type connTLSer interface {
+	Handshake() error
 	ConnectionState() tls.ConnectionState
 }
 
@@ -1268,7 +1269,7 @@ func (s *Server) NextProto(key string, nph ServeHandler) {
 }
 
 func (s *Server) hasNextProto(c net.Conn) (proto string, err error) {
-	tlsConn, ok := c.(*tls.Conn)
+	tlsConn, ok := c.(connTLSer)
 	if ok {
 		err = tlsConn.Handshake()
 		proto = tlsConn.ConnectionState().NegotiatedProtocol


### PR DESCRIPTION
As you can see here https://golang.org/src/crypto/tls/conn.go#L1041
crypto/tls.Conn does not perform a TLS handshake until Read or Write functions are called.
Then the solution is to call crypto/tls.Conn.Handshake() to check Client values.

Solves https://github.com/valyala/fasthttp/issues/453