### PR TITLE
Custom LookupIPAddr function

### DIFF
--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -443,10 +443,9 @@ func resolveTCPAddrs(addr string, dualStack bool, resolver Resolver) ([]net.TCPA
 	if resolver == nil {
 		resolver = net.DefaultResolver
 	}
-
-	var ipaddrs []net.IPAddr
+	
 	ctx := context.Background()
-	ipaddrs, err = resolver.LookupIPAddr(ctx, host)
+	ipaddrs, err := resolver.LookupIPAddr(ctx, host)
 	if err != nil {
 		return nil, err
 	}

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -144,7 +144,7 @@ type TCPDialer struct {
 	// 	},
 	// }
 	Resolver *net.Resolver
-	// This function may be used to implement your own logic for name resolution
+	// LookupIPAddr may be used to implement your own logic for name resolution
 	// (e.g., doing DNS request separately and reusing its result here).
 	// By default if this function is not defined, the resolver above is used.
 	LookupIPAddr LookupIPAddrFunc


### PR DESCRIPTION
Continuing the work started at https://github.com/valyala/fasthttp/pull/689/files . 

Turns out, specifying custom resolver doesn't allow to avoid resolving completely (as `Dial()` has to return a connection to a DNS server), so in this way it becomes possible to reimplement `LookupIPAddr()` function to specify resolved name manually or get it from some place other than actual DNS query.