### PR TITLE
Improve round2 performance

### DIFF
--- a/http.go
+++ b/http.go
@@ -1956,11 +1956,13 @@ func round2(n int) int {
 	if n <= 0 {
 		return 0
 	}
-	n--
-	x := uint(0)
-	for n > 0 {
-		n >>= 1
-		x++
-	}
-	return 1 << x
+
+	x := uint32(n - 1)
+	x |= x >> 1
+	x |= x >> 2
+	x |= x >> 4
+	x |= x >> 8
+	x |= x >> 16
+
+	return int(x + 1)
 }


### PR DESCRIPTION
I think `uint32` is enough(4GB) for current situation.

And here is the benchmark result:

Test case
```go
func BenchmarkRound2(b *testing.B) {
	b.RunParallel(func(pb *testing.PB) {
		b.ReportAllocs()
		b.ResetTimer()
		for pb.Next() {
			round2(0x10001)
		}
	})
}
```

OLD:
```hs
BenchmarkRound2-16      1000000000               0.875 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.880 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.874 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.876 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.874 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.877 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.873 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.878 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.888 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.904 ns/op           0 B/op          0 allocs/op
```

NEW:
```hs
BenchmarkRound2-16      1000000000               0.156 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.157 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.155 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.156 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.149 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.156 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.156 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.154 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.156 ns/op           0 B/op          0 allocs/op
BenchmarkRound2-16      1000000000               0.152 ns/op           0 B/op          0 allocs/op
```

benchstat:
```hs
name       old time/op    new time/op    delta
Round2-16    0.88ns ± 1%    0.16ns ± 2%  -82.29%  (p=0.000 n=9+9)

name       old alloc/op   new alloc/op   delta
Round2-16     0.00B          0.00B          ~     (all equal)

name       old allocs/op  new allocs/op  delta
Round2-16      0.00           0.00          ~     (all equal)
```
