### PR TITLE
Use QueryString while constructing RequestURI instead of QueryArgs if parsedQueryArgs is set to false

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -406,7 +406,7 @@ func (u *URI) RequestURI() []byte {
 	} else {
 		dst = appendQuotedPath(u.requestURI[:0], u.Path())
 	}
-	if u.queryArgs.Len() > 0 {
+	if u.parsedQueryArgs && u.queryArgs.Len() > 0 {
 		dst = append(dst, '?')
 		dst = u.queryArgs.AppendBytes(dst)
 	} else if len(u.queryString) > 0 {

--- a/uri_test.go
+++ b/uri_test.go
@@ -386,3 +386,15 @@ func testURIParse(t *testing.T, u *URI, host, uri,
 		t.Fatalf("Unexpected hash %q. Expected %q. host=%q, uri=%q", u.Hash(), expectedHash, host, uri)
 	}
 }
+
+func TestURIWithQuerystringOverride(t *testing.T) {
+	var u URI
+	u.SetQueryString("q1=foo&q2=bar")
+	u.QueryArgs().Add("q3", "baz")
+	u.SetQueryString("q1=foo&q2=bar&q4=quux")
+	uriString := string(u.RequestURI())
+
+	if uriString != "/?q1=foo&q2=bar&q4=quux" {
+		t.Fatalf("Expected Querystring to be overriden but was %s ", uriString)
+	}
+}


### PR DESCRIPTION
https://github.com/valyala/fasthttp/issues/919