### PR TITLE
Check lbClient is under penalty

### DIFF
--- a/lbclient.go
+++ b/lbclient.go
@@ -125,6 +125,9 @@ func (cc *LBClient) get() *lbClient {
 		minN := minC.PendingRequests()
 		minT := atomic.LoadUint64(&minC.total)
 		for _, c := range cs[off:] {
+			if c.underPenalty() {
+				continue
+			}
 			n := c.PendingRequests()
 			t := atomic.LoadUint64(&c.total)
 			if n < minN || (n == minN && t < minT) {


### PR DESCRIPTION
We have experienced with a trouble with LBClient. We have a lot of destination hosts and some of them is under deploy/maintenance sometimes and are inaccessible. We noticed that inaccessible servers receives most of the requests due to LBClient thinks they are so fast in comparison nodes (in fact they answers with error code quickly).
The problem is here https://github.com/valyala/fasthttp/blob/master/lbclient.go#L138
, since pending request is zero and penalty counter can be maximum 300, therefore LBClient.get() method decides that inaccessible node is less busy.
This PR just ignores nodes that still are under penalty.