### PR TITLE
No error response on keep-alive close

### DIFF
--- a/server.go
+++ b/server.go
@@ -1850,6 +1850,13 @@ func (s *Server) serveConn(c net.Conn) error {
 		if err != nil {
 			if err == io.EOF {
 				err = nil
+			} else if connRequestNum > 1 && !ctx.Request.Header.hasReadOneByte {
+				// This is not the first request and we haven't read a single byte
+				// of a new request yet. This means it's just a keep-alive connection
+				// closing down either because the remote closed it or because
+				// or a read timeout on our side. Either way just close the connection
+				// and don't return any error response.
+				err = nil
 			} else {
 				bw = s.writeErrorResponse(bw, ctx, serverName, err)
 			}


### PR DESCRIPTION
Don't return an error response if a keep-alive connection closes either because the other side closed the connection or a read timeout occurs.

This will prevent net/http from printing
`Unsolicited response received on idle HTTP channel`
when a ReadTimeout is set on the fasthttp Server.

Fixes #465