### PR TITLE
Fix header .Add functions

### DIFF
--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -20,7 +20,6 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	expectedRequestURI := "/foo/bar?baz=123"
 	expectedBody := "body 123 foo bar baz"
 	expectedContentLength := len(expectedBody)
-	expectedTransferEncoding := "encoding"
 	expectedHost := "foobar.com"
 	expectedRemoteAddr := "1.2.3.4:6789"
 	expectedHeader := map[string]string{
@@ -56,8 +55,8 @@ func TestNewFastHTTPHandler(t *testing.T) {
 		if r.ContentLength != int64(expectedContentLength) {
 			t.Fatalf("unexpected contentLength %d. Expecting %d", r.ContentLength, expectedContentLength)
 		}
-		if len(r.TransferEncoding) != 1 || r.TransferEncoding[0] != expectedTransferEncoding {
-			t.Fatalf("unexpected transferEncoding %q. Expecting %q", r.TransferEncoding, expectedTransferEncoding)
+		if len(r.TransferEncoding) != 0 {
+			t.Fatalf("unexpected transferEncoding %q. Expecting []", r.TransferEncoding)
 		}
 		if r.Host != expectedHost {
 			t.Fatalf("unexpected host %q. Expecting %q", r.Host, expectedHost)
@@ -101,7 +100,6 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	req.Header.SetMethod(expectedMethod)
 	req.SetRequestURI(expectedRequestURI)
 	req.Header.SetHost(expectedHost)
-	req.Header.Add(fasthttp.HeaderTransferEncoding, expectedTransferEncoding)
 	req.BodyWriter().Write([]byte(expectedBody)) // nolint:errcheck
 	for k, v := range expectedHeader {
 		req.Header.Set(k, v)


### PR DESCRIPTION
These functions should take the headers that are handled differently into account.

Fixes #1033

After this change it is not possible to have multiple 
Content-Type, Content-Length, Connection, Server, Set-Cookie, Transfer-Encoding and Date headers. Having other headers multiple times is still fine. For these headers it should never happen anyways and I don't think we have any users who do this. But if they do it would break for then.