### PR TITLE
Propagating custom SkipBody value to allow skipping body for non-HEAD requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -1143,7 +1143,11 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 
 	// Free up resources occupied by response before sending the request,
 	// so the GC may reclaim these resources (e.g. response body).
+
+	// backing up SkipBody in case it was set explicitly
+	customSkipBody := resp.SkipBody
 	resp.Reset()
+	resp.SkipBody = customSkipBody
 
 	// If we detected a redirect to another schema
 	if req.schemaUpdate {
@@ -1210,7 +1214,7 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 		}
 	}
 
-	if !req.Header.IsGet() && req.Header.IsHead() {
+	if customSkipBody || !req.Header.IsGet() && req.Header.IsHead() {
 		resp.SkipBody = true
 	}
 	if c.DisableHeaderNamesNormalizing {


### PR DESCRIPTION
As a next step from https://github.com/valyala/fasthttp/pull/532, as in comments @xuecai mentioned an issue with it being overwritten by .Reset() and future check.