### PR TITLE
No error response on keep-alive close

### DIFF
--- a/header.go
+++ b/header.go
@@ -1373,6 +1373,11 @@ func (h *RequestHeader) tryRead(r *bufio.Reader, n int) error {
 			}
 		}
 
+		if n == 1 {
+			// We didn't read a single byte.
+			return errNothingRead
+		}
+
 		return fmt.Errorf("error when reading request headers: %s", err)
 	}
 	b = mustPeekBuffered(r)
@@ -2145,6 +2150,7 @@ func AppendNormalizedHeaderKeyBytes(dst, key []byte) []byte {
 var (
 	errNeedMore    = errors.New("need more data: cannot find trailing lf")
 	errSmallBuffer = errors.New("small read buffer. Increase ReadBufferSize")
+	errNothingRead = errors.New("read timeout with nothing read")
 )
 
 // ErrSmallBuffer is returned when the provided buffer size is too small

--- a/server.go
+++ b/server.go
@@ -1850,6 +1850,13 @@ func (s *Server) serveConn(c net.Conn) error {
 		if err != nil {
 			if err == io.EOF {
 				err = nil
+			} else if connRequestNum > 1 && err == errNothingRead {
+				// This is not the first request and we haven't read a single byte
+				// of a new request yet. This means it's just a keep-alive connection
+				// closing down either because the remote closed it or because
+				// or a read timeout on our side. Either way just close the connection
+				// and don't return any error response.
+				err = nil
 			} else {
 				bw = s.writeErrorResponse(bw, ctx, serverName, err)
 			}


### PR DESCRIPTION
Don't return an error response if a keep-alive connection closes either because the other side closed the connection or a read timeout occurs.

This will prevent net/http from printing
`Unsolicited response received on idle HTTP channel`
when a ReadTimeout is set on the fasthttp Server.

Fixes #465