### PR TITLE
Timing fixes

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -2283,51 +2283,6 @@ func TestServerTimeoutError(t *testing.T) {
 	}
 }
 
-func TestServerMaxKeepaliveDuration(t *testing.T) {
-	s := &Server{
-		Handler: func(ctx *RequestCtx) {
-			time.Sleep(20 * time.Millisecond)
-		},
-		MaxKeepaliveDuration: 10 * time.Millisecond,
-	}
-
-	rw := &readWriter{}
-	rw.r.WriteString("GET /aaa HTTP/1.1\r\nHost: aa.com\r\n\r\n")
-	rw.r.WriteString("GET /bbbb HTTP/1.1\r\nHost: bbb.com\r\n\r\n")
-
-	ch := make(chan error)
-	go func() {
-		ch <- s.ServeConn(rw)
-	}()
-
-	select {
-	case err := <-ch:
-		if err != nil {
-			t.Fatalf("Unexpected error from serveConn: %s", err)
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("timeout")
-	}
-
-	br := bufio.NewReader(&rw.w)
-	var resp Response
-	if err := resp.Read(br); err != nil {
-		t.Fatalf("Unexpected error when parsing response: %s", err)
-	}
-	if !resp.ConnectionClose() {
-		t.Fatalf("Response must have 'connection: close' header")
-	}
-	verifyResponseHeader(t, &resp.Header, 200, 0, string(defaultContentType))
-
-	data, err := ioutil.ReadAll(br)
-	if err != nil {
-		t.Fatalf("Unexpected error when reading remaining data: %s", err)
-	}
-	if len(data) != 0 {
-		t.Fatalf("Unexpected data read after the first response %q. Expecting %q", data, "")
-	}
-}
-
 func TestServerMaxRequestsPerConn(t *testing.T) {
 	s := &Server{
 		Handler:            func(ctx *RequestCtx) {},


### PR DESCRIPTION
- Improved timing code to be much cleaner
- Add IdleTimeout
- Remove obsolete optimization (was fixed in Go 2 years ago: https://github.com/golang/go/issues/15133#issuecomment-271571395)

Fixes #563 and potentially #491