### PR TITLE
Added method (*Server).GetOpenConnectionsCount() and option DisableSleepWhenConcurrencyLimitsExceeded

### DIFF
--- a/server.go
+++ b/server.go
@@ -16,10 +16,6 @@ import (
 	"time"
 )
 
-const (
-	defaultSleepDurationWhenConcurrenyLimitExceeded = time.Millisecond * 100
-)
-
 var errNoCertOrKeyProvided = errors.New("Cert or key has not provided")
 
 var (
@@ -307,9 +303,8 @@ type Server struct {
 	DisableHeaderNamesNormalizing bool
 
 	// SleepWhenConcurrencyLimitsExceeded is a duration to be slept of if
-	// the concurrency limit in exceeded (default [when is 0]: 100ms;
-	// any negative value to disable the sleeping and accept new connections
-	// immidiatelly).
+	// the concurrency limit in exceeded (default [when is 0]: don't sleep
+	// and accept new connections immidiatelly).
 	SleepWhenConcurrencyLimitsExceeded time.Duration
 
 	// NoDefaultServerHeader, when set to true, causes the default Server header
@@ -1576,12 +1571,10 @@ func (s *Server) Serve(ln net.Listener) error {
 			//
 			// There is a hope other servers didn't reach their
 			// concurrency limits yet :)
-			sleepDuration := s.SleepWhenConcurrencyLimitsExceeded
-			if sleepDuration == 0 {
-				sleepDuration = defaultSleepDurationWhenConcurrenyLimitExceeded
-			}
-			if sleepDuration > 0 {
-				time.Sleep(sleepDuration)
+			//
+			// See also: https://github.com/valyala/fasthttp/pull/485#discussion_r239994990
+			if s.SleepWhenConcurrencyLimitsExceeded > 0 {
+				time.Sleep(s.SleepWhenConcurrencyLimitsExceeded)
 			}
 		}
 		c = nil

--- a/server.go
+++ b/server.go
@@ -1747,6 +1747,13 @@ func (s *Server) GetCurrentConcurrency() uint32 {
 	return atomic.LoadUint32(&s.concurrency)
 }
 
+// GetOpenConnectionsCount returns a number of opened connections.
+//
+// This function is intended be used by monitoring systems
+func (s *Server) GetOpenConnectionsCount() int32 {
+	return atomic.LoadInt32(&s.open) - 1
+}
+
 func (s *Server) getConcurrency() int {
 	n := s.Concurrency
 	if n <= 0 {


### PR DESCRIPTION
The method `(*Server).GetOpenConnectionsCount()` is required for our monitoring system

The option `DisableSleepWhenConcurrencyLimitsExceeded` is required in our high-load application. This `Sleep()` caused some problems in our infrastructure when servers were overloaded so we'd like to be able to disable it if possible :)