### PR TITLE
Various changes regarding code readibility

### DIFF
--- a/args.go
+++ b/args.go
@@ -134,7 +134,7 @@ func (a *Args) AppendBytes(dst []byte) []byte {
 	for i, n := 0, len(a.args); i < n; i++ {
 		kv := &a.args[i]
 		dst = AppendQuotedArg(dst, kv.key)
-		if kv.noValue == argsHasValue {
+		if !kv.noValue {
 			dst = append(dst, '=')
 			if len(kv.value) > 0 {
 				dst = AppendQuotedArg(dst, kv.value)
@@ -370,7 +370,7 @@ func copyArgs(dst, src []argsKV) []argsKV {
 		dstKV := &dst[i]
 		srcKV := &src[i]
 		dstKV.key = append(dstKV.key[:0], srcKV.key...)
-		if srcKV.noValue == argsNoValue {
+		if srcKV.noValue {
 			dstKV.value = dstKV.value[:0]
 		} else {
 			dstKV.value = append(dstKV.value[:0], srcKV.value...)
@@ -407,7 +407,7 @@ func setArg(h []argsKV, key, value string, noValue bool) []argsKV {
 	for i := 0; i < n; i++ {
 		kv := &h[i]
 		if key == string(kv.key) {
-			if noValue == argsNoValue {
+			if noValue {
 				kv.value = kv.value[:0]
 			} else {
 				kv.value = append(kv.value[:0], value...)
@@ -427,7 +427,7 @@ func appendArg(args []argsKV, key, value string, noValue bool) []argsKV {
 	var kv *argsKV
 	args, kv = allocArg(args)
 	kv.key = append(kv.key[:0], key...)
-	if noValue == argsNoValue {
+	if noValue {
 		kv.value = kv.value[:0]
 	} else {
 		kv.value = append(kv.value[:0], value...)

--- a/client_test.go
+++ b/client_test.go
@@ -72,9 +72,7 @@ func TestClientRedirectSameSchema(t *testing.T) {
 		return
 	}
 
-	var reqClient *HostClient
-
-	reqClient = &HostClient{
+	reqClient := &HostClient{
 		IsTLS: true,
 		Addr:  urlParsed.Host,
 		TLSConfig: &tls.Config{
@@ -117,9 +115,7 @@ func TestClientRedirectChangingSchemaHttp2Https(t *testing.T) {
 		return
 	}
 
-	var reqClient *HostClient
-
-	reqClient = &HostClient{
+	reqClient := &HostClient{
 		Addr: urlParsed.Host,
 		TLSConfig: &tls.Config{
 			InsecureSkipVerify: true,

--- a/fs.go
+++ b/fs.go
@@ -958,7 +958,7 @@ func (h *fsHandler) createDirIndex(base *URI, dirPath string, mustCompress bool)
 	base.CopyTo(&u)
 	u.Update(string(u.Path()) + "/")
 
-	sort.Sort(sort.StringSlice(filenames))
+	sort.Strings(filenames)
 	for _, name := range filenames {
 		u.Update(name)
 		pathEscaped := html.EscapeString(string(u.Path()))

--- a/fs_test.go
+++ b/fs_test.go
@@ -534,7 +534,7 @@ func TestFSHandlerSingleThread(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot read dirnames in cwd: %s", err)
 	}
-	sort.Sort(sort.StringSlice(filenames))
+	sort.Strings(filenames)
 
 	for i := 0; i < 3; i++ {
 		fsHandlerTest(t, requestHandler, filenames)
@@ -554,7 +554,7 @@ func TestFSHandlerConcurrent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot read dirnames in cwd: %s", err)
 	}
-	sort.Sort(sort.StringSlice(filenames))
+	sort.Strings(filenames)
 
 	concurrency := 10
 	ch := make(chan struct{}, concurrency)

--- a/fs_test.go
+++ b/fs_test.go
@@ -172,7 +172,7 @@ func TestServeFileSmallNoReadFrom(t *testing.T) {
 		t.Fatalf("expected %d bytes, got %d bytes", len(teststr), n)
 	}
 
-	body := string(buf.Bytes())
+	body := buf.String()
 	if body != teststr {
 		t.Fatalf("expected '%s'", teststr)
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -1833,7 +1833,7 @@ Content-Type: application/json
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if string(w.Bytes()) != s {
+	if w.String() != s {
 		t.Fatalf("unexpected output %q", w.Bytes())
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -395,7 +395,7 @@ func TestRequestUpdateURI(t *testing.T) {
 	if !strings.HasPrefix(s, "GET /123/432.html?aaa=bcse") {
 		t.Fatalf("cannot find %q in %q", "GET /123/432.html?aaa=bcse", s)
 	}
-	if strings.Index(s, "\r\nHost: foobar.com\r\n") < 0 {
+	if !strings.Contains(s, "\r\nHost: foobar.com\r\n") {
 		t.Fatalf("cannot find %q in %q", "\r\nHost: foobar.com\r\n", s)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -1986,8 +1986,7 @@ func (s *Server) serveConn(c net.Conn) error {
 		}
 
 		if hijackHandler != nil {
-			var hjr io.Reader
-			hjr = c
+			var hjr io.Reader = c
 			if br != nil {
 				hjr = br
 				br = nil


### PR DESCRIPTION
Changes:

07f0c88 (Shulhan, 2 hours ago)
   all: simplify variable initialization

   If we assign the variable after declaring it, we can simplify it using
   ":=" operator or "= value". The reader can still known the type of variable
   from the struct name or variable type before assignment operator.

7e00ec6 (Shulhan, 2 hours ago)
   args: simplify if-condition check on boolean value

cf6c51e (Shulhan, 2 hours ago)
   http_test: simplify strings.Index with strings.Contains

   Both have the same O(n), but strings.Contains more readable on
   if-condition.

8439088 (Shulhan, 2 hours ago)
   all: replace string(bytes.Buffer.Bytes()) with bytes.Buffer.String()

   Although its only occured on test files, it may be worth to simplified it.

5f1f929 (Shulhan, 2 hours ago)
   all: use sort.Strings when applicable

   Basically, sort.Strings is the shortcut of Sort(StringSlice(a)) but its
   more readable.