### PR TITLE
Replace int2hexbyte with lowerhex

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -296,7 +296,7 @@ func writeHexInt(w *bufio.Writer, n int) error {
 	buf := v.([]byte)
 	i := len(buf) - 1
 	for {
-		buf[i] = int2hexbyte(n & 0xf)
+		buf[i] = upperhex[n&0xf]
 		n >>= 4
 		if n == 0 {
 			break
@@ -306,13 +306,6 @@ func writeHexInt(w *bufio.Writer, n int) error {
 	_, err := w.Write(buf[i:])
 	hexIntBufPool.Put(v)
 	return err
-}
-
-func int2hexbyte(n int) byte {
-	if n < 10 {
-		return '0' + byte(n)
-	}
-	return 'a' + byte(n) - 10
 }
 
 var hex2intTable = func() []byte {

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -448,7 +448,7 @@ func AppendQuotedArg(dst, src []byte) []byte {
 		case c == ' ':
 			dst = append(dst, '+')
 		case quotedArgShouldEscapeTable[int(c)]:
-			dst = append(dst, '%', upperhex[c>>4], upperhex[c&15])
+			dst = append(dst, '%', upperhex[c>>4], upperhex[c&0xf])
 		default:
 			dst = append(dst, c)
 		}

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -296,7 +296,7 @@ func writeHexInt(w *bufio.Writer, n int) error {
 	buf := v.([]byte)
 	i := len(buf) - 1
 	for {
-		buf[i] = upperhex[n&0xf]
+		buf[i] = lowerhex[n&0xf]
 		n >>= 4
 		if n == 0 {
 			break
@@ -327,6 +327,7 @@ var hex2intTable = func() []byte {
 const (
 	toLower  = 'a' - 'A'
 	upperhex = "0123456789ABCDEF"
+	lowerhex = "0123456789abcdef"
 )
 
 var toLowerTable = func() [256]byte {

--- a/bytesconv_timing_test.go
+++ b/bytesconv_timing_test.go
@@ -65,18 +65,6 @@ func BenchmarkAppendIPv4(b *testing.B) {
 	})
 }
 
-func BenchmarkInt2HexByte(b *testing.B) {
-	buf := []int{1, 0xf, 2, 0xd, 3, 0xe, 4, 0xa, 5, 0xb, 6, 0xc, 7, 0xf, 0, 0xf, 6, 0xd, 9, 8, 4, 0x5}
-	b.RunParallel(func(pb *testing.PB) {
-		var n int
-		for pb.Next() {
-			for _, n = range buf {
-				int2hexbyte(n)
-			}
-		}
-	})
-}
-
 func BenchmarkWriteHexInt(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var w bytebufferpool.ByteBuffer


### PR DESCRIPTION
int2hexbyte can be replaced with lowerhex, and i'm wandering maybe we could use only one HEX format, since the constant upperhex is already exists.( If use upperhex only, we need to modify our test instead)

Also replace 15 with 0xf in take the 4 LSBs in byte, maybe 0xf looks more readable in this case?