### PR TITLE
Request head Host been overwrite when set a custom URI Host value

### DIFF
--- a/http.go
+++ b/http.go
@@ -1141,7 +1141,7 @@ func (req *Request) onlyMultipartForm() bool {
 //
 // See also WriteTo.
 func (req *Request) Write(w *bufio.Writer) error {
-	if len(req.Header.Host()) == 0 || req.parsedURI {
+	if len(req.Header.Host()) == 0 && req.parsedURI {
 		uri := req.URI()
 		host := uri.Host()
 		if len(host) == 0 {


### PR DESCRIPTION
I use req.Header.Read(bufio.NewReader(buf)) to get request, and i need sent this request to a special host, so i call req.SetHost(SPECIAL_ADDR), but then, request head Host value has been change too, i think maybe there is a typo.