### PR TITLE
Fixed case when no hijacker is added but no-response is true

### DIFF
--- a/server.go
+++ b/server.go
@@ -2087,7 +2087,7 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 
 		hijackHandler = ctx.hijackHandler
 		ctx.hijackHandler = nil
-		hijackNoResponse = ctx.hijackNoResponse
+		hijackNoResponse = ctx.hijackNoResponse && hijackHandler != nil
 		ctx.hijackNoResponse = false
 
 		ctx.userValues.Reset()


### PR DESCRIPTION
Hello,

It can be the case when the hijackerHandler is not set but hijackNoResponse is. If that case happens before this commit the server won't send any response to the client and then the connection will hang (client will be waiting, the server will be waiting too).

Thanks.