### PR TITLE
Fix chunked streaming

### DIFF
--- a/http.go
+++ b/http.go
@@ -2072,25 +2072,35 @@ func parseChunkSize(r *bufio.Reader) (int, error) {
 		if c == ' ' {
 			continue
 		}
-		if c != '\r' {
+		if err := r.UnreadByte(); err != nil {
 			return -1, ErrBrokenChunk{
-				error: fmt.Errorf("unexpected char %q at the end of chunk size. Expected %q", c, '\r'),
+				error: fmt.Errorf("cannot unread '\r' char at the end of chunk size: %s", err),
 			}
 		}
 		break
 	}
-	c, err := r.ReadByte()
+	err = readCrLf(r)
 	if err != nil {
-		return -1, ErrBrokenChunk{
-			error: fmt.Errorf("cannot read '\n' char at the end of chunk size: %s", err),
-		}
-	}
-	if c != '\n' {
-		return -1, ErrBrokenChunk{
-			error: fmt.Errorf("unexpected char %q at the end of chunk size. Expected %q", c, '\n'),
-		}
+		return -1, err
 	}
 	return n, nil
+}
+
+func readCrLf(r *bufio.Reader) error {
+	for _, exp := range []byte{'\r', '\n'} {
+		c, err := r.ReadByte()
+		if err != nil {
+			return ErrBrokenChunk{
+				error: fmt.Errorf("cannot read %q char at the end of chunk size: %s", exp, err),
+			}
+		}
+		if c != exp {
+			return ErrBrokenChunk{
+				error: fmt.Errorf("unexpected char %q at the end of chunk size. Expected %q", c, exp),
+			}
+		}
+	}
+	return nil
 }
 
 func round2(n int) int {

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -101,7 +101,7 @@ aaaaaaaaaa`
 }
 
 func getChunkedTestEnv(t testing.TB) (*fasthttputil.InmemoryListener, []byte) {
-	body := createFixedBody(3)
+	body := createFixedBody(128 * 1024)
 	chunkedBody := createChunkedBody(body)
 
 	testHandler := func(ctx *RequestCtx) {


### PR DESCRIPTION
`io.Reader` interface provided by `requestStream` is broken for chunks exceeding `len(p)` which can lead to various panics in code using `Read()`.