### PR TITLE
Use ipv6-compliant methodology for joining host port

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1653,7 +1654,7 @@ func addMissingPort(addr string, isTLS bool) string {
 	if isTLS {
 		port = 443
 	}
-	return net.JoinHostPort(addr, port)
+	return net.JoinHostPort(addr, strconv.Itoa(port))
 }
 
 // PipelineClient pipelines requests over a limited set of concurrent

--- a/client.go
+++ b/client.go
@@ -1653,7 +1653,7 @@ func addMissingPort(addr string, isTLS bool) string {
 	if isTLS {
 		port = 443
 	}
-	return fmt.Sprintf("%s:%d", addr, port)
+	return net.JoinHostPort(addr, port)
 }
 
 // PipelineClient pipelines requests over a limited set of concurrent


### PR DESCRIPTION
Hello! First, thank you for maintaining this great library!

I stumbled recently upon this description of `fmt.Sprintf("%s:%d", addr, port)` as an anti-pattern: https://github.com/golang/go/issues/28308 - it seems to apply here.