### PR TITLE
Forward context in fasthttpadaptor

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -82,7 +82,7 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 		r.URL = rURL
 
 		var w netHTTPResponseWriter
-		h.ServeHTTP(&w, &r)
+		h.ServeHTTP(&w, r.WithContext(ctx))
 
 		ctx.SetStatusCode(w.StatusCode())
 		for k, vv := range w.Header() {

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -135,7 +135,7 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	}
 }
 
-func setContextValueMiddleware(next fasthttp.RequestHandler, key string, value interface{}) fasthttp.RequestHandler{
+func setContextValueMiddleware(next fasthttp.RequestHandler, key string, value interface{}) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		ctx.SetUserValue(key, value)
 		next(ctx)


### PR DESCRIPTION
Right now the request in fasthttpadaptor has a background context. It would be beneficial to set it to `fasthttp.RequestCtx` or at least forward values that are already set in the context. This would allow us to retrieve any value that was set in middleware before the request reached the `http.Handler`.