### PR TITLE
Handle perIPConn in RequestCtx.IsTLS() specially

### DIFF
--- a/server.go
+++ b/server.go
@@ -715,6 +715,13 @@ func (ctx *RequestCtx) IsTLS() bool {
 	//
 	//     // other custom fields here
 	// }
+
+	// perIPConn wraps the net.Conn in the Conn field
+	if pic, ok := ctx.c.(*perIPConn); ok {
+		_, ok := pic.Conn.(connTLSer)
+		return ok
+	}
+
 	_, ok := ctx.c.(connTLSer)
 	return ok
 }

--- a/server_test.go
+++ b/server_test.go
@@ -529,6 +529,11 @@ func TestRequestCtxIsTLS(t *testing.T) {
 	if !ctx.IsTLS() {
 		t.Fatal("IsTLS must return true")
 	}
+
+	ctx.c = &perIPConn{Conn: &tls.Conn{}}
+	if !ctx.IsTLS() {
+		t.Fatal("IsTLS must return true")
+	}
 }
 
 func TestRequestCtxRedirectHTTPSSchemeless(t *testing.T) {


### PR DESCRIPTION
Fixes #1062 