### PR TITLE
fix go vet do not work on noCopy

### DIFF
--- a/nocopy.go
+++ b/nocopy.go
@@ -4,6 +4,8 @@ package fasthttp
 // so `go vet` gives a warning if this struct is copied.
 //
 // See https://github.com/golang/go/issues/8005#issuecomment-190753527 for details.
+// and also: https://stackoverflow.com/questions/52494458/nocopy-minimal-example
 type noCopy struct{}
 
 func (*noCopy) Lock() {}
+func (*noCopy) UnLock() {}


### PR DESCRIPTION
I've tried that if `noCopy` does not implement the `sync.Locker` interface, go vet will not work. see:

```bash
$ cat main.go 
package main

type noCopy struct{}

func (*noCopy) Lock() {}

//func (*noCopy) Unlock() {}

type Demo struct {
	noCopy noCopy
}

func Copy(d Demo) {}

func main() {
	d := Demo{}
	Copy(d)
}
$ go vet main.go
```

implement `sync.Locker` interface:

```bash
$ cat main.go 
package main

type noCopy struct{}

func (*noCopy) Lock() {}

func (*noCopy) Unlock() {}

type Demo struct {
	noCopy noCopy
}

func Copy(d Demo) {}

func main() {
	d := Demo{}
	Copy(d)
}
$ go vet main.go 
# command-line-arguments
./main.go:13: Copy passes lock by value: main.Demo contains main.noCopy
./main.go:17: call of Copy copies lock value: main.Demo contains main.noCopy
```