### PR TITLE
Use proper content-type when it is not present

### DIFF
--- a/header.go
+++ b/header.go
@@ -32,10 +32,10 @@ type ResponseHeader struct {
 	noDefaultContentType bool
 	noDefaultDate        bool
 
-	statusCode         int
-	contentLength      int
-	contentLengthBytes []byte
-	secureErrorLogMessage     bool
+	statusCode            int
+	contentLength         int
+	contentLengthBytes    []byte
+	secureErrorLogMessage bool
 
 	contentType []byte
 	server      []byte
@@ -64,9 +64,9 @@ type RequestHeader struct {
 	// for reducing RequestHeader object size.
 	cookiesCollected bool
 
-	contentLength      int
-	contentLengthBytes []byte
-	secureErrorLogMessage     bool
+	contentLength         int
+	contentLengthBytes    []byte
+	secureErrorLogMessage bool
 
 	method      []byte
 	requestURI  []byte
@@ -1649,7 +1649,7 @@ func (h *RequestHeader) AppendBytes(dst []byte) []byte {
 
 	contentType := h.ContentType()
 	if len(contentType) == 0 && !h.ignoreBody() {
-		contentType = strPostArgsContentType
+		contentType = strDefaultContentType
 	}
 	if len(contentType) > 0 {
 		dst = appendHeaderLine(dst, strContentType, contentType)

--- a/header_test.go
+++ b/header_test.go
@@ -1250,6 +1250,33 @@ func TestResponseContentTypeNoDefaultNotEmpty(t *testing.T) {
 	}
 }
 
+func TestRequestContentTypeDefaultNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	var h RequestHeader
+	h.SetMethod(MethodPost)
+	h.SetContentLength(5)
+
+	w := &bytes.Buffer{}
+	bw := bufio.NewWriter(w)
+	if err := h.Write(bw); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	var h1 RequestHeader
+	br := bufio.NewReader(w)
+	if err := h1.Read(br); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	if string(h1.contentType) != "application/octet-stream" {
+		t.Fatalf("unexpected Content-Type %q. Expecting %q", h1.contentType, "application/octet-stream")
+	}
+}
+
 func TestResponseDateNoDefaultNotEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -2415,7 +2442,6 @@ func TestResponseHeaderReadErrorSecureLog(t *testing.T) {
 	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 foobar OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
 	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 123foobar OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
 	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 foobar344 OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
-
 
 	// no headers
 	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 200 OK\r\n")

--- a/strings.go
+++ b/strings.go
@@ -77,6 +77,7 @@ var (
 	strIdentity            = []byte("identity")
 	str100Continue         = []byte("100-continue")
 	strPostArgsContentType = []byte("application/x-www-form-urlencoded")
+	strDefaultContentType  = []byte("application/octet-stream")
 	strMultipartFormData   = []byte("multipart/form-data")
 	strBoundary            = []byte("boundary")
 	strBytes               = []byte("bytes")


### PR DESCRIPTION
refer to https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5 

> A sender that generates a message containing a payload body SHOULD
   generate a Content-Type header field in that message unless the
   intended media type of the enclosed representation is unknown to the
   sender.  If a Content-Type header field is not present, the recipient
   MAY either assume a media type of "application/octet-stream"
   ([RFC2046], Section 4.5.1) or examine the data to determine its type.

default content type should be "application/octet-stream" instead of "application/x-www-form-urlencoded" which will mess body up.

I found this because when I sent curl command like `curl my/proxy/with/fasthttp -d abcd -XPOST` I noticed content-type had been modified by fasthttp to `application/x-www-form-urlencoded`, and body changed to `abcd=`. 