### PR TITLE
Format errors

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -450,7 +450,7 @@ func TestArgsSetGetDel(t *testing.T) {
 
 	a.Parse("aaa=xxx&bb=aa")
 	if string(a.Peek("foo0")) != "" {
-		t.Fatalf("Unepxected value %q", a.Peek("foo0"))
+		t.Fatalf("Unexpected value %q", a.Peek("foo0"))
 	}
 	if string(a.Peek("aaa")) != "xxx" {
 		t.Fatalf("Unexpected value %q. Expected %q", a.Peek("aaa"), "xxx")

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -81,7 +81,7 @@ func testAppendIPv4(t *testing.T, ipStr string, isValid bool) {
 	s := string(AppendIPv4(nil, ip))
 	if isValid {
 		if s != ipStr {
-			t.Fatalf("unepxected ip %q. Expecting %q", s, ipStr)
+			t.Fatalf("unexpected ip %q. Expecting %q", s, ipStr)
 		}
 	} else {
 		ipStr = "non-v4 ip passed to AppendIPv4"

--- a/header_test.go
+++ b/header_test.go
@@ -1292,7 +1292,7 @@ func TestResponseHeaderVisitAll(t *testing.T) {
 	r := bytes.NewBufferString("HTTP/1.1 200 OK\r\nContent-Type: aa\r\nContent-Length: 123\r\nSet-Cookie: aa=bb; path=/foo/bar\r\nSet-Cookie: ccc\r\n\r\n")
 	br := bufio.NewReader(r)
 	if err := h.Read(br); err != nil {
-		t.Fatalf("Unepxected error: %s", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 
 	if h.Len() != 4 {
@@ -1378,11 +1378,11 @@ func TestRequestHeaderVisitAll(t *testing.T) {
 			}
 			cookieCount++
 		default:
-			t.Fatalf("Unepxected header %q=%q", k, v)
+			t.Fatalf("Unexpected header %q=%q", k, v)
 		}
 	})
 	if hostCount != 1 {
-		t.Fatalf("Unepxected number of host headers detected %d. Expected 1", hostCount)
+		t.Fatalf("Unexpected number of host headers detected %d. Expected 1", hostCount)
 	}
 	if xxCount != 2 {
 		t.Fatalf("Unexpected number of xx headers detected %d. Expected 2", xxCount)
@@ -1400,7 +1400,7 @@ func TestResponseHeaderVisitAllInOrder(t *testing.T) {
 	r := bytes.NewBufferString("GET / HTTP/1.1\r\nContent-Type: aa\r\nCookie: a=b\r\nHost: example.com\r\nUser-Agent: xxx\r\n\r\n")
 	br := bufio.NewReader(r)
 	if err := h.Read(br); err != nil {
-		t.Fatalf("Unepxected error: %s", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 
 	if h.Len() != 4 {

--- a/reuseport/reuseport_test.go
+++ b/reuseport/reuseport_test.go
@@ -109,7 +109,7 @@ func serveEcho(t *testing.T, ln net.Listener) {
 		}
 		req, err := ioutil.ReadAll(c)
 		if err != nil {
-			t.Fatalf("unepxected error when reading request: %s", err)
+			t.Fatalf("unexpected error when reading request: %s", err)
 		}
 		if _, err = c.Write(req); err != nil {
 			t.Fatalf("unexpected error when writing response: %s", err)

--- a/server.go
+++ b/server.go
@@ -22,7 +22,7 @@ var errNoCertOrKeyProvided = errors.New("cert or key has not provided")
 var (
 	// ErrAlreadyServing is returned when calling Serve on a Server
 	// that is already serving connections.
-	ErrAlreadyServing = errors.New("server is already serving connections")
+	ErrAlreadyServing = errors.New("Server is already serving connections")
 )
 
 // ServeConn serves HTTP requests from the given connection

--- a/server.go
+++ b/server.go
@@ -17,12 +17,12 @@ import (
 	"time"
 )
 
-var errNoCertOrKeyProvided = errors.New("Cert or key has not provided")
+var errNoCertOrKeyProvided = errors.New("cert or key has not provided")
 
 var (
 	// ErrAlreadyServing is returned when calling Serve on a Server
 	// that is already serving connections.
-	ErrAlreadyServing = errors.New("Server is already serving connections")
+	ErrAlreadyServing = errors.New("server is already serving connections")
 )
 
 // ServeConn serves HTTP requests from the given connection

--- a/stackless/writer_test.go
+++ b/stackless/writer_test.go
@@ -65,7 +65,7 @@ func testWriter(newWriter NewWriterFunc, newReader func(io.Reader) io.Reader) er
 
 	for i := 0; i < 5; i++ {
 		if err := testWriterReuse(w, dstW, newReader); err != nil {
-			return fmt.Errorf("unepxected error when re-using writer on iteration %d: %s", i, err)
+			return fmt.Errorf("unexpected error when re-using writer on iteration %d: %s", i, err)
 		}
 		dstW = &bytes.Buffer{}
 		w.Reset(dstW)


### PR DESCRIPTION
Format errors and fix some typos, according to https://github.com/golang/go/wiki/CodeReviewComments#error-strings