### PR TITLE
Optimized some logic when illegal request method.

### DIFF
--- a/header.go
+++ b/header.go
@@ -1722,7 +1722,10 @@ func (h *RequestHeader) parseFirstLine(buf []byte) (int, error) {
 	n := bytes.IndexByte(b, ' ')
 	if n <= 0 {
 		return 0, fmt.Errorf("cannot find http request method in %q", buf)
+	} else if n > MaxLengthMethod {
+		return 0, fmt.Errorf("get http request invalid method in %q", buf)
 	}
+
 	h.method = append(h.method[:0], b[:n]...)
 	b = b[n+1:]
 

--- a/header_test.go
+++ b/header_test.go
@@ -2403,6 +2403,20 @@ func TestRequestHeaderReadError(t *testing.T) {
 	testRequestHeaderReadError(t, h, "POST /a HTTP/1.1\r\nHost: bb\r\nContent-Type: aa\r\nContent-Length: dff\r\n\r\nqwerty")
 }
 
+func TestRequestHeaderInvalidMethodFromString(t *testing.T) {
+	t.Parallel()
+
+	s := "XXXXXXXX / HTTP/1.1\r\n" +
+		"Host: foobar\r\n" +
+		"\r\n"
+	var h RequestHeader
+	want := "get http request invalid method in"
+	br := bufio.NewReader(bytes.NewBufferString(s))
+	if err := h.Read(br); err != nil && !strings.Contains(err.Error(), want) {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
 func testResponseHeaderReadError(t *testing.T, h *ResponseHeader, headers string) {
 	r := bytes.NewBufferString(headers)
 	br := bufio.NewReader(r)

--- a/methods.go
+++ b/methods.go
@@ -12,3 +12,6 @@ const (
 	MethodOptions = "OPTIONS" // RFC 7231, 4.3.7
 	MethodTrace   = "TRACE"   // RFC 7231, 4.3.8
 )
+
+// HTTP max length of methods, len(MethodConnect) == 7.
+const MaxLengthMethod = 7


### PR DESCRIPTION
In `RequestHeader.parseFirstLin` when the parsed method can be terminated early for illegal length.