### PR TITLE
Allow queue size (channel capacity) of workers modifiable 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 tags
 *.pprof
 *.fasthttp.gz

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -3,7 +3,7 @@ package fasthttp_test
 import (
 	"log"
 
-	"github.com/valyala/fasthttp"
+	"github.com/vijayviji/fasthttp"
 )
 
 func ExampleHostClient() {

--- a/client_test.go
+++ b/client_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/valyala/fasthttp/fasthttputil"
+	"github.com/vijayviji/fasthttp/fasthttputil"
 )
 
 func TestClientPostArgs(t *testing.T) {

--- a/client_timing_test.go
+++ b/client_timing_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/valyala/fasthttp/fasthttputil"
+	"github.com/vijayviji/fasthttp/fasthttputil"
 )
 
 type fakeClientConn struct {

--- a/compress.go
+++ b/compress.go
@@ -11,7 +11,7 @@ import (
 	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/zlib"
 	"github.com/valyala/bytebufferpool"
-	"github.com/valyala/fasthttp/stackless"
+	"github.com/vijayviji/fasthttp/stackless"
 )
 
 // Supported compression levels.

--- a/cookie.go
+++ b/cookie.go
@@ -21,6 +21,7 @@ var (
 // CookieSameSite is an enum for the mode in which the SameSite flag should be set for the given cookie.
 // See https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00 for details.
 type CookieSameSite int
+
 const (
 	// CookieSameSiteDisabled removes the SameSite flag
 	CookieSameSiteDisabled CookieSameSite = iota

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -98,7 +98,7 @@ func TestCookieSameSite(t *testing.T) {
 	if !strings.Contains(s, "; SameSite") {
 		t.Fatalf("missing SameSite flag in cookie %q", s)
 	}
-	
+
 	if err := c.Parse("foo=bar; samesite=lax"); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -109,7 +109,7 @@ func TestCookieSameSite(t *testing.T) {
 	if !strings.Contains(s, "; SameSite=Lax") {
 		t.Fatalf("missing SameSite flag in cookie %q", s)
 	}
-	
+
 	if err := c.Parse("foo=bar; samesite=strict"); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -120,7 +120,7 @@ func TestCookieSameSite(t *testing.T) {
 	if !strings.Contains(s, "; SameSite=Strict") {
 		t.Fatalf("missing SameSite flag in cookie %q", s)
 	}
-	
+
 	if err := c.Parse("foo=bar"); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/fs_example_test.go
+++ b/fs_example_test.go
@@ -3,7 +3,7 @@ package fasthttp_test
 import (
 	"log"
 
-	"github.com/valyala/fasthttp"
+	"github.com/vijayviji/fasthttp"
 )
 
 func ExampleFS() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/valyala/fasthttp
+module github.com/vijayviji/fasthttp
 
 require (
 	github.com/klauspost/compress v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/vijayviji/fasthttp
 
 require (
 	github.com/klauspost/compress v1.4.0
-	github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e // indirect
 	github.com/valyala/bytebufferpool v1.0.0
+	github.com/valyala/fasthttp v1.0.0
 	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a
 	golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e h1:+lIPJOWl+jSiJOc
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.0.0 h1:BwIoZQbBsTo3v2F5lz5Oy3TlTq4wLKTLV260EVTEWco=
+github.com/valyala/fasthttp v1.0.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a h1:0R4NLDRDZX6JcmhJgXi5E4b8Wg84ihbmUKp/GvSPEzc=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3 h1:czFLhve3vsQetD6JOJ8NZZvGQIXlnN3/yXxbT6/awxI=

--- a/lbclient_example_test.go
+++ b/lbclient_example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/vijayiji/fasthttp"
+	"github.com/vijayviji/fasthttp"
 )
 
 func ExampleLBClient() {

--- a/lbclient_example_test.go
+++ b/lbclient_example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/valyala/fasthttp"
+	"github.com/vijayiji/fasthttp"
 )
 
 func ExampleLBClient() {

--- a/requestctx_setbodystreamwriter_example_test.go
+++ b/requestctx_setbodystreamwriter_example_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/valyala/fasthttp"
+	"github.com/vijayviji/fasthttp"
 )
 
 func ExampleRequestCtx_SetBodyStreamWriter() {

--- a/server.go
+++ b/server.go
@@ -1531,11 +1531,11 @@ func (s *Server) Serve(ln net.Listener) error {
 	maxWorkersCount := s.getConcurrency()
 	s.concurrencyCh = make(chan struct{}, maxWorkersCount)
 	wp := &workerPool{
-		WorkerFunc:      s.serveConn,
-		MaxWorkersCount: maxWorkersCount,
-		LogAllErrors:    s.LogAllErrors,
-		Logger:          s.logger(),
-		connState:       s.setState,
+		WorkerFunc:            s.serveConn,
+		MaxWorkersCount:       maxWorkersCount,
+		LogAllErrors:          s.LogAllErrors,
+		Logger:                s.logger(),
+		connState:             s.setState,
 		WorkerChannelCapacity: s.getWorkerChannelCapacity(),
 	}
 	wp.Start()

--- a/server.go
+++ b/server.go
@@ -1778,12 +1778,12 @@ func (s *Server) getWorkerChannelCapacity() uint32 {
 		// in higher performance (under go1.5 at least).
 		if runtime.GOMAXPROCS(0) == 1 {
 			n = 0
+		} else {
+			// Use non-blocking workerChan if GOMAXPROCS>1,
+			// since otherwise the Serve caller (Acceptor) may lag accepting
+			// new connections if WorkerFunc is CPU-bound.
+			n = 1
 		}
-
-		// Use non-blocking workerChan if GOMAXPROCS>1,
-		// since otherwise the Serve caller (Acceptor) may lag accepting
-		// new connections if WorkerFunc is CPU-bound.
-		n = 1
 	}
 
 	return n

--- a/server_example_test.go
+++ b/server_example_test.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/valyala/fasthttp"
+	"github.com/vijayviji/fasthttp"
 )
 
 func ExampleListenAndServe() {

--- a/stream.go
+++ b/stream.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/valyala/fasthttp/fasthttputil"
+	"github.com/vijayviji/fasthttp/fasthttputil"
 )
 
 // StreamWriter must write data to w.

--- a/strings.go
+++ b/strings.go
@@ -62,7 +62,7 @@ var (
 	strCookieSameSite       = []byte("SameSite")
 	strCookieSameSiteLax    = []byte("Lax")
 	strCookieSameSiteStrict = []byte("Strict")
-	
+
 	strClose               = []byte("close")
 	strGzip                = []byte("gzip")
 	strDeflate             = []byte("deflate")

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/valyala/fasthttp/fasthttputil"
+	"github.com/vijayviji/fasthttp/fasthttputil"
 )
 
 func TestWorkerPoolStartStopSerial(t *testing.T) {


### PR DESCRIPTION
This change is required in certain cases such as in the model, where there will be 1 acceptor and (n-1) workers, n being the no. of CPUs. In this model, the idea is to make workers CPU bound, and also not let acceptor suffer. Nevertheless, by default, it will behave the old way.

I'm creating a PR, addressing this issue https://github.com/valyala/fasthttp/issues/499