### PR TITLE
Fix data race in fasthttputil.pipeConn

### DIFF
--- a/fasthttputil/inmemory_listener_test.go
+++ b/fasthttputil/inmemory_listener_test.go
@@ -2,7 +2,13 @@ package fasthttputil
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"sync"
 	"testing"
 	"time"
 )
@@ -89,4 +95,90 @@ func TestInmemoryListener(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("timeout")
 	}
+}
+
+// echoServerHandler implements http.Handler.
+type echoServerHandler struct {
+	t *testing.T
+}
+
+func (s *echoServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	time.Sleep(time.Millisecond * 100)
+	if _, err := io.Copy(w, r.Body); err != nil {
+		s.t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func testInmemoryListenerHTTP(t *testing.T, f func(t *testing.T, client *http.Client)) {
+	ln := NewInmemoryListener()
+	defer ln.Close()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return ln.Dial()
+			},
+		},
+		Timeout: time.Second,
+	}
+
+	server := &http.Server{
+		Handler: &echoServerHandler{t},
+	}
+
+	go func() {
+		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	}()
+
+	f(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+	server.Shutdown(ctx)
+}
+
+func testInmemoryListenerHTTPSingle(t *testing.T, client *http.Client, content string) {
+	res, err := client.Post("http://...", "text/plain", bytes.NewBufferString(content))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	s := string(b)
+	if string(b) != content {
+		t.Fatalf("unexpected response %s, expecting %s", s, content)
+	}
+}
+
+func TestInmemoryListenerHTTPSingle(t *testing.T) {
+	testInmemoryListenerHTTP(t, func(t *testing.T, client *http.Client) {
+		testInmemoryListenerHTTPSingle(t, client, "request")
+	})
+}
+
+func TestInmemoryListenerHTTPSerial(t *testing.T) {
+	testInmemoryListenerHTTP(t, func(t *testing.T, client *http.Client) {
+		for i := 0; i < 10; i++ {
+			testInmemoryListenerHTTPSingle(t, client, fmt.Sprintf("request_%d", i))
+		}
+	})
+}
+
+func TestInmemoryListenerHTTPConcurrent(t *testing.T) {
+	testInmemoryListenerHTTP(t, func(t *testing.T, client *http.Client) {
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				testInmemoryListenerHTTPSingle(t, client, fmt.Sprintf("request_%d", i))
+			}(i)
+		}
+		wg.Wait()
+	})
 }

--- a/fasthttputil/pipeconns.go
+++ b/fasthttputil/pipeconns.go
@@ -161,10 +161,11 @@ func (c *pipeConn) readNextByteBuffer(mayBlock bool) error {
 			return errWouldBlock
 		}
 		c.readDeadlineChLock.Lock()
-		defer c.readDeadlineChLock.Unlock()
+		readDeadlineCh := c.readDeadlineCh
+		c.readDeadlineChLock.Unlock()
 		select {
 		case c.b = <-c.rCh:
-		case <-c.readDeadlineCh:
+		case <-readDeadlineCh:
 			c.readDeadlineCh = closedDeadlineCh
 			// rCh may contain data when deadline is reached.
 			// Read the data before returning ErrTimeout.


### PR DESCRIPTION
When requests are made from `http.Client` to `http.Server` through `fasthttp.InmemoryListener`, data race occurs. Also, when `fasthttp.Server` is used for the server side instead of `http.Server`, which might be common for testing programs using this lovely library, the same thing happens.

This might be because `pipeConn` implemented in `fasthttputil/pipeconns.go` does not conform to [net.Conn](https://golang.org/pkg/net/#Conn) which states that "Multiple goroutines may invoke methods on a Conn simultaneously." 

Specifically, the data race I have found occurs when `pipeConn.Read` and `pipeConn.SetReadDeadline` are called concurrently. 

This PR includes the following.

- Add tests to reproduce the data race.
  - To reproduce, please go one commit back.
- Add one lock to stop the data race from happening.

The data race before the fix is as follows.

```
$ go test ./fasthttputil -run '^TestInmemoryListenerHTTPSingle$' -v -race
=== RUN   TestInmemoryListenerHTTPSingle
==================
WARNING: DATA RACE
Read at 0x00c000140160 by goroutine 16:
  github.com/valyala/fasthttp/fasthttputil.(*pipeConn).readNextByteBuffer()
      /.../fasthttp/fasthttputil/pipeconns.go:163 +0x12a
  github.com/valyala/fasthttp/fasthttputil.(*pipeConn).read()
      /.../fasthttp/fasthttputil/pipeconns.go:141 +0x1ae
  github.com/valyala/fasthttp/fasthttputil.(*pipeConn).Read()
      /.../fasthttp/fasthttputil/pipeconns.go:124 +0xc8
  net/http.(*connReader).backgroundRead()
      /usr/lib/go-1.12/src/net/http/server.go:677 +0x91

Previous write at 0x00c000140160 by goroutine 11:
  github.com/valyala/fasthttp/fasthttputil.(*pipeConn).SetReadDeadline()
      /.../fasthttp/fasthttputil/pipeconns.go:217 +0xb6
  net/http.(*connReader).abortPendingRead()
      /usr/lib/go-1.12/src/net/http/server.go:723 +0x131
  net/http.(*response).finishRequest()
      /usr/lib/go-1.12/src/net/http/server.go:1592 +0x13d
  net/http.(*conn).serve()
      /usr/lib/go-1.12/src/net/http/server.go:1883 +0x864

Goroutine 16 (running) created at:
  net/http.(*connReader).startBackgroundRead()
      /usr/lib/go-1.12/src/net/http/server.go:673 +0x141
  net/http.(*connReader).startBackgroundRead-fm()
      /usr/lib/go-1.12/src/net/http/server.go:662 +0x41
  net/http.(*body).readLocked()
      /usr/lib/go-1.12/src/net/http/transfer.go:854 +0x19c
  net/http.(*body).Read()
      /usr/lib/go-1.12/src/net/http/transfer.go:808 +0x10f
  io.copyBuffer()
      /usr/lib/go-1.12/src/io/io.go:402 +0x143
  net/http.(*response).ReadFrom()
      /usr/lib/go-1.12/src/io/io.go:375 +0x272
  io.copyBuffer()
      /usr/lib/go-1.12/src/io/io.go:388 +0x3fa
  github.com/valyala/fasthttp/fasthttputil.(*echoServerHandler).ServeHTTP()
      /usr/lib/go-1.12/src/io/io.go:364 +0x12c
  net/http.serverHandler.ServeHTTP()
      /usr/lib/go-1.12/src/net/http/server.go:2774 +0xce
  net/http.(*conn).serve()
      /usr/lib/go-1.12/src/net/http/server.go:1878 +0x811

Goroutine 11 (running) created at:
  net/http.(*Server).Serve()
      /usr/lib/go-1.12/src/net/http/server.go:2884 +0x4c4
  github.com/valyala/fasthttp/fasthttputil.testInmemoryListenerHTTP.func2()
      /.../fasthttp/fasthttputil/inmemory_listener_test.go:131 +0x52
==================
--- FAIL: TestInmemoryListenerHTTPSingle (0.11s)
    testing.go:809: race detected during execution of test
FAIL
FAIL    github.com/valyala/fasthttp/fasthttputil        0.120s
```

The corresponding test results after the fix are as follows.

```
$ go test ./fasthttputil -run '^TestInmemoryListenerHTTP' -race -v
=== RUN   TestInmemoryListenerHTTPSingle
--- PASS: TestInmemoryListenerHTTPSingle (0.11s)
=== RUN   TestInmemoryListenerHTTPSerial
--- PASS: TestInmemoryListenerHTTPSerial (1.53s)
=== RUN   TestInmemoryListenerHTTPConcurrent
--- PASS: TestInmemoryListenerHTTPConcurrent (0.11s)
PASS
ok      github.com/valyala/fasthttp/fasthttputil        2.767s
```