### PR TITLE
Fix s2b

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 	"unsafe"
+	"runtime"
 )
 
 // AppendHTMLEscape appends html-escaped s to dst and returns the extended dst.
@@ -345,8 +346,9 @@ func s2b(s string) (b []byte) {
 	/* #nosec G103 */
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	bh.Data = sh.Data
-	bh.Len = sh.Len
 	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	runtime.KeepAlive(&s)
 	return b
 }
 


### PR DESCRIPTION
Ensure `len(b)` <= `cap(b)` at all times. Additionally, use `runtime.KeepAlive()` to prevent `s` from being GC-ed.

A likely better solution (which requires Go 1.17) would use:
```
b = unsafe.Slice((*byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data)), len(s))
```