### PR TITLE
feat:no  need  to  store nil

### DIFF
--- a/userdata.go
+++ b/userdata.go
@@ -21,6 +21,9 @@ func (d *userData) Set(key string, value interface{}) {
 			return
 		}
 	}
+	if value == nil {
+		return 
+	}
 
 	c := cap(args)
 	if c > n {

--- a/userdata.go
+++ b/userdata.go
@@ -22,7 +22,7 @@ func (d *userData) Set(key string, value interface{}) {
 		}
 	}
 	if value == nil {
-		return 
+		return
 	}
 
 	c := cap(args)


### PR DESCRIPTION
I  dont think it is necessary  to  store  key & value into  `userdata ` ,when value  is  `nil` . 
-  method `Get` will  return  nil , if  key does not  exist.    same result with not    storing  key & value into  `userdata `.
-  there is not  a flag  indicates whether value was found in the   `userdata ` . for example ` func (d *userData) Get(key string) (value interface{} , exist bool )`


 