### PR TITLE
 improve statusLine and StatusMessage by using slice instead of map

### DIFF
--- a/status.go
+++ b/status.go
@@ -169,6 +169,7 @@ func StatusMessage(statusCode int) string {
 func init() {
 	invalidStatusLines.Store(make(map[int][]byte))
 
+	// Fill all valid status lines
 	for i := 0; i < len(statusLines); i++ {
 		statusLines[i] = []byte(fmt.Sprintf("HTTP/1.1 %d %s\r\n", i, StatusMessage(i)))
 	}

--- a/status.go
+++ b/status.go
@@ -179,9 +179,6 @@ func statusLine(statusCode int) []byte {
 	return statusLines[statusCode]
 }
 
-// invalidStatusLine return status line of which
-// smaller than 0 or
-// bigger than statusMessageMax(511)
 func invalidStatusLine(statusCode int) []byte {
 	statusText := StatusMessage(statusCode)
 	return []byte(fmt.Sprintf("HTTP/1.1 %d %s\r\n", statusCode, statusText))

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,24 @@
+package fasthttp
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStatusLine(t *testing.T) {
+	t.Parallel()
+
+	testStatusLine(t, -1, []byte("HTTP/1.1 -1 Unknown Status Code\r\n"))
+	testStatusLine(t, 99, []byte("HTTP/1.1 99 Unknown Status Code\r\n"))
+	testStatusLine(t, 200, []byte("HTTP/1.1 200 OK\r\n"))
+	testStatusLine(t, 512, []byte("HTTP/1.1 512 Unknown Status Code\r\n"))
+	testStatusLine(t, 512, []byte("HTTP/1.1 512 Unknown Status Code\r\n"))
+	testStatusLine(t, 520, []byte("HTTP/1.1 520 Unknown Status Code\r\n"))
+}
+
+func testStatusLine(t *testing.T, statusCode int, expected []byte) {
+	line := statusLine(statusCode)
+	if !bytes.Equal(expected, line) {
+		t.Fatalf("unexpected status line %s. Expecting %s", string(line), string(expected))
+	}
+}

--- a/status_timing_test.go
+++ b/status_timing_test.go
@@ -1,0 +1,29 @@
+package fasthttp
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkStatusLine99(b *testing.B) {
+	benchmarkStatusLine(b, 99, []byte("HTTP/1.1 99 Unknown Status Code\r\n"))
+}
+
+func BenchmarkStatusLine200(b *testing.B) {
+	benchmarkStatusLine(b, 200, []byte("HTTP/1.1 200 OK\r\n"))
+}
+
+func BenchmarkStatusLine512(b *testing.B) {
+	benchmarkStatusLine(b, 512, []byte("HTTP/1.1 512 Unknown Status Code\r\n"))
+}
+
+func benchmarkStatusLine(b *testing.B, statusCode int, expected []byte) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			line := statusLine(statusCode)
+			if !bytes.Equal(expected, line) {
+				b.Fatalf("unexpected status line %s. Expecting %s", string(line), string(expected))
+			}
+		}
+	})
+}


### PR DESCRIPTION
We use slice instead of map to store all status messages and status lines. But for the status code bigger than `statusMessageMax(511)`, it still should store them in the dynamic map(`invalidStatusLines`).

@erikdubbelboer PTAL

benchmarks result:
OLD:
```
BenchmarkStatusLine99
BenchmarkStatusLine99-8         278959663                4.51 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine99-8         262258332                4.83 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine99-8         257144448                4.73 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine99-8         251641419                4.80 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine200
BenchmarkStatusLine200-8        257207306                4.64 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine200-8        257618150                4.71 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine200-8        251996420                4.75 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine200-8        252930247                4.79 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine512
BenchmarkStatusLine512-8        222729294                5.49 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine512-8        218682082                5.43 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine512-8        218821902                5.48 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine512-8        219236438                5.62 ns/op            0 B/op          0 allocs/op
```
NEW:
```
BenchmarkStatusLine99
BenchmarkStatusLine99-8         545864635                2.22 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine99-8         517671476                2.33 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine99-8         505288328                2.31 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine99-8         505923718                2.36 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine200
BenchmarkStatusLine200-8        534919548                2.20 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine200-8        538629565                2.25 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine200-8        523182661                2.30 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine200-8        515232004                2.27 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine512
BenchmarkStatusLine512-8        223080207                5.42 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine512-8        222268503                5.39 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine512-8        216794157                5.47 ns/op            0 B/op          0 allocs/op
BenchmarkStatusLine512-8        216436990                5.57 ns/op            0 B/op          0 allocs/op
```


Co-authored-by: Fenny <fenny@gofiber.io>
Co-authored-by: ReneWerner87 <rene@gofiber.io>