### PR TITLE
Requests with incomplete bodies no longer cause log noise

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -3147,7 +3147,7 @@ func TestMaxWriteTimeoutPerRequest(t *testing.T) {
 	}
 }
 
-func TestIncompleteBody(t *testing.T) {
+func TestIncompleteBodyReturnsUnexpectedEOF(t *testing.T) {
 	rw := &readWriter{}
 	rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: google.com\r\nContent-Length: 5\r\n\r\n123")
 	s := &Server{
@@ -3159,7 +3159,7 @@ func TestIncompleteBody(t *testing.T) {
 	}()
 	select {
 	case err := <-ch:
-		if err != nil {
+		if err.Error() != "unexpected EOF" {
 			t.Fatal(err)
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -3159,7 +3159,7 @@ func TestIncompleteBodyReturnsUnexpectedEOF(t *testing.T) {
 	}()
 	select {
 	case err := <-ch:
-		if err.Error() != "unexpected EOF" {
+		if err == nil || err.Error() != "unexpected EOF" {
 			t.Fatal(err)
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -3147,6 +3147,24 @@ func TestMaxWriteTimeoutPerRequest(t *testing.T) {
 	}
 }
 
+func TestIncompleteBody(t *testing.T) {
+	rw := &readWriter{}
+	rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: google.com\r\nContent-Length: 5\r\n\r\n123")
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {},
+	}
+	ch := make(chan error)
+	go func() {
+		ch <- s.ServeConn(rw)
+	}()
+	select {
+	case err := <-ch:
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func verifyResponse(t *testing.T, r *bufio.Reader, expectedStatusCode int, expectedContentType, expectedBody string) {
 	var resp Response
 	if err := resp.Read(r); err != nil {

--- a/workerpool.go
+++ b/workerpool.go
@@ -214,6 +214,7 @@ func (wp *workerPool) workerFunc(ch *workerChan) {
 			if wp.LogAllErrors || !(strings.Contains(errStr, "broken pipe") ||
 				strings.Contains(errStr, "reset by peer") ||
 				strings.Contains(errStr, "request headers: small read buffer") ||
+				strings.Contains(errStr, "unexpected EOF") ||
 				strings.Contains(errStr, "i/o timeout")) {
 				wp.Logger.Printf("error when serving connection %q<->%q: %s", c.LocalAddr(), c.RemoteAddr(), err)
 			}


### PR DESCRIPTION
**Steps to Reproduce**

1. Run [hello world example](https://github.com/valyala/fasthttp/blob/master/examples/helloworldserver/helloworldserver.go) 
2. Send request with timeout where the value of the `content-length` request header exceeds length of the request body.
```
curl 'http://localhost:8080/' -X "POST" -H 'content-length: 5' -d "123" --max-time 1
```

**Actual Behavior:**

- Server logs unexpected EOF.

```
2019/10/26 18:11:57 error when serving connection "127.0.0.1:8080"<->"127.0.0.1:58492": unexpected EOF
```

**Expected Behavior:**

- Server logs no error (matching behavior of net/http).

---

See #660  