### PR TITLE
Adding support for securing error logs

### DIFF
--- a/client.go
+++ b/client.go
@@ -723,6 +723,14 @@ type HostClient struct {
 	// extra slashes are removed, special characters are encoded.
 	DisablePathNormalizing bool
 
+	// Will not log potentially sensitive content in error logs
+	//
+	// This option is useful for servers that handle sensitive data
+	// in the request/response.
+	//
+	// Client logs full errors by default.
+	SecureErrorLogMessage bool
+
 	// Maximum duration for waiting for a free connection.
 	//
 	// By default will not waiting, return ErrNoFreeConns immediately
@@ -1324,6 +1332,12 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 	if resp == nil {
 		panic("BUG: resp cannot be nil")
 	}
+
+	// Secure header error logs configuration
+	resp.secureErrorLogMessage = c.SecureErrorLogMessage
+	resp.Header.secureErrorLogMessage = c.SecureErrorLogMessage
+	req.secureErrorLogMessage = c.SecureErrorLogMessage
+	req.Header.secureErrorLogMessage = c.SecureErrorLogMessage
 
 	if c.IsTLS != bytes.Equal(req.uri.Scheme(), strHTTPS) {
 		return false, ErrHostClientRedirectToDifferentScheme

--- a/header_test.go
+++ b/header_test.go
@@ -2399,6 +2399,31 @@ func TestResponseHeaderReadError(t *testing.T) {
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n")
 }
 
+func TestResponseHeaderReadErrorSecureLog(t *testing.T) {
+	h := &ResponseHeader{
+		secureErrorLogMessage: true,
+	}
+
+	// incorrect first line
+	testResponseHeaderReadSecuredError(t, h, "fo")
+	testResponseHeaderReadSecuredError(t, h, "foobarbaz")
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1")
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 ")
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 s")
+
+	// non-numeric status code
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 foobar OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 123foobar OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 foobar344 OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
+
+
+	// no headers
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 200 OK\r\n")
+
+	// no trailing crlf
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n")
+}
+
 func TestRequestHeaderReadError(t *testing.T) {
 	t.Parallel()
 
@@ -2417,6 +2442,25 @@ func TestRequestHeaderReadError(t *testing.T) {
 	testRequestHeaderReadError(t, h, "POST /a HTTP/1.1\r\nHost: bb\r\nContent-Type: aa\r\nContent-Length: dff\r\n\r\nqwerty")
 }
 
+func TestRequestHeaderReadSecuredError(t *testing.T) {
+	t.Parallel()
+
+	h := &RequestHeader{
+		secureErrorLogMessage: true,
+	}
+
+	// incorrect first line
+	testRequestHeaderReadSecuredError(t, h, "fo")
+	testRequestHeaderReadSecuredError(t, h, "GET ")
+	testRequestHeaderReadSecuredError(t, h, "GET / HTTP/1.1\r")
+
+	// missing RequestURI
+	testRequestHeaderReadSecuredError(t, h, "GET  HTTP/1.1\r\nHost: google.com\r\n\r\n")
+
+	// post with invalid content-length
+	testRequestHeaderReadSecuredError(t, h, "POST /a HTTP/1.1\r\nHost: bb\r\nContent-Type: aa\r\nContent-Length: dff\r\n\r\nqwerty")
+}
+
 func testResponseHeaderReadError(t *testing.T, h *ResponseHeader, headers string) {
 	r := bytes.NewBufferString(headers)
 	br := bufio.NewReader(r)
@@ -2424,7 +2468,21 @@ func testResponseHeaderReadError(t *testing.T, h *ResponseHeader, headers string
 	if err == nil {
 		t.Fatalf("Expecting error when reading response header %q", headers)
 	}
+	// make sure response header works after error
+	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 200 OK\r\nContent-Type: foo/bar\r\nContent-Length: 12345\r\n\r\nsss",
+		200, 12345, "foo/bar", "sss")
+}
 
+func testResponseHeaderReadSecuredError(t *testing.T, h *ResponseHeader, headers string) {
+	r := bytes.NewBufferString(headers)
+	br := bufio.NewReader(r)
+	err := h.Read(br)
+	if err == nil {
+		t.Fatalf("Expecting error when reading response header %q", headers)
+	}
+	if strings.Contains(err.Error(), headers) {
+		t.Fatalf("Not expecting header content in err %q", err)
+	}
 	// make sure response header works after error
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 200 OK\r\nContent-Type: foo/bar\r\nContent-Length: 12345\r\n\r\nsss",
 		200, 12345, "foo/bar", "sss")
@@ -2438,6 +2496,21 @@ func testRequestHeaderReadError(t *testing.T, h *RequestHeader, headers string) 
 		t.Fatalf("Expecting error when reading request header %q", headers)
 	}
 
+	// make sure request header works after error
+	testRequestHeaderReadSuccess(t, h, "GET /foo/bar HTTP/1.1\r\nHost: aaaa\r\n\r\nxxx",
+		-2, "/foo/bar", "aaaa", "", "", "xxx")
+}
+
+func testRequestHeaderReadSecuredError(t *testing.T, h *RequestHeader, headers string) {
+	r := bytes.NewBufferString(headers)
+	br := bufio.NewReader(r)
+	err := h.Read(br)
+	if err == nil {
+		t.Fatalf("Expecting error when reading request header %q", headers)
+	}
+	if strings.Contains(err.Error(), headers) {
+		t.Fatalf("Not expecting header content in err %q", err)
+	}
 	// make sure request header works after error
 	testRequestHeaderReadSuccess(t, h, "GET /foo/bar HTTP/1.1\r\nHost: aaaa\r\n\r\nxxx",
 		-2, "/foo/bar", "aaaa", "", "", "xxx")

--- a/http.go
+++ b/http.go
@@ -41,6 +41,7 @@ type Request struct {
 
 	multipartForm         *multipart.Form
 	multipartFormBoundary string
+	secureErrorLogMessage        bool
 
 	// Group bool members in order to reduce Request object size.
 	parsedURI      bool
@@ -88,6 +89,7 @@ type Response struct {
 	SkipBody bool
 
 	keepBodyBuffer bool
+	secureErrorLogMessage bool
 
 	// Remote TCPAddr from concurrently net.Conn
 	raddr net.Addr
@@ -1368,6 +1370,9 @@ func (req *Request) Write(w *bufio.Writer) error {
 	if hasBody {
 		_, err = w.Write(body)
 	} else if len(body) > 0 {
+		if req.secureErrorLogMessage {
+			return fmt.Errorf("non-zero body for non-POST request")
+		}
 		return fmt.Errorf("non-zero body for non-POST request. body=%q", body)
 	}
 	return err

--- a/server.go
+++ b/server.go
@@ -312,6 +312,14 @@ type Server struct {
 	// are suppressed in order to limit output log traffic.
 	LogAllErrors bool
 
+	// Will not log potentially sensitive content in error logs
+	//
+	// This option is useful for servers that handle sensitive data
+	// in the request/response.
+	//
+	// Server logs all full errors by default.
+	SecureErrorLogMessage bool
+
 	// Header names are passed as-is without normalization
 	// if this option is set.
 	//
@@ -2054,6 +2062,12 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 		ctx.Request.isTLS = isTLS
 		ctx.Response.Header.noDefaultContentType = s.NoDefaultContentType
 		ctx.Response.Header.noDefaultDate = s.NoDefaultDate
+
+		// Secure header error logs configuration
+		ctx.Request.Header.secureErrorLogMessage = s.SecureErrorLogMessage
+		ctx.Response.Header.secureErrorLogMessage = s.SecureErrorLogMessage
+		ctx.Request.secureErrorLogMessage = s.SecureErrorLogMessage
+		ctx.Response.secureErrorLogMessage = s.SecureErrorLogMessage
 
 		if err == nil {
 			if s.ReadTimeout > 0 {


### PR DESCRIPTION
For some applications handling sensitive data, it can violate certain certifications, such as HIPAA, to log parts of requests and responses like the header and body.

This PR adds the option `SecureErrorLogMessage` which will replace the fully detailed error messages with more generic ones so that they can safely be logged.