### PR TITLE
Option for immediate header flush

### DIFF
--- a/http.go
+++ b/http.go
@@ -62,8 +62,11 @@ type Response struct {
 	// Response header
 	//
 	// Copying Header by value is forbidden. Use pointer to Header instead.
-	Header               ResponseHeader
-	immediateHeaderFlush bool
+	Header ResponseHeader
+
+	// Flush headers as soon as possible without waiting for first body bytes.
+	// Relevant for bodyStream only.
+	ImmediateHeaderFlush bool
 
 	bodyStream io.Reader
 	w          responseBodyWriter
@@ -149,16 +152,6 @@ func (req *Request) ConnectionClose() bool {
 // SetConnectionClose sets 'Connection: close' header.
 func (req *Request) SetConnectionClose() {
 	req.Header.SetConnectionClose()
-}
-
-// ImmediateHeaderFlush returns whether headers will be flushed without waiting for body bytes
-func (resp *Response) ImmediateHeaderFlush() bool {
-	return resp.immediateHeaderFlush
-}
-
-// SetImmediateHeaderFlush causes headers to be flushed without waiting for body bytes
-func (resp *Response) SetImmediateHeaderFlush() {
-	resp.immediateHeaderFlush = true
 }
 
 // SendFile registers file on the given path to be used as response body
@@ -881,7 +874,7 @@ func (resp *Response) Reset() {
 	resp.SkipBody = false
 	resp.raddr = nil
 	resp.laddr = nil
-	resp.immediateHeaderFlush = false
+	resp.ImmediateHeaderFlush = false
 }
 
 func (resp *Response) resetSkipHeader() {
@@ -1467,7 +1460,7 @@ func (resp *Response) writeBodyStream(w *bufio.Writer, sendBody bool) error {
 	}
 	if contentLength >= 0 {
 		if err = resp.Header.Write(w); err == nil && sendBody {
-			if resp.immediateHeaderFlush {
+			if resp.ImmediateHeaderFlush {
 				err = w.Flush()
 			}
 			if err == nil {
@@ -1477,7 +1470,7 @@ func (resp *Response) writeBodyStream(w *bufio.Writer, sendBody bool) error {
 	} else {
 		resp.Header.SetContentLength(-1)
 		if err = resp.Header.Write(w); err == nil && sendBody {
-			if resp.immediateHeaderFlush {
+			if resp.ImmediateHeaderFlush {
 				err = w.Flush()
 			}
 			if err == nil {


### PR DESCRIPTION
In case of body stream if first body bytes generation takes long this adds an option of "faster response".

Will add tests if general idea is ok.