### PR TITLE
Allow a body for GET requests

### DIFF
--- a/header_regression_test.go
+++ b/header_regression_test.go
@@ -81,11 +81,7 @@ func issue6VerifyRequestHeader(t *testing.T, h *RequestHeader, contentType strin
 	if string(h.Method()) != method {
 		t.Fatalf("unexpected method: %q. Expecting %q", h.Method(), method)
 	}
-	if method != MethodGet {
-		if h.ContentLength() != contentLength {
-			t.Fatalf("unexpected content-length: %d. Expecting %d. method=%q", h.ContentLength(), contentLength, method)
-		}
-	} else if h.ContentLength() != 0 {
-		t.Fatalf("unexpected content-length for GET method: %d. Expecting 0", h.ContentLength())
+	if h.ContentLength() != contentLength {
+		t.Fatalf("unexpected content-length: %d. Expecting %d. method=%q", h.ContentLength(), contentLength, method)
 	}
 }

--- a/http.go
+++ b/http.go
@@ -1184,11 +1184,12 @@ func (req *Request) Write(w *bufio.Writer) error {
 		req.Header.SetMultipartFormBoundary(req.multipartFormBoundary)
 	}
 
-	hasBody := !req.Header.ignoreBody()
-	if hasBody {
-		if len(body) == 0 {
-			body = req.postArgs.QueryString()
-		}
+	hasBody := false
+	if len(body) == 0 {
+		body = req.postArgs.QueryString()
+	}
+	if len(body) != 0 || !req.Header.ignoreBody() {
+		hasBody = true
 		req.Header.SetContentLength(len(body))
 	}
 	if err = req.Header.Write(w); err != nil {

--- a/http_test.go
+++ b/http_test.go
@@ -1534,6 +1534,9 @@ func TestRequestSuccess(t *testing.T) {
 
 	// only host is set
 	testRequestSuccess(t, "", "", "gooble.com", "", "", MethodGet)
+
+	// get with body
+	testRequestSuccess(t, MethodGet, "/foo/bar", "aaa.com", "", "foobar", MethodGet)
 }
 
 func TestResponseSuccess(t *testing.T) {
@@ -1605,9 +1608,6 @@ func TestRequestWriteError(t *testing.T) {
 
 	// no host
 	testRequestWriteError(t, "", "/foo/bar", "", "", "")
-
-	// get with body
-	testRequestWriteError(t, MethodGet, "/foo/bar", "aaa.com", "", "foobar")
 }
 
 func testRequestWriteError(t *testing.T, method, requestURI, host, userAgent, body string) {

--- a/server.go
+++ b/server.go
@@ -1982,7 +1982,7 @@ func (s *Server) serveConn(c net.Conn) error {
 
 		// 'Expect: 100-continue' request handling.
 		// See http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html for details.
-		if !ctx.Request.Header.ignoreBody() && ctx.Request.MayContinue() {
+		if ctx.Request.MayContinue() {
 			// Send 'HTTP/1.1 100 Continue' response.
 			if bw == nil {
 				bw = acquireWriter(ctx)

--- a/server_test.go
+++ b/server_test.go
@@ -73,11 +73,8 @@ func TestServerInvalidHeader(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	// Since we delay header parsing for GET and HEAD requests until the users asks for it
-	// we can't return 400 in case of a bad header.
-	// Inside the handler above we make sure to test that the invalid Foo header was ignored.
-	if resp.StatusCode() != StatusOK {
-		t.Fatalf("unexpected status code: %d. Expecting %d", resp.StatusCode(), StatusOK)
+	if resp.StatusCode() != StatusBadRequest {
+		t.Fatalf("unexpected status code: %d. Expecting %d", resp.StatusCode(), StatusBadRequest)
 	}
 
 	if err := c.Close(); err != nil {


### PR DESCRIPTION
This means we can't skip parsing headers for GET requests anymore. This
can be seen as good as it also allows us to reject malformed GET
requests, something we didn't do before this. Performance also isn't
affect much:
```
benchmark                                            old ns/op     new ns/op     delta
BenchmarkClientGetEndToEnd1Inmemory-16               640           641           +0.16%
BenchmarkClientGetEndToEnd10Inmemory-16              713           710           -0.42%
BenchmarkClientGetEndToEnd100Inmemory-16             732           749           +2.32%
BenchmarkClientGetEndToEnd1000Inmemory-16            759           774           +1.98%
BenchmarkClientGetEndToEnd10KInmemory-16             785           808           +2.93%
BenchmarkNetHTTPClientGetEndToEnd1Inmemory-16        5045          4954          -1.80%
BenchmarkNetHTTPClientGetEndToEnd10Inmemory-16       5806          6225          +7.22%
BenchmarkNetHTTPClientGetEndToEnd100Inmemory-16      7877          7998          +1.54%
BenchmarkNetHTTPClientGetEndToEnd1000Inmemory-16     16603         16559         -0.27%
```

Fixes https://github.com/valyala/fasthttp/issues/670