### PR TITLE
fasthttputil: add errInmemoryListenerClosed

### DIFF
--- a/fasthttputil/inmemory_listener.go
+++ b/fasthttputil/inmemory_listener.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-var errInmemoryListenerClosed = errors.New("InmemoryListener is already closed: use of closed network connection")
+var ErrInmemoryListenerClosed = errors.New("InmemoryListener is already closed: use of closed network connection")
 
 // InmemoryListener provides in-memory dialer<->net.Listener implementation.
 //

--- a/fasthttputil/inmemory_listener.go
+++ b/fasthttputil/inmemory_listener.go
@@ -38,7 +38,7 @@ func NewInmemoryListener() *InmemoryListener {
 func (ln *InmemoryListener) Accept() (net.Conn, error) {
 	c, ok := <-ln.conns
 	if !ok {
-		return nil, errInmemoryListenerClosed
+		return nil, ErrInmemoryListenerClosed
 	}
 	close(c.accepted)
 	return c.conn, nil
@@ -53,7 +53,7 @@ func (ln *InmemoryListener) Close() error {
 		close(ln.conns)
 		ln.closed = true
 	} else {
-		err = errInmemoryListenerClosed
+		err = ErrInmemoryListenerClosed
 	}
 	ln.lock.Unlock()
 	return err
@@ -90,7 +90,7 @@ func (ln *InmemoryListener) Dial() (net.Conn, error) {
 	ln.lock.Unlock()
 
 	if cConn == nil {
-		return nil, errInmemoryListenerClosed
+		return nil, ErrInmemoryListenerClosed
 	}
 	return cConn, nil
 }

--- a/fasthttputil/inmemory_listener.go
+++ b/fasthttputil/inmemory_listener.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-var errInmemoryListenerClosed = errors.New("InmemoryListener is already closed")
+var errInmemoryListenerClosed = errors.New("InmemoryListener is already closed: use of closed network connection")
 
 // InmemoryListener provides in-memory dialer<->net.Listener implementation.
 //

--- a/fasthttputil/inmemory_listener.go
+++ b/fasthttputil/inmemory_listener.go
@@ -1,10 +1,12 @@
 package fasthttputil
 
 import (
-	"fmt"
+	"errors"
 	"net"
 	"sync"
 )
+
+var errInmemoryListenerClosed = errors.New("InmemoryListener is already closed")
 
 // InmemoryListener provides in-memory dialer<->net.Listener implementation.
 //
@@ -36,7 +38,7 @@ func NewInmemoryListener() *InmemoryListener {
 func (ln *InmemoryListener) Accept() (net.Conn, error) {
 	c, ok := <-ln.conns
 	if !ok {
-		return nil, fmt.Errorf("InmemoryListener is already closed: use of closed network connection")
+		return nil, errInmemoryListenerClosed
 	}
 	close(c.accepted)
 	return c.conn, nil
@@ -51,7 +53,7 @@ func (ln *InmemoryListener) Close() error {
 		close(ln.conns)
 		ln.closed = true
 	} else {
-		err = fmt.Errorf("InmemoryListener is already closed")
+		err = errInmemoryListenerClosed
 	}
 	ln.lock.Unlock()
 	return err
@@ -88,7 +90,7 @@ func (ln *InmemoryListener) Dial() (net.Conn, error) {
 	ln.lock.Unlock()
 
 	if cConn == nil {
-		return nil, fmt.Errorf("InmemoryListener is already closed")
+		return nil, errInmemoryListenerClosed
 	}
 	return cConn, nil
 }


### PR DESCRIPTION
There are three identical errors in inmemory_listener.go, maybe we could use errInmemoryListenerClosed to replace them.