### PR TITLE
Add ResetUserValues() and related test

### DIFF
--- a/server.go
+++ b/server.go
@@ -693,6 +693,11 @@ func (ctx *RequestCtx) VisitUserValues(visitor func([]byte, interface{})) {
 	}
 }
 
+// ResetUserValues allows to reset user values from Request Context
+func (ctx *RequestCtx) ResetUserValues() {
+	ctx.userValues.Reset()
+}
+
 type connTLSer interface {
 	Handshake() error
 	ConnectionState() tls.ConnectionState

--- a/server_test.go
+++ b/server_test.go
@@ -1608,6 +1608,15 @@ func TestRequestCtxUserValue(t *testing.T) {
 	if len(ctx.userValues) != vlen {
 		t.Fatalf("the length of user values returned from VisitUserValues is not equal to the length of the userValues, expecting: %d but got: %d", len(ctx.userValues), vlen)
 	}
+
+	ctx.ResetUserValues()
+	for i := 0; i < 10; i++ {
+		k := fmt.Sprintf("key-%d", i)
+		v := ctx.UserValue(k)
+		if v != nil {
+			t.Fatalf("unexpected value obtained for key %q: %v. Expecting nil", k, v)
+		}
+	}
 }
 
 func TestServerHeadRequest(t *testing.T) {


### PR DESCRIPTION
 `ResetUserValues()` function will allow users to reset the user values from RequestCtx.