### PR TITLE
Worker pool should exit immidiatly while sleeping

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -57,13 +57,15 @@ func (wp *workerPool) Start() {
 	}
 	go func() {
 		var scratch []*workerChan
+
+		sleep := time.NewTicker(wp.getMaxIdleWorkerDuration())
 		for {
 			wp.clean(&scratch)
 			select {
 			case <-stopCh:
+				sleep.Stop()
 				return
-			default:
-				time.Sleep(wp.getMaxIdleWorkerDuration())
+			case <-sleep.C:
 			}
 		}
 	}()


### PR DESCRIPTION
I have some tests with [goleak](https://github.com/uber-go/goleak) tool. From time to time It complains on workerpool goroutine. This PR fixes the issue.