### PR TITLE
fixed panic when was called ParseBytes method

### DIFF
--- a/args.go
+++ b/args.go
@@ -456,7 +456,11 @@ func allocArg(h []argsKV) ([]argsKV, *argsKV) {
 }
 
 func releaseArg(h []argsKV) []argsKV {
-	return h[:len(h)-1]
+	n := len(h) - 1
+	if n < 1 {
+		n = 0
+	}
+	return h[:n]
 }
 
 func hasArg(h []argsKV, key string) bool {


### PR DESCRIPTION
We got panic in production when we tried to get parameters from the URL.
We use fasthttp version v1.19.1 

StackTrace:
```
[panic] runtime error: slice bounds out of range [:-1]
/usr/local/go/src/runtime/panic.go:106 (0x4351e4)
/go/src/gotask.ws/scm/ts/rotator/vendor/github.com/valyala/fasthttp/args.go:459 (0x9ef21c)
/go/src/gotask.ws/scm/ts/rotator/vendor/github.com/valyala/fasthttp/args.go:103 (0x9ef096)
/go/src/gotask.ws/scm/ts/rotator/vendor/github.com/valyala/fasthttp/uri.go:603 (0xa47a5c)
/go/src/gotask.ws/scm/ts/rotator/vendor/github.com/valyala/fasthttp/uri.go:595 (0xa47a69)
```
