### PR TITLE
Support SameSite value "None" cookie attribute

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -398,7 +398,7 @@ func (c *Cookie) ParseBytes(src []byte) error {
 						if caseInsensitiveCompare(strCookieSameSiteStrict, kv.value) {
 							c.sameSite = CookieSameSiteStrictMode
 						}
-					case 'n': // "strict"
+					case 'n': // "none"
 						if caseInsensitiveCompare(strCookieSameSiteNone, kv.value) {
 							c.sameSite = CookieSameSiteNoneMode
 						}

--- a/cookie.go
+++ b/cookie.go
@@ -31,6 +31,9 @@ const (
 	CookieSameSiteLaxMode
 	// CookieSameSiteStrictMode sets the SameSite flag with the "Strict" parameter
 	CookieSameSiteStrictMode
+	// CookieSameSiteStrictMode sets the SameSite flag with the "None" parameter
+	// see https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
+	CookieSameSiteNoneMode
 )
 
 // AcquireCookie returns an empty Cookie object from the pool.
@@ -119,8 +122,12 @@ func (c *Cookie) SameSite() CookieSameSite {
 }
 
 // SetSameSite sets the cookie's SameSite flag to the given value.
+// set value CookieSameSiteNoneMode will set Secure to true also to avoid browser rejection
 func (c *Cookie) SetSameSite(mode CookieSameSite) {
 	c.sameSite = mode
+	if mode == CookieSameSiteNoneMode {
+		c.SetSecure(true)
+	}
 }
 
 // Path returns cookie path.
@@ -288,6 +295,11 @@ func (c *Cookie) AppendBytes(dst []byte) []byte {
 		dst = append(dst, strCookieSameSite...)
 		dst = append(dst, '=')
 		dst = append(dst, strCookieSameSiteStrict...)
+	case CookieSameSiteNoneMode:
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieSameSite...)
+		dst = append(dst, '=')
+		dst = append(dst, strCookieSameSiteNone...)
 	}
 	return dst
 }
@@ -385,6 +397,10 @@ func (c *Cookie) ParseBytes(src []byte) error {
 					case 's': // "strict"
 						if caseInsensitiveCompare(strCookieSameSiteStrict, kv.value) {
 							c.sameSite = CookieSameSiteStrictMode
+						}
+					case 'n': // "strict"
+						if caseInsensitiveCompare(strCookieSameSiteNone, kv.value) {
+							c.sameSite = CookieSameSiteNoneMode
 						}
 					}
 				}

--- a/cookie.go
+++ b/cookie.go
@@ -31,7 +31,7 @@ const (
 	CookieSameSiteLaxMode
 	// CookieSameSiteStrictMode sets the SameSite flag with the "Strict" parameter
 	CookieSameSiteStrictMode
-	// CookieSameSiteStrictMode sets the SameSite flag with the "None" parameter
+	// CookieSameSiteNoneMode sets the SameSite flag with the "None" parameter
 	// see https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
 	CookieSameSiteNoneMode
 )

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -121,6 +121,29 @@ func TestCookieSameSite(t *testing.T) {
 		t.Fatalf("missing SameSite flag in cookie %q", s)
 	}
 
+	if err := c.Parse("foo=bar; samesite=none"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if c.SameSite() != CookieSameSiteNoneMode {
+		t.Fatalf("SameSite None Mode must be set")
+	}
+	s = c.String()
+	if !strings.Contains(s, "; SameSite=None") {
+		t.Fatalf("missing SameSite flag in cookie %q", s)
+	}
+
+	if err := c.Parse("foo=bar"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	c.SetSameSite(CookieSameSiteNoneMode)
+	s = c.String()
+	if !strings.Contains(s, "; SameSite=None") {
+		t.Fatalf("missing SameSite flag in cookie %q", s)
+	}
+	if !strings.Contains(s, "; secure") {
+		t.Fatalf("missing Secure flag in cookie %q", s)
+	}
+
 	if err := c.Parse("foo=bar"); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/strings.go
+++ b/strings.go
@@ -62,6 +62,7 @@ var (
 	strCookieSameSite       = []byte("SameSite")
 	strCookieSameSiteLax    = []byte("Lax")
 	strCookieSameSiteStrict = []byte("Strict")
+	strCookieSameSiteNone   = []byte("None")
 
 	strClose               = []byte("close")
 	strGzip                = []byte("gzip")


### PR DESCRIPTION
As you may have heard Google recently announced changes coming to Chrome with the release of version 76 in July 2019. This change will directly impact the handling of 3rd party cookies.

For Chrome, set the cookie attribute “SameSite = None”, so that your cookie will be sent in the third party context. Leaving the attribute of “SameSite” unspecified would result in your cookie not being sent in case the user enables the “same-site-by-default-cookies” setting in their browser.
Set "SameSite = None"  is required is this case alongside "Secure"

You can find more detailed information here: 
https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
https://blog.chromium.org/2019/05/improving-privacy-and-security-on-web.html
