### PR TITLE
Remove useless runtime.KeepAlive

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -348,7 +348,6 @@ func s2b(s string) (b []byte) {
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
-	runtime.KeepAlive(&s)
 	return b
 }
 


### PR DESCRIPTION
According to https://github.com/golang/go/issues/47562 and comment from PR with the removed change (https://github.com/valyala/fasthttp/pull/1079#issuecomment-906225431) this `KeepAlive` is meaningless.