### PR TITLE
add nil check for LocalAddr

### DIFF
--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -327,7 +327,11 @@ func (d *TCPDialer) tryDial(network string, addr *net.TCPAddr, deadline time.Tim
 		defer func() { <-concurrencyCh }()
 	}
 
-	dialer := net.Dialer{LocalAddr: d.LocalAddr}
+	dialer := net.Dialer{}
+	if d.LocalAddr != nil {
+		dialer = net.Dialer{LocalAddr: d.LocalAddr}
+	}
+
 	ctx, cancel_ctx := context.WithDeadline(context.Background(), deadline)
 	defer cancel_ctx()
 	conn, err := dialer.DialContext(ctx, network, addr.String())


### PR DESCRIPTION
Add nil check for `TCPDialer`'s LocalAddr. The PR will improve the error message for dial failure when LocalAddr is not set.

```
# error message before
err: dial tcp4 <nil>->127.0.0.1:8080: connect: connection refused

# error message after
err: dial tcp4 127.0.0.1:8080: connect: connection refused
```
