### PR TITLE
Correctly handle `NoDefaultContentType` without setting an `Content-Type` value

### DIFF
--- a/header.go
+++ b/header.go
@@ -1499,7 +1499,10 @@ func (h *ResponseHeader) AppendBytes(dst []byte) []byte {
 	// or if it is explicitly set.
 	// See https://github.com/valyala/fasthttp/issues/28 .
 	if h.ContentLength() != 0 || len(h.contentType) > 0 {
-		dst = appendHeaderLine(dst, strContentType, h.ContentType())
+		contentType := h.ContentType()
+		if len(contentType) > 0 {
+			dst = appendHeaderLine(dst, strContentType, contentType)
+		}
 	}
 
 	if len(h.contentLengthBytes) > 0 {

--- a/header_test.go
+++ b/header_test.go
@@ -1111,6 +1111,19 @@ func TestRequestHeaderCopyTo(t *testing.T) {
 	}
 }
 
+func TestResponseContentTypeNoDefaultNotEmpty(t *testing.T) {
+	var h ResponseHeader
+
+	h.noDefaultContentType = true
+	h.SetContentLength(5)
+
+	headers := h.String()
+
+	if strings.Index(headers, "Content-Type: \r\n") != -1 {
+		t.Fatalf("ResponseContentTypeNoDefaultNotEmpty fail, response: \n%+v\noutcome: \n%q\n", h, headers)
+	}
+}
+
 func TestRequestHeaderConnectionClose(t *testing.T) {
 	var h RequestHeader
 


### PR DESCRIPTION
At the moment if one configures `NoDefaultContentType` and does not configure any `Content-Type` header (through any of the appropriate header methods), `fasthttp` outputs an invalid header with an empty value, i.e. `Content-Type: `

This small patch fixes this case.
