### PR TITLE
Refactoring to reuse response status codes

### DIFF
--- a/client.go
+++ b/client.go
@@ -861,7 +861,7 @@ func getRedirectURL(baseURL string, location []byte) string {
 
 // StatusCodeIsRedirect checks the response code.
 //
-// If this is a redirect code then it returns true, otherwise false.
+// StatusCodeIsRedirect returns true if the status code indicates a redirect.
 func StatusCodeIsRedirect(statusCode int) bool {
 	return statusCode == StatusMovedPermanently ||
 		statusCode == StatusFound ||

--- a/client.go
+++ b/client.go
@@ -825,12 +825,7 @@ func doRequestFollowRedirects(req *Request, dst []byte, url string, c clientDoer
 		if err = c.Do(req, resp); err != nil {
 			break
 		}
-		statusCode = resp.Header.StatusCode()
-		if statusCode != StatusMovedPermanently &&
-			statusCode != StatusFound &&
-			statusCode != StatusSeeOther &&
-			statusCode != StatusTemporaryRedirect &&
-			statusCode != StatusPermanentRedirect {
+		if IsFinishStatusCode(resp.Header.StatusCode()) {
 			break
 		}
 
@@ -862,6 +857,14 @@ func getRedirectURL(baseURL string, location []byte) string {
 	redirectURL := u.String()
 	ReleaseURI(u)
 	return redirectURL
+}
+
+func IsFinishStatusCode(statusCode int) bool {
+	return statusCode != StatusMovedPermanently &&
+		statusCode != StatusFound &&
+		statusCode != StatusSeeOther &&
+		statusCode != StatusTemporaryRedirect &&
+		statusCode != StatusPermanentRedirect
 }
 
 var (

--- a/client.go
+++ b/client.go
@@ -825,7 +825,7 @@ func doRequestFollowRedirects(req *Request, dst []byte, url string, c clientDoer
 		if err = c.Do(req, resp); err != nil {
 			break
 		}
-		if IsFinishStatusCode(resp.Header.StatusCode()) {
+		if !StatusCodeIsRedirect(resp.Header.StatusCode()) {
 			break
 		}
 
@@ -859,12 +859,15 @@ func getRedirectURL(baseURL string, location []byte) string {
 	return redirectURL
 }
 
-func IsFinishStatusCode(statusCode int) bool {
-	return statusCode != StatusMovedPermanently &&
-		statusCode != StatusFound &&
-		statusCode != StatusSeeOther &&
-		statusCode != StatusTemporaryRedirect &&
-		statusCode != StatusPermanentRedirect
+// StatusCodeIsRedirect checks the response code.
+//
+// If this is a redirect code then it returns true, otherwise false.
+func StatusCodeIsRedirect(statusCode int) bool {
+	return statusCode == StatusMovedPermanently ||
+		statusCode == StatusFound ||
+		statusCode == StatusSeeOther ||
+		statusCode == StatusTemporaryRedirect ||
+		statusCode == StatusPermanentRedirect
 }
 
 var (


### PR DESCRIPTION
Refactoring to reuse response status codes.
Status codes are needed, where we ourselves implement a cycle for all redirects.
To understand where the last redirect is.
