### PR TITLE
Fix adaptor doesn't convert header values correctly

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -68,7 +68,7 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 			case "Transfer-Encoding":
 				r.TransferEncoding = append(r.TransferEncoding, sv)
 			default:
-				hdr.Set(sk, sv)
+				hdr.Add(sk, sv)
 			}
 		})
 		r.Header = hdr
@@ -92,7 +92,7 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 			}
 
 			for _, v := range vv {
-				ctx.Response.Header.Set(k, v)
+				ctx.Response.Header.Add(k, v)
 			}
 		}
 		if !haveContentType {


### PR DESCRIPTION
Fix(adaptor): Fixed an issue where the adapter did not convert all values of the header successfully when converting the header.

Change `Header.Set()` to `Header.Add()` to support header that has multiple values such as `Accept`

Relative reference: https://github.com/gofiber/fiber/issues/1329

