### PR TITLE
support wait conn on busy

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,7 +89,7 @@ func DoTimeout(req *Request, resp *Response, timeout time.Duration) error {
 // the given deadline.
 //
 // ErrNoFreeConns is returned if all DefaultMaxConnsPerHost connections
-// to the requested host are busy when PreferWaitConn is false.
+// to the requested host are busy and PreferWaitConn is false.
 //
 // It is recommended obtaining req and resp via AcquireRequest
 // and AcquireResponse in performance-critical code.
@@ -188,7 +188,7 @@ type Client struct {
 	// DefaultMaxConnsPerHost is used if not set.
 	MaxConnsPerHost int
 
-	// wait conn instead of throw ErrNoFreeConns to clipping traffic,default is false
+	// Wait for a connection if MaxConnsPerHost is reached instead of returning ErrNoFreeConns.
 	PreferWaitConn bool
 
 	// Idle keep-alive connections are closed after this duration.
@@ -321,7 +321,7 @@ func (c *Client) Post(dst []byte, url string, postArgs *Args) (statusCode int, b
 // the given timeout.
 //
 // ErrNoFreeConns is returned if all Client.MaxConnsPerHost connections
-// to the requested host are busy when PreferWaitConn is false.
+// to the requested host are busy and PreferWaitConn is false.
 //
 // It is recommended obtaining req and resp via AcquireRequest
 // and AcquireResponse in performance-critical code.
@@ -353,7 +353,7 @@ func (c *Client) DoTimeout(req *Request, resp *Response, timeout time.Duration) 
 // the given deadline.
 //
 // ErrNoFreeConns is returned if all Client.MaxConnsPerHost connections
-// to the requested host are busy when PreferWaitConn is false.
+// to the requested host are busy and PreferWaitConn is false.
 //
 // It is recommended obtaining req and resp via AcquireRequest
 // and AcquireResponse in performance-critical code.
@@ -555,7 +555,7 @@ type HostClient struct {
 	// DefaultMaxConnsPerHost is used if not set.
 	MaxConns int
 
-	// wait conn instead of throw ErrNoFreeConns to clipping traffic,default is disabled
+	// Wait for a connection if MaxConnsPerHost is reached instead of returning ErrNoFreeConns.
 	PreferWaitConn bool
 
 	// Keep-alive connections are closed after this duration.

--- a/client.go
+++ b/client.go
@@ -1167,10 +1167,12 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 	}
 	deadline := req.deadline
 	// the deadline is final if call clientDoDeadline. otherwise every attempts is assign a new one
-	if deadline.IsZero() && c.ReadTimeout != 0 {
-		deadline = time.Now().Add(c.ReadTimeout)
-	} else {
-		deadline = time.Now().Add(DefaultDialTimeout)
+	if deadline.IsZero() {
+		if c.ReadTimeout != 0 {
+			deadline = time.Now().Add(c.ReadTimeout)
+		} else {
+			deadline = time.Now().Add(DefaultDialTimeout)
+		}
 	}
 	cc, err := c.acquireConn(deadline)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1825,6 +1825,7 @@ func TestClient_WaitPrefer(t *testing.T) {
 		waitClient = &Client{
 			PreferWaitConn:  true,
 			MaxConnsPerHost: 2,
+			ReadTimeout:     time.Minute,
 		}
 		wg             sync.WaitGroup
 		noFreeConnErrs int32
@@ -1868,12 +1869,12 @@ func TestClient_WaitPrefer(t *testing.T) {
 // 1            running     OK
 // 2            wait     running     OK
 // 3            wait     wait       running    OK
-// 4            wait     wait       wait       wait     wait
-// 5            wait     wait       wait       running  running
+// 4            wait     wait       wait       wait     timeout(cancel)
+// 5            wait     wait       wait       running  timeout
 //
 // In 1 second,on 0,300,600,900 ms will sending request to server.
 //  request at 900ms will timeout because did not get response in time.
-// one request wait conn all the time because there is no free.
+// one request wait conn all the time then cancel because there is no free.
 
 func TestClient_DoTimeout_PreferWaitConn(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/http.go
+++ b/http.go
@@ -856,6 +856,7 @@ func (req *Request) resetSkipHeader() {
 	req.postArgs.Reset()
 	req.parsedPostArgs = false
 	req.isTLS = false
+	req.deadline = time.Time{}
 }
 
 // RemoveMultipartFormFiles removes multipart/form-data temporary files

--- a/http.go
+++ b/http.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/valyala/bytebufferpool"
 )
@@ -49,6 +50,7 @@ type Request struct {
 
 	// To detect scheme changes in redirects
 	schemaUpdate bool
+	deadline     time.Time
 }
 
 // Response represents HTTP response.


### PR DESCRIPTION
support wait conn on busy ,it is aim at avoid make too much conns which i think will make performance problem. thanks  for  reviewing  and i had make same change.
```
func (c *HostClient) releaseConn(cc *clientConn) {
	c.connsLock.Lock()
	c.conns = append(c.conns, cc)
	c.connsLock.Unlock()
	select {
	case c.connNotify <- struct{}{}:
	default:
	}
}
```
  i do not think  lost notify will cause problem. waiting is no guarantee on continuous heavy requests.it is crop traffic on a time bucket (timeout) not for make requests ordered .