### PR TITLE
all: fix typo on comments

### DIFF
--- a/header.go
+++ b/header.go
@@ -73,7 +73,8 @@ type RequestHeader struct {
 
 	rawHeaders []byte
 
-	// stores an immutable copy of headers as they were recieved from the wire.
+	// stores an immutable copy of headers as they were received from the
+	// wire.
 	rawHeadersCopy []byte
 }
 

--- a/server.go
+++ b/server.go
@@ -1278,7 +1278,8 @@ func (ctx *RequestCtx) TimeoutErrorWithResponse(resp *Response) {
 	ctx.timeoutResponse = respCopy
 }
 
-// NextProto adds nph to be processed when key is negotiated when TLS conection is established.
+// NextProto adds nph to be processed when key is negotiated when TLS
+// connection is established.
 //
 // This function can only be called before the server is started.
 func (s *Server) NextProto(key string, nph ServeHandler) {


### PR DESCRIPTION
While at it wrap comments with long lines.