### PR TITLE
Improve Client/HostClient pooling when many HostClient structs created and removed during program execution

### DIFF
--- a/client.go
+++ b/client.go
@@ -293,6 +293,8 @@ type Client struct {
 	//
 	// By default will use isIdempotent function
 	RetryIf RetryIfFunc
+	
+	CheckRedirect func(*fasthttp.Request, *fasthttp.Response) error
 
 	mLock sync.Mutex
 	m     map[string]*HostClient

--- a/client.go
+++ b/client.go
@@ -293,12 +293,12 @@ type Client struct {
 	//
 	// By default will use isIdempotent function
 	RetryIf RetryIfFunc
-	
-	CheckRedirect func(*fasthttp.Request, *fasthttp.Response) error
 
 	mLock sync.Mutex
 	m     map[string]*HostClient
 	ms    map[string]*HostClient
+	readerPool sync.Pool
+	writerPool sync.Pool
 }
 
 // Get returns the status code and body of url.
@@ -505,6 +505,8 @@ func (c *Client) Do(req *Request, resp *Response) error {
 			DisablePathNormalizing:        c.DisablePathNormalizing,
 			MaxConnWaitTimeout:            c.MaxConnWaitTimeout,
 			RetryIf:                       c.RetryIf,
+			clientReaderPool:              &c.readerPool,
+			clientWriterPool:              &c.writerPool,
 		}
 		m[string(host)] = hc
 		if len(m) == 1 {
@@ -752,6 +754,9 @@ type HostClient struct {
 
 	readerPool sync.Pool
 	writerPool sync.Pool
+
+	clientReaderPool *sync.Pool
+	clientWriterPool *sync.Pool
 
 	pendingRequests int32
 
@@ -1745,39 +1750,73 @@ func (c *HostClient) releaseConn(cc *clientConn) {
 }
 
 func (c *HostClient) acquireWriter(conn net.Conn) *bufio.Writer {
-	v := c.writerPool.Get()
-	if v == nil {
-		n := c.WriteBufferSize
-		if n <= 0 {
-			n = defaultWriteBufferSize
+	var v interface{}
+	if c.clientWriterPool != nil {
+		v = c.clientWriterPool.Get()
+		if v == nil {
+			n := c.WriteBufferSize
+			if n <= 0 {
+				n = defaultWriteBufferSize
+			}
+			return bufio.NewWriterSize(conn, n)
 		}
-		return bufio.NewWriterSize(conn, n)
+	} else {
+		v = c.writerPool.Get()
+		if v == nil {
+			n := c.WriteBufferSize
+			if n <= 0 {
+				n = defaultWriteBufferSize
+			}
+			return bufio.NewWriterSize(conn, n)
+		}
 	}
+
 	bw := v.(*bufio.Writer)
 	bw.Reset(conn)
 	return bw
 }
 
 func (c *HostClient) releaseWriter(bw *bufio.Writer) {
-	c.writerPool.Put(bw)
+	if c.clientWriterPool != nil {
+		c.clientWriterPool.Put(bw)
+	} else {
+		c.writerPool.Put(bw)
+	}
 }
 
 func (c *HostClient) acquireReader(conn net.Conn) *bufio.Reader {
-	v := c.readerPool.Get()
-	if v == nil {
-		n := c.ReadBufferSize
-		if n <= 0 {
-			n = defaultReadBufferSize
+	var v interface{}
+	if c.clientReaderPool != nil {
+		v = c.clientReaderPool.Get()
+		if v == nil {
+			n := c.ReadBufferSize
+			if n <= 0 {
+				n = defaultReadBufferSize
+			}
+			return bufio.NewReaderSize(conn, n)
 		}
-		return bufio.NewReaderSize(conn, n)
+	} else {
+		v = c.readerPool.Get()
+		if v == nil {
+			n := c.ReadBufferSize
+			if n <= 0 {
+				n = defaultReadBufferSize
+			}
+			return bufio.NewReaderSize(conn, n)
+		}
 	}
+
 	br := v.(*bufio.Reader)
 	br.Reset(conn)
 	return br
 }
 
 func (c *HostClient) releaseReader(br *bufio.Reader) {
-	c.readerPool.Put(br)
+	if c.clientReaderPool != nil {
+		c.clientReaderPool.Put(br)
+	} else {
+		c.readerPool.Put(br)
+	}
 }
 
 func newClientTLSConfig(c *tls.Config, addr string) *tls.Config {


### PR DESCRIPTION
@erikdubbelboer In case if #992 will be implemented, my fix almost (but may improve reusability of pools anyway, less number of objects inuse) won't needed, because of hostclients reused both with internal to HostClient pools, looking forward to one of our patches.