### PR TITLE
Make the prefork mode more robust

### DIFF
--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -1,6 +1,7 @@
 package prefork
 
 import (
+	"errors"
 	"flag"
 	"log"
 	"net"
@@ -176,6 +177,7 @@ func (p *Prefork) prefork(addr string) (err error) {
 				log.Printf("child prefork processes exit too many times, "+
 					"which exceeds the value of RecoverThreshold(%d), "+
 					"exiting the master process.\n", brokenProcs)
+				err = errors.New("exceeding the value of RecoverThreshold")
 				break
 			}
 

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -134,8 +134,8 @@ func (p *Prefork) prefork(addr string) (err error) {
 	childProcs := make(map[int]*exec.Cmd)
 
 	defer func() {
-		for _, cmd := range childProcs {
-			_ = cmd.Process.Kill()
+		for _, proc := range childProcs {
+			_ = proc.Process.Kill()
 		}
 	}()
 
@@ -146,9 +146,6 @@ func (p *Prefork) prefork(addr string) (err error) {
 		cmd.Stderr = os.Stderr
 		cmd.ExtraFiles = p.files
 		if err = cmd.Start(); err != nil {
-			for _, proc := range childProcs {
-				_ = proc.Process.Kill()
-			}
 			log.Printf("failed to start a child prefork process, error: %v\n", err)
 			return
 		}
@@ -166,6 +163,7 @@ func (p *Prefork) prefork(addr string) (err error) {
 
 			log.Printf("one of the child prefork processes failed to complete, "+
 				"error: %v", sig.err)
+			
 			/* #nosec G204 */
 			cmd := exec.Command(os.Args[0], append(os.Args[1:], preforkChildFlag)...)
 			cmd.Stdout = os.Stdout

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -222,6 +222,7 @@ func (p *Prefork) prefork(addr string) (err error) {
 			}()
 		} else {
 			if completeProcs++; completeProcs == goMaxProcs {
+				p.logger().Printf("all child prefork processes exit, master process exiting")
 				break
 			}
 		}


### PR DESCRIPTION
The main process will exit if one of the prefork child processes doesn't complete successfully under the current prefork mode, so it ought to make sure that all child processes run independently and the main process will only exit after all child processes are finished.