### PR TITLE
fix s2b go vet warning

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -343,7 +343,7 @@ func s2b(s string) (b []byte) {
 	/* #nosec G103 */
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	/* #nosec G103 */
-	sh := *(*reflect.StringHeader)(unsafe.Pointer(&s))
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	bh.Data = sh.Data
 	bh.Len = sh.Len
 	bh.Cap = sh.Len


### PR DESCRIPTION
The `go vet` will complain about `sh := *(*reflect.StringHeader)(unsafe.Pointer(&s))` (possible misuse of reflect.StringHeader). The extra `*` is added because it generate less code compared to `sh := (*reflect.StringHeader)(unsafe.Pointer(&s))`, see details in https://godbolt.org/z/xG3hbn   

They are actually do the same thing for now(almost same speed, previous implementation 1 CPU tick faster maybe), but if `go vet` complain about this, i think we can remove the extra `*` to prevent later Go release has inconsistent behavior(escape analysis etc).