### PR TITLE
Fixing deletion of headers/queryargs having multiple values.

### DIFF
--- a/args.go
+++ b/args.go
@@ -391,6 +391,7 @@ func delAllArgs(args []argsKV, key string) []argsKV {
 			tmp := *kv
 			copy(args[i:], args[i+1:])
 			n--
+			i--
 			args[n] = tmp
 			args = args[:n]
 		}

--- a/args_test.go
+++ b/args_test.go
@@ -583,3 +583,17 @@ func testArgsParse(t *testing.T, a *Args, s string, expectedLen int, expectedArg
 		}
 	}
 }
+
+func TestArgsDeleteAll(t *testing.T) {
+	t.Parallel()
+	var a Args
+	a.Add("q1", "foo")
+	a.Add("q1", "bar")
+	a.Add("q1", "baz")
+	a.Add("q1", "quux")
+	a.Add("q2", "1234")
+	a.Del("q1")
+	if a.Len() != 1 || a.Has("q1") {
+		t.Fatalf("Expected q1 arg to be completely deleted. Current Args: %s", a.String())
+	}
+}


### PR DESCRIPTION
In a HTTP Request Headers/QueryArgs can have multiple values for the same key. Currently [delAllArgs](https://github.com/valyala/fasthttp/blob/master/args.go#L387-L399) doesn't delete all the headers/queryargs with the same key. This change fixes it by setting the index `i` to be checked next for deletion, correctly.

I have extracted relevant parts of code in [playground](https://play.golang.org/p/JmE2-Y8vz2k) to show the before and after changes.