### PR TITLE
An atomic approach for HostClient.MaxConns

### DIFF
--- a/client.go
+++ b/client.go
@@ -544,6 +544,8 @@ type HostClient struct {
 	// Maximum number of connections which may be established to all hosts
 	// listed in Addr.
 	//
+	// It is safe to change this value using atomic.StoreUint64()
+	//
 	// DefaultMaxConnsPerHost is used if not set.
 	MaxConns uint64
 

--- a/client.go
+++ b/client.go
@@ -413,7 +413,7 @@ func (c *Client) Do(req *Request, resp *Response) error {
 			DialDualStack:                 c.DialDualStack,
 			IsTLS:                         isTLS,
 			TLSConfig:                     c.TLSConfig,
-			MaxConns:                      c.MaxConnsPerHost,
+			MaxConns:                      uint64(c.MaxConnsPerHost),
 			MaxIdleConnDuration:           c.MaxIdleConnDuration,
 			MaxIdemponentCallAttempts:     c.MaxIdemponentCallAttempts,
 			ReadBufferSize:                c.ReadBufferSize,
@@ -545,7 +545,7 @@ type HostClient struct {
 	// listed in Addr.
 	//
 	// DefaultMaxConnsPerHost is used if not set.
-	MaxConns int
+	MaxConns uint64
 
 	// Keep-alive connections are closed after this duration.
 	//
@@ -614,7 +614,7 @@ type HostClient struct {
 	lastUseTime uint32
 
 	connsLock  sync.Mutex
-	connsCount int
+	connsCount uint64
 	conns      []*clientConn
 
 	addrsLock sync.Mutex
@@ -1235,6 +1235,10 @@ var (
 		"Make sure the server returns 'Connection: close' response header before closing the connection")
 )
 
+func (c *HostClient) getMaxConns() uint64 {
+	return atomic.LoadUint64(&c.MaxConns)
+}
+
 func (c *HostClient) acquireConn() (*clientConn, error) {
 	var cc *clientConn
 	createConn := false
@@ -1244,7 +1248,7 @@ func (c *HostClient) acquireConn() (*clientConn, error) {
 	c.connsLock.Lock()
 	n = len(c.conns)
 	if n == 0 {
-		maxConns := c.MaxConns
+		maxConns := c.getMaxConns()
 		if maxConns <= 0 {
 			maxConns = DefaultMaxConnsPerHost
 		}


### PR DESCRIPTION
We need to dynamically change a `MaxConns` value. So this patch is about safe atomic reading from `MaxConns`.