### PR TITLE
Opt in PanicHandler

### DIFF
--- a/server.go
+++ b/server.go
@@ -167,6 +167,12 @@ type Server struct {
 	//   * ErrBrokenChunks
 	ErrorHandler func(ctx *RequestCtx, err error)
 
+	// RecoverHandler for reacting on a panic. Called with the result of calling recover() if it is not nil.
+	//
+	// To be on the safe side, implementors are advised to re-panic so the stack would continue to unwind.
+	// This would make sure you're not left in some inconsistent state due to the original panic.
+	RecoverHandler func(r interface{})
+
 	// HeaderReceived is called after receiving the header
 	//
 	// non zero RequestConfig field values will overwrite the default configs
@@ -1578,6 +1584,7 @@ func (s *Server) Serve(ln net.Listener) error {
 		WorkerFunc:      s.serveConn,
 		MaxWorkersCount: maxWorkersCount,
 		LogAllErrors:    s.LogAllErrors,
+		RecoverHandler:  s.RecoverHandler,
 		Logger:          s.logger(),
 		connState:       s.setState,
 	}

--- a/server.go
+++ b/server.go
@@ -167,11 +167,11 @@ type Server struct {
 	//   * ErrBrokenChunks
 	ErrorHandler func(ctx *RequestCtx, err error)
 
-	// RecoverHandler for reacting on a panic. Called with the result of calling recover() if it is not nil.
+	// PanicHandler for reacting on a panic. Called with the result of calling recover() if it is not nil.
 	//
 	// To be on the safe side, implementors are advised to re-panic so the stack would continue to unwind.
 	// This would make sure you're not left in some inconsistent state due to the original panic.
-	RecoverHandler func(r interface{})
+	PanicHandler func(r interface{})
 
 	// HeaderReceived is called after receiving the header
 	//
@@ -1584,7 +1584,7 @@ func (s *Server) Serve(ln net.Listener) error {
 		WorkerFunc:      s.serveConn,
 		MaxWorkersCount: maxWorkersCount,
 		LogAllErrors:    s.LogAllErrors,
-		RecoverHandler:  s.RecoverHandler,
+		PanicHandler:    s.PanicHandler,
 		Logger:          s.logger(),
 		connState:       s.setState,
 	}

--- a/workerpool.go
+++ b/workerpool.go
@@ -213,13 +213,13 @@ func (wp *workerPool) workerFunc(ch *workerChan) {
 
 	if wp.PanicHandler != nil {
 		defer func() {
+			wp.workerDone()
 			if r := recover(); r != nil {
 				if c != nil {
 					c.Close()
 				}
 				wp.PanicHandler(r)
 			}
-			wp.workerDone()
 		}()
 	}
 

--- a/workerpool.go
+++ b/workerpool.go
@@ -22,7 +22,7 @@ type workerPool struct {
 
 	LogAllErrors bool
 
-	RecoverHandler func(r interface{})
+	PanicHandler func(r interface{})
 
 	MaxIdleWorkerDuration time.Duration
 
@@ -211,13 +211,13 @@ func (wp *workerPool) workerDone() {
 func (wp *workerPool) workerFunc(ch *workerChan) {
 	var c net.Conn
 
-	if wp.RecoverHandler != nil {
+	if wp.PanicHandler != nil {
 		defer func() {
 			if r := recover(); r != nil {
 				if c != nil {
 					c.Close()
 				}
-				wp.RecoverHandler(r)
+				wp.PanicHandler(r)
 			}
 			wp.workerDone()
 		}()
@@ -251,7 +251,7 @@ func (wp *workerPool) workerFunc(ch *workerChan) {
 		}
 	}
 
-	if wp.RecoverHandler == nil {
+	if wp.PanicHandler == nil {
 		wp.workerDone()
 	}
 }

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -209,9 +209,9 @@ func testWorkerPoolPanicErrorMulti(t *testing.T) {
 		MaxWorkersCount:       1000,
 		MaxIdleWorkerDuration: time.Millisecond,
 		Logger:                &customLogger{},
-		RecoverHandler: func(r interface{}) {
+		PanicHandler: func(r interface{}) {
 			if r == nil {
-				t.Fatalf("RecoverHandler got nil")
+				t.Fatalf("PanicHandler got nil")
 			}
 			atomic.AddUint64(&recoverCount, 1)
 		},
@@ -222,7 +222,7 @@ func testWorkerPoolPanicErrorMulti(t *testing.T) {
 	}
 
 	if recoverCount == 0 {
-		t.Fatalf("RecoverHandler was not called")
+		t.Fatalf("PanicHandler was not called")
 	}
 }
 

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -1,8 +1,10 @@
 package fasthttp
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -165,5 +167,113 @@ func testWorkerPoolMaxWorkersCount(t *testing.T) {
 	if err := ln.Close(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+	wp.Stop()
+}
+
+func TestWorkerPoolPanicErrorSerial(t *testing.T) {
+	testWorkerPoolPanicErrorMulti(t)
+}
+
+func TestWorkerPoolPanicErrorConcurrent(t *testing.T) {
+	concurrency := 10
+	ch := make(chan struct{}, concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			testWorkerPoolPanicErrorMulti(t)
+			ch <- struct{}{}
+		}()
+	}
+	for i := 0; i < concurrency; i++ {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatalf("timeout")
+		}
+	}
+}
+
+func testWorkerPoolPanicErrorMulti(t *testing.T) {
+	var globalCount uint64
+	var recoverCount uint64
+	wp := &workerPool{
+		WorkerFunc: func(conn net.Conn) error {
+			count := atomic.AddUint64(&globalCount, 1)
+			switch count % 3 {
+			case 0:
+				panic("foobar")
+			case 1:
+				return fmt.Errorf("fake error")
+			}
+			return nil
+		},
+		MaxWorkersCount:       1000,
+		MaxIdleWorkerDuration: time.Millisecond,
+		Logger:                &customLogger{},
+		RecoverHandler: func(r interface{}) {
+			if r == nil {
+				t.Fatalf("RecoverHandler got nil")
+			}
+			atomic.AddUint64(&recoverCount, 1)
+		},
+	}
+
+	for i := 0; i < 10; i++ {
+		testWorkerPoolPanicError(t, wp)
+	}
+
+	if recoverCount == 0 {
+		t.Fatalf("RecoverHandler was not called")
+	}
+}
+
+func testWorkerPoolPanicError(t *testing.T, wp *workerPool) {
+	wp.Start()
+
+	ln := fasthttputil.NewInmemoryListener()
+
+	clientsCount := 10
+	clientCh := make(chan struct{}, clientsCount)
+	for i := 0; i < clientsCount; i++ {
+		go func() {
+			conn, err := ln.Dial()
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			data, err := ioutil.ReadAll(conn)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if len(data) > 0 {
+				t.Fatalf("unexpected data read: %q. Expecting empty data", data)
+			}
+			if err = conn.Close(); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			clientCh <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < clientsCount; i++ {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !wp.Serve(conn) {
+			t.Fatalf("worker pool mustn't be full")
+		}
+	}
+
+	for i := 0; i < clientsCount; i++ {
+		select {
+		case <-clientCh:
+		case <-time.After(time.Second):
+			t.Fatalf("timeout")
+		}
+	}
+
+	if err := ln.Close(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
 	wp.Stop()
 }


### PR DESCRIPTION
After recover() band-aids were removed ([commit](https://github.com/valyala/fasthttp/commit/886e5411604884629c566961ea8ed2cec074e4b1)). Users were left with no possibility to act on a panic in a goroutine started inside fasthttp code. They can recover inside their own code. However, that might turn to be repetitive and cumbersome as they have to it on every handler, callback, custom interface implementation (ReadCloser) etc...

The discussion on [this issue](https://github.com/valyala/fasthttp/issues/471) suggests that panic handling is the responsibility of the user. This PR allow the user to provide an opt-in callback which is called on a non nil return value from `recover()`. Users are encouraged to re-panic in their implementation to allow the process to crash completely and not leave fasthttp internals in some unexpected state.

Main use cases are error reporting and proper cleanup of resources upon an unexpected process termination.

**Note:** Currently, not all places creating goroutines are handled. I can add them later on if the general idea is accepted by the maintainers.