### PR TITLE
Backwards incompatible! HostClient can't switch between protocols

### DIFF
--- a/http.go
+++ b/http.go
@@ -46,10 +46,9 @@ type Request struct {
 
 	keepBodyBuffer bool
 
+	// Used by Server to indicate the request was received on a HTTPS endpoint.
+	// Client/HostClient shouldn't use this field but should depend on the uri.scheme instead.
 	isTLS bool
-
-	// To detect scheme changes in redirects
-	schemaUpdate bool
 
 	// Request timeout. Usually set by DoDealine or DoTimeout
 	// if <= 0, means not set


### PR DESCRIPTION
`HostClient` connects to its host though either HTTP or HTTPS. It should never switch between protocols. This breaks the `HostClient` maps inside `Client`. There are two maps there:
`m` is for http HostClients
`ms` is for https HostClients
Updating a http `HostClient` to https, while it is still inside map m will make all future requests to the given http host go to https. Since servers can serve different content on both ports this can break things.

Thats why from now on `HostClient` will throw and error when it is used outside `Client` and tries to follow a redirect to a different protocol.