### PR TITLE
fix: adaptor content type

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -82,6 +82,7 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 		r.URL = rURL
 
 		var w netHTTPResponseWriter
+		w.Header().Set(fasthttp.HeaderContentType, "text/html")
 		h.ServeHTTP(&w, r.WithContext(ctx))
 
 		ctx.SetStatusCode(w.StatusCode())


### PR DESCRIPTION
In case of needs to create router for swagger adaptor from repository doesn't work because it always returns
`Content-Type: text/plain`