### PR TITLE
SkipBody is propagated to Response copy

### DIFF
--- a/client.go
+++ b/client.go
@@ -982,6 +982,9 @@ func clientDoDeadline(req *Request, resp *Response, deadline time.Time, c client
 	req.copyToSkipBody(reqCopy)
 	swapRequestBody(req, reqCopy)
 	respCopy := AcquireResponse()
+	// Not calling resp.copyToSkipBody(respCopy) here to avoid
+	// unexpected messing with headers
+	respCopy.SkipBody = resp.SkipBody
 
 	// Note that the request continues execution on ErrTimeout until
 	// client-specific ReadTimeout exceeds. This helps limiting load


### PR DESCRIPTION
Addressing https://github.com/valyala/fasthttp/issues/529 , shouldn't break anything.