### PR TITLE
fix: cannot use custom host in header

### DIFF
--- a/http.go
+++ b/http.go
@@ -1143,11 +1143,13 @@ func (req *Request) onlyMultipartForm() bool {
 func (req *Request) Write(w *bufio.Writer) error {
 	if len(req.Header.Host()) == 0 || req.parsedURI {
 		uri := req.URI()
-		host := uri.Host()
-		if len(host) == 0 {
-			return errRequestHostRequired
+		if len(req.Header.Host()) == 0 {
+			host := uri.Host()
+			if len(host) == 0 {
+				return errRequestHostRequired
+			}
+			req.Header.SetHostBytes(host)
 		}
-		req.Header.SetHostBytes(host)
 		req.Header.SetRequestURIBytes(uri.RequestURI())
 
 		if len(uri.username) > 0 {


### PR DESCRIPTION
fix: cannot use custom host in header, usually used in proxy,
the same as "proxy_set_header Host $host" in nginx
see: https://tools.ietf.org/html/rfc2616#page-128