### PR TITLE
remove unnecessary type conversion

### DIFF
--- a/http.go
+++ b/http.go
@@ -477,7 +477,8 @@ func (resp *Response) BodyWriteTo(w io.Writer) error {
 //
 // It is safe re-using p after the function returns.
 func (resp *Response) AppendBody(p []byte) {
-	resp.AppendBodyString(b2s(p))
+	resp.closeBodyStream()     //nolint:errcheck
+	resp.bodyBuffer().Write(p) //nolint:errcheck
 }
 
 // AppendBodyString appends s to response body.
@@ -490,7 +491,10 @@ func (resp *Response) AppendBodyString(s string) {
 //
 // It is safe re-using body argument after the function returns.
 func (resp *Response) SetBody(body []byte) {
-	resp.SetBodyString(b2s(body))
+	resp.closeBodyStream() //nolint:errcheck
+	bodyBuf := resp.bodyBuffer()
+	bodyBuf.Reset()
+	bodyBuf.Write(body) //nolint:errcheck
 }
 
 // SetBodyString sets response body.
@@ -626,7 +630,9 @@ func (req *Request) Body() []byte {
 //
 // It is safe re-using p after the function returns.
 func (req *Request) AppendBody(p []byte) {
-	req.AppendBodyString(b2s(p))
+	req.RemoveMultipartFormFiles()
+	req.closeBodyStream()     //nolint:errcheck
+	req.bodyBuffer().Write(p) //nolint:errcheck
 }
 
 // AppendBodyString appends s to request body.
@@ -640,7 +646,9 @@ func (req *Request) AppendBodyString(s string) {
 //
 // It is safe re-using body argument after the function returns.
 func (req *Request) SetBody(body []byte) {
-	req.SetBodyString(b2s(body))
+	req.RemoveMultipartFormFiles()
+	req.closeBodyStream() //nolint:errcheck
+	req.bodyBuffer().Set(body)
 }
 
 // SetBodyString sets request body.


### PR DESCRIPTION
I know doing this causes some kind of code duplication but I was writing `[]byte` directly into the response and converting`[]byte` to `string` and again `string` to `[]byte` caused a little process and delay for my large data. And I think reusing a code just adds inconvenience in this case.