### PR TITLE
noCopy does not implement sync.Locker well. L letter of Unlock must be lower case

### DIFF
--- a/nocopy.go
+++ b/nocopy.go
@@ -7,5 +7,5 @@ package fasthttp
 // and also: https://stackoverflow.com/questions/52494458/nocopy-minimal-example
 type noCopy struct{}
 
-func (*noCopy) Lock() {}
-func (*noCopy) UnLock() {}
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}


### PR DESCRIPTION
Fix https://github.com/valyala/fasthttp/pull/460/commits/02d006acf71a963d0568172d54de893bd147f3fc#diff-3b5fdea3b153cacd75dfcc26d1fe6617R11
```bash
$ cat main.go
package main

type noCopy struct{}

func (*noCopy) Lock() {}

func (*noCopy) UnLock() {}

type Demo struct {
        noCopy noCopy
}

func Copy(d Demo) {}

func main() {
        d := Demo{}
        Copy(d)
}
$ go vet main.go
$
```

```bash
$ cat main.go
package main

type noCopy struct{}

func (*noCopy) Lock() {}

func (*noCopy) Unlock() {}

type Demo struct {
        noCopy noCopy
}

func Copy(d Demo) {}

func main() {
        d := Demo{}
        Copy(d)
}
$ go vet main.go
# command-line-arguments
./main.go:13: Copy passes lock by value: main.Demo contains main.noCopy
./main.go:17: call of Copy copies lock value: main.Demo contains main.noCopy
```