### PR TITLE
Don't start a goroutine when not needed

### DIFF
--- a/server.go
+++ b/server.go
@@ -2460,6 +2460,8 @@ func (s *Server) writeFastError(w io.Writer, statusCode int, msg string) {
 		server = fmt.Sprintf("Server: %s\r\n", s.getServerName())
 	}
 
+	serverDateOnce.Do(updateServerDate)
+
 	fmt.Fprintf(w, "Connection: close\r\n"+
 		server+
 		"Date: %s\r\n"+


### PR DESCRIPTION
sync.Once only has the overhead of a single atomic.LoadUint32

Fixes #693