### PR TITLE
improve invalidStatusLine by  appending a `[]byte` directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tags
 *.fasthttp.br
 .idea
 .DS_Store
+vendor/

--- a/status.go
+++ b/status.go
@@ -1,7 +1,9 @@
 package fasthttp
 
 import (
+	"bytes"
 	"fmt"
+	"strconv"
 )
 
 const (
@@ -181,5 +183,13 @@ func statusLine(statusCode int) []byte {
 
 func invalidStatusLine(statusCode int) []byte {
 	statusText := StatusMessage(statusCode)
-	return []byte(fmt.Sprintf("HTTP/1.1 %d %s\r\n", statusCode, statusText))
+	var buf bytes.Buffer
+	// xxx  placeholder of status code
+	buf.Grow(len("HTTP/1.1 xxx \r\n") + len(statusText))
+	buf.WriteString("HTTP/1.1 ")
+	buf.WriteString(strconv.Itoa(statusCode))
+	buf.WriteString(" ")
+	buf.WriteString(statusText)
+	buf.WriteString("\r\n")
+	return buf.Bytes()
 }

--- a/status.go
+++ b/status.go
@@ -2,7 +2,6 @@ package fasthttp
 
 import (
 	"fmt"
-	"strconv"
 )
 
 const (
@@ -185,7 +184,7 @@ func invalidStatusLine(statusCode int) []byte {
 	// xxx placeholder of status code
 	var line = make([]byte, 0, len("HTTP/1.1 xxx \r\n")+len(statusText))
 	line = append(line, []byte("HTTP/1.1 ")...)
-	line = append(line, []byte(strconv.Itoa(statusCode))...)
+	line = AppendUint(line, statusCode)
 	line = append(line, []byte(" ")...)
 	line = append(line, []byte(statusText)...)
 	line = append(line, []byte("\r\n")...)

--- a/status.go
+++ b/status.go
@@ -183,7 +183,13 @@ func invalidStatusLine(statusCode int) []byte {
 	statusText := StatusMessage(statusCode)
 	// xxx placeholder of status code
 	var line = make([]byte, 0, len("HTTP/1.1 xxx \r\n")+len(statusText))
-	line = append(line, []byte("HTTP/1.1 ")...)
+	if statusCode < 0 {
+		line = append(line, []byte("HTTP/1.1 -")...)
+		statusCode = -statusCode
+	} else {
+		line = append(line, []byte("HTTP/1.1 ")...)
+	}
+
 	line = AppendUint(line, statusCode)
 	line = append(line, []byte(" ")...)
 	line = append(line, []byte(statusText)...)

--- a/status.go
+++ b/status.go
@@ -1,7 +1,6 @@
 package fasthttp
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
 )
@@ -183,13 +182,12 @@ func statusLine(statusCode int) []byte {
 
 func invalidStatusLine(statusCode int) []byte {
 	statusText := StatusMessage(statusCode)
-	var buf bytes.Buffer
-	// xxx  placeholder of status code
-	buf.Grow(len("HTTP/1.1 xxx \r\n") + len(statusText))
-	buf.WriteString("HTTP/1.1 ")
-	buf.WriteString(strconv.Itoa(statusCode))
-	buf.WriteString(" ")
-	buf.WriteString(statusText)
-	buf.WriteString("\r\n")
-	return buf.Bytes()
+	// xxx placeholder of status code
+	var line = make([]byte, 0, len("HTTP/1.1 xxx \r\n")+len(statusText))
+	line = append(line, []byte("HTTP/1.1 ")...)
+	line = append(line, []byte(strconv.Itoa(statusCode))...)
+	line = append(line, []byte(" ")...)
+	line = append(line, []byte(statusText)...)
+	line = append(line, []byte("\r\n")...)
+	return line
 }

--- a/status.go
+++ b/status.go
@@ -2,6 +2,7 @@ package fasthttp
 
 import (
 	"fmt"
+	"strconv"
 )
 
 const (
@@ -183,14 +184,8 @@ func invalidStatusLine(statusCode int) []byte {
 	statusText := StatusMessage(statusCode)
 	// xxx placeholder of status code
 	var line = make([]byte, 0, len("HTTP/1.1 xxx \r\n")+len(statusText))
-	if statusCode < 0 {
-		line = append(line, []byte("HTTP/1.1 -")...)
-		statusCode = -statusCode
-	} else {
-		line = append(line, []byte("HTTP/1.1 ")...)
-	}
-
-	line = AppendUint(line, statusCode)
+	line = append(line, []byte("HTTP/1.1 ")...)
+	line = strconv.AppendInt(line, int64(statusCode), 10)
 	line = append(line, []byte(" ")...)
 	line = append(line, []byte(statusText)...)
 	line = append(line, []byte("\r\n")...)


### PR DESCRIPTION
we  create  a  new `[]byte` by   appending ` []byte` directly  instead of  ` fmt.Sprintf `+`[]byte(str)` . it  not only reduce memory allocation ,but also improve performance.
benchmark result:
- old
```
$tyltr > go test -benchmem -run=none  -bench=BenchmarkStatusLine512 -count 10
goos: darwin
goarch: amd64
pkg: github.com/valyala/fasthttp
BenchmarkStatusLine512-8        12142441               109 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8         8737126               126 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8         9828290               108 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8        12083548               106 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8        12042510               101 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8         9378646               116 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8        10912117               119 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8         8671092               144 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8        10802367               112 ns/op             120 B/op          4 allocs/op
BenchmarkStatusLine512-8        10569896               104 ns/op             120 B/op          4 allocs/op
PASS
ok      github.com/valyala/fasthttp     14.813s
```

- New

```
$tyltr > go test -benchmem -run=none  -bench=BenchmarkStatusLine512 -count 10
goos: darwin
goarch: amd64
pkg: github.com/valyala/fasthttp
BenchmarkStatusLine512-8        38009354                31.6 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        33037570                32.2 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        33171657                35.2 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        31569279                34.4 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        33563328                38.0 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        29985741                37.3 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        35844474                35.7 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        33703874                32.2 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        34399201                32.3 ns/op            51 B/op          2 allocs/op
BenchmarkStatusLine512-8        33057207                32.0 ns/op            51 B/op          2 allocs/op
PASS
ok      github.com/valyala/fasthttp     13.049s

```