### PR TITLE
Replace hexCharUpeer with upperhex

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -315,13 +315,6 @@ func int2hexbyte(n int) byte {
 	return 'a' + byte(n) - 10
 }
 
-func hexCharUpper(c byte) byte {
-	if c < 10 {
-		return '0' + c
-	}
-	return c - 10 + 'A'
-}
-
 var hex2intTable = func() []byte {
 	b := make([]byte, 256)
 	for i := 0; i < 256; i++ {
@@ -338,7 +331,10 @@ var hex2intTable = func() []byte {
 	return b
 }()
 
-const toLower = 'a' - 'A'
+const (
+	toLower  = 'a' - 'A'
+	upperhex = "0123456789ABCDEF"
+)
 
 var toLowerTable = func() [256]byte {
 	var a [256]byte
@@ -459,7 +455,7 @@ func AppendQuotedArg(dst, src []byte) []byte {
 		case c == ' ':
 			dst = append(dst, '+')
 		case quotedArgShouldEscapeTable[int(c)]:
-			dst = append(dst, '%', hexCharUpper(c>>4), hexCharUpper(c&15))
+			dst = append(dst, '%', upperhex[c>>4], upperhex[c&15])
 		default:
 			dst = append(dst, c)
 		}
@@ -475,7 +471,7 @@ func appendQuotedPath(dst, src []byte) []byte {
 
 	for _, c := range src {
 		if quotedPathShouldEscapeTable[int(c)] {
-			dst = append(dst, '%', hexCharUpper(c>>4), hexCharUpper(c&15))
+			dst = append(dst, '%', upperhex[c>>4], upperhex[c&15])
 		} else {
 			dst = append(dst, c)
 		}


### PR DESCRIPTION
In this case, indexed read of the table is faster than calculate the result

(benchmark result)
BenchmarkHexString-8    2000000000               0.65 ns/op
BenchmarkHexCharUpeer-8        500000000                3.77 ns/op

(benchmark codes)
```
var r byte

func BenchmarkHexString(b *testing.B) {
	testSlice := make([]byte, 0, b.N)
	for i := 0; i < b.N; i++ {
		testSlice = append(testSlice, uint8(rand.Uint32()))
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		r = "0123456789ABCDEF"[testSlice[i]>> 4]
	}
}

func BenchmarkHexCharUpeer(b *testing.B) {
	testSlice := make([]byte, 0, b.N)
	for i := 0; i < b.N; i++ {
		testSlice = append(testSlice, uint8(rand.Uint32()))
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		r = hexCharUpeer(testSlice[i] >> 4)
	}
}
```