### PR TITLE
Fix ignoreBody still set content length

### DIFF
--- a/http.go
+++ b/http.go
@@ -41,7 +41,7 @@ type Request struct {
 
 	multipartForm         *multipart.Form
 	multipartFormBoundary string
-	secureErrorLogMessage        bool
+	secureErrorLogMessage bool
 
 	// Group bool members in order to reduce Request object size.
 	parsedURI      bool
@@ -88,7 +88,7 @@ type Response struct {
 	// Use it for writing HEAD responses.
 	SkipBody bool
 
-	keepBodyBuffer bool
+	keepBodyBuffer        bool
 	secureErrorLogMessage bool
 
 	// Remote TCPAddr from concurrently net.Conn
@@ -1111,7 +1111,10 @@ func (req *Request) ContinueReadBody(r *bufio.Reader, maxBodySize int, preParseM
 		// the end of body is determined by connection close.
 		// So just ignore request body for requests without
 		// 'Content-Length' and 'Transfer-Encoding' headers.
-		req.Header.SetContentLength(0)
+		// refer to https://tools.ietf.org/html/rfc7230#section-3.3.2
+		if !req.Header.IsGet() {
+			req.Header.SetContentLength(0)
+		}
 		return nil
 	}
 

--- a/http.go
+++ b/http.go
@@ -1112,7 +1112,7 @@ func (req *Request) ContinueReadBody(r *bufio.Reader, maxBodySize int, preParseM
 		// So just ignore request body for requests without
 		// 'Content-Length' and 'Transfer-Encoding' headers.
 		// refer to https://tools.ietf.org/html/rfc7230#section-3.3.2
-		if !req.Header.IsGet() {
+		if !req.Header.ignoreBody() {
 			req.Header.SetContentLength(0)
 		}
 		return nil

--- a/http_test.go
+++ b/http_test.go
@@ -741,6 +741,23 @@ func TestResponseReadEOF(t *testing.T) {
 	}
 }
 
+func TestRequestReadNoBody(t *testing.T) {
+	t.Parallel()
+
+	var r Request
+
+	br := bufio.NewReader(bytes.NewBufferString("GET / HTTP/1.1\r\n\r\n"))
+	err := r.Read(br)
+	r.SetHost("foobar")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	s := r.String()
+	if strings.Contains(s, "Content-Length: ") {
+		t.Fatalf("unexpected Content-Length")
+	}
+}
+
 func TestResponseWriteTo(t *testing.T) {
 	t.Parallel()
 
@@ -2210,9 +2227,9 @@ func TestRequestRawBodyCopyTo(t *testing.T) {
 }
 
 type testReader struct {
-	read chan (int)
-	cb   chan (struct{})
-	onClose func() error 
+	read    chan (int)
+	cb      chan (struct{})
+	onClose func() error
 }
 
 func (r *testReader) Read(b []byte) (int, error) {


### PR DESCRIPTION
Come from #1019  @erikdubbelboer I added test to prove my changes work. I'm not always removing `Content-Length` header, I remove it when `contentLength == -2` which means no body. 

This is not a perfect solution, because I found If any `Request.SetContentLength` is called then `contentLength` must be printed when `RequestHeader.Write`. I suppose we may define -3 or sth don't set `contentLengthBytes` any more.

Shall we close MR only after we have the same conclusion?