### PR TITLE
feat: improve IsMethod 

### DIFF
--- a/client.go
+++ b/client.go
@@ -950,7 +950,7 @@ var clientURLResponseChPool sync.Pool
 
 func clientPostURL(dst []byte, url string, postArgs *Args, c clientDoer) (statusCode int, body []byte, err error) {
 	req := AcquireRequest()
-	req.Header.SetMethodBytes(strPost)
+	req.Header.SetMethodBytes([]byte(MethodPost))
 	req.Header.SetContentTypeBytes(strPostArgsContentType)
 	if postArgs != nil {
 		if _, err := postArgs.WriteTo(req.BodyWriter()); err != nil {

--- a/client.go
+++ b/client.go
@@ -950,7 +950,7 @@ var clientURLResponseChPool sync.Pool
 
 func clientPostURL(dst []byte, url string, postArgs *Args, c clientDoer) (statusCode int, body []byte, err error) {
 	req := AcquireRequest()
-	req.Header.SetMethodBytes([]byte(MethodPost))
+	req.Header.SetMethod(MethodPost)
 	req.Header.SetContentTypeBytes(strPostArgsContentType)
 	if postArgs != nil {
 		if _, err := postArgs.WriteTo(req.BodyWriter()); err != nil {

--- a/header.go
+++ b/header.go
@@ -443,7 +443,7 @@ func (h *RequestHeader) SetRefererBytes(referer []byte) {
 // Method returns HTTP request method.
 func (h *RequestHeader) Method() []byte {
 	if len(h.method) == 0 {
-		return strGet
+		return []byte(MethodGet)
 	}
 	return h.method
 }

--- a/header.go
+++ b/header.go
@@ -503,47 +503,47 @@ func (h *RequestHeader) SetRequestURIBytes(requestURI []byte) {
 
 // IsGet returns true if request method is GET.
 func (h *RequestHeader) IsGet() bool {
-	return bytes.Equal(h.Method(), strGet)
+	return string(h.Method()) == MethodGet
 }
 
 // IsPost returns true if request method is POST.
 func (h *RequestHeader) IsPost() bool {
-	return bytes.Equal(h.Method(), strPost)
+	return string(h.Method()) == MethodPost
 }
 
 // IsPut returns true if request method is PUT.
 func (h *RequestHeader) IsPut() bool {
-	return bytes.Equal(h.Method(), strPut)
+	return string(h.Method()) == MethodPut
 }
 
 // IsHead returns true if request method is HEAD.
 func (h *RequestHeader) IsHead() bool {
-	return bytes.Equal(h.Method(), strHead)
+	return string(h.Method()) == MethodHead
 }
 
 // IsDelete returns true if request method is DELETE.
 func (h *RequestHeader) IsDelete() bool {
-	return bytes.Equal(h.Method(), strDelete)
+	return string(h.Method()) == MethodDelete
 }
 
 // IsConnect returns true if request method is CONNECT.
 func (h *RequestHeader) IsConnect() bool {
-	return bytes.Equal(h.Method(), strConnect)
+	return string(h.Method()) == MethodConnect
 }
 
 // IsOptions returns true if request method is OPTIONS.
 func (h *RequestHeader) IsOptions() bool {
-	return bytes.Equal(h.Method(), strOptions)
+	return string(h.Method()) == MethodOptions
 }
 
 // IsTrace returns true if request method is TRACE.
 func (h *RequestHeader) IsTrace() bool {
-	return bytes.Equal(h.Method(), strTrace)
+	return string(h.Method()) == MethodTrace
 }
 
 // IsPatch returns true if request method is PATCH.
 func (h *RequestHeader) IsPatch() bool {
-	return bytes.Equal(h.Method(), strPatch)
+	return string(h.Method()) == MethodPatch
 }
 
 // IsHTTP11 returns true if the request is HTTP/1.1.

--- a/header_timing_test.go
+++ b/header_timing_test.go
@@ -178,3 +178,12 @@ func BenchmarkRemoveNewLines(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkRequestHeaderIsPost(b *testing.B) {
+	req := &RequestHeader{method: strPost}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req.IsPost()
+		}
+	})
+}

--- a/header_timing_test.go
+++ b/header_timing_test.go
@@ -187,3 +187,64 @@ func BenchmarkRequestHeaderIsPost(b *testing.B) {
 		}
 	})
 }
+func BenchmarkRequestHeaderIsHead(b *testing.B) {
+	req := &RequestHeader{method: strHead}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req.IsHead()
+		}
+	})
+}
+func BenchmarkRequestHeaderIsPut(b *testing.B) {
+	req := &RequestHeader{method: strPut}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req.IsPut()
+		}
+	})
+}
+
+func BenchmarkRequestHeaderIsDelete(b *testing.B) {
+	req := &RequestHeader{method: strDelete}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req.IsDelete()
+		}
+	})
+}
+
+func BenchmarkRequestHeaderIsConnect(b *testing.B) {
+	req := &RequestHeader{method: strConnect}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req.IsConnect()
+		}
+	})
+}
+
+func BenchmarkRequestHeaderIsOptions(b *testing.B) {
+	req := &RequestHeader{method: strOptions}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req.IsOptions()
+		}
+	})
+}
+
+func BenchmarkRequestHeaderIsTrace(b *testing.B) {
+	req := &RequestHeader{method: strTrace}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req.IsTrace()
+		}
+	})
+}
+
+func BenchmarkRequestHeaderIsPatch(b *testing.B) {
+	req := &RequestHeader{method: strPatch}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req.IsPatch()
+		}
+	})
+}

--- a/header_timing_test.go
+++ b/header_timing_test.go
@@ -179,72 +179,11 @@ func BenchmarkRemoveNewLines(b *testing.B) {
 	}
 }
 
-func BenchmarkRequestHeaderIsPost(b *testing.B) {
-	req := &RequestHeader{method: strPost}
+func BenchmarkRequestHeaderIsGet(b *testing.B) {
+	req := &RequestHeader{method: []byte(MethodGet)}
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			req.IsPost()
-		}
-	})
-}
-func BenchmarkRequestHeaderIsHead(b *testing.B) {
-	req := &RequestHeader{method: strHead}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			req.IsHead()
-		}
-	})
-}
-func BenchmarkRequestHeaderIsPut(b *testing.B) {
-	req := &RequestHeader{method: strPut}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			req.IsPut()
-		}
-	})
-}
-
-func BenchmarkRequestHeaderIsDelete(b *testing.B) {
-	req := &RequestHeader{method: strDelete}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			req.IsDelete()
-		}
-	})
-}
-
-func BenchmarkRequestHeaderIsConnect(b *testing.B) {
-	req := &RequestHeader{method: strConnect}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			req.IsConnect()
-		}
-	})
-}
-
-func BenchmarkRequestHeaderIsOptions(b *testing.B) {
-	req := &RequestHeader{method: strOptions}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			req.IsOptions()
-		}
-	})
-}
-
-func BenchmarkRequestHeaderIsTrace(b *testing.B) {
-	req := &RequestHeader{method: strTrace}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			req.IsTrace()
-		}
-	})
-}
-
-func BenchmarkRequestHeaderIsPatch(b *testing.B) {
-	req := &RequestHeader{method: strPatch}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			req.IsPatch()
+			req.IsGet()
 		}
 	})
 }

--- a/strings.go
+++ b/strings.go
@@ -24,15 +24,15 @@ var (
 
 	strResponseContinue = []byte("HTTP/1.1 100 Continue\r\n\r\n")
 
-	strGet     = []byte(MethodGet)
-	strHead    = []byte(MethodHead)
-	strPost    = []byte(MethodPost)
-	strPut     = []byte(MethodPut)
-	strDelete  = []byte(MethodDelete)
-	strConnect = []byte(MethodConnect)
-	strOptions = []byte(MethodOptions)
-	strTrace   = []byte(MethodTrace)
-	strPatch   = []byte(MethodPatch)
+	strGet     = []byte(MethodGet)     //nolint:unused
+	strHead    = []byte(MethodHead)    //nolint:unused
+	strPost    = []byte(MethodPost)    //nolint:unused
+	strPut     = []byte(MethodPut)     //nolint:unused
+	strDelete  = []byte(MethodDelete)  //nolint:unused
+	strConnect = []byte(MethodConnect) //nolint:unused
+	strOptions = []byte(MethodOptions) //nolint:unused
+	strTrace   = []byte(MethodTrace)   //nolint:unused
+	strPatch   = []byte(MethodPatch)   //nolint:unused
 
 	strExpect           = []byte(HeaderExpect)
 	strConnection       = []byte(HeaderConnection)

--- a/strings.go
+++ b/strings.go
@@ -24,16 +24,6 @@ var (
 
 	strResponseContinue = []byte("HTTP/1.1 100 Continue\r\n\r\n")
 
-	strGet     = []byte(MethodGet)     //nolint:unused
-	strHead    = []byte(MethodHead)    //nolint:unused
-	strPost    = []byte(MethodPost)    //nolint:unused
-	strPut     = []byte(MethodPut)     //nolint:unused
-	strDelete  = []byte(MethodDelete)  //nolint:unused
-	strConnect = []byte(MethodConnect) //nolint:unused
-	strOptions = []byte(MethodOptions) //nolint:unused
-	strTrace   = []byte(MethodTrace)   //nolint:unused
-	strPatch   = []byte(MethodPatch)   //nolint:unused
-
 	strExpect           = []byte(HeaderExpect)
 	strConnection       = []byte(HeaderConnection)
 	strContentLength    = []byte(HeaderContentLength)


### PR DESCRIPTION
improve `IsMethod`  i.e `IsPost` 、 `IsGet ` and  so on.

benchmark
- old
```
goos: linux
goarch: amd64
pkg: github.com/valyala/fasthttp
cpu: Intel(R) Xeon(R) Platinum 8255C CPU @ 2.50GHz
BenchmarkRequestHeaderIsPost-2          559623241                2.003 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          604524886                1.992 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          601059054                2.015 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          605856414                2.006 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          606804846                1.981 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          608144640                1.984 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          606334010                2.000 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          606591694                2.001 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          606142994                2.007 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          602808153                1.974 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/valyala/fasthttp     14.092s
```

- new
```
goos: linux
goarch: amd64
pkg: github.com/valyala/fasthttp
cpu: Intel(R) Xeon(R) Platinum 8255C CPU @ 2.50GHz
BenchmarkRequestHeaderIsPost-2          982056084                1.123 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.127 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.121 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.122 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.114 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.132 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.114 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.115 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.111 ns/op           0 B/op          0 allocs/op
BenchmarkRequestHeaderIsPost-2          1000000000               1.133 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/valyala/fasthttp     12.406s

```


