### PR TITLE
feat: use skipmap in tcpAddrsMap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/klauspost/compress v1.13.4
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/tcplisten v1.0.0
+	github.com/zhangyunhao116/skipmap v0.7.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,14 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/tcplisten v1.0.0 h1:rBHj/Xf+E1tRGZyWIWwJDiRY0zc1Js+CV5DqwacVSA8=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
+github.com/zhangyunhao116/fastrand v0.1.0 h1:NBvafu24zKd6taYBVtw9MWyxkK/HSSVnFtxnPAprasw=
+github.com/zhangyunhao116/fastrand v0.1.0/go.mod h1:0v5KgHho0VE6HU192HnY15de/oDS8UrbBChIFjIhBtc=
+github.com/zhangyunhao116/sbconv v0.2.1 h1:9Z43QFpnkYNjCrRz8UR9ShVRVQ0OG5VtLKQ3mAL5zjU=
+github.com/zhangyunhao116/sbconv v0.2.1/go.mod h1:pdAXGnJGNM68XNdJOfGCelkEHgrQMWSeW/2/qKjuiQQ=
+github.com/zhangyunhao116/skipmap v0.7.0 h1:qpm8IZYgbdTGbOmjglyQfZfCDPEJfILDEqo1uo0r++M=
+github.com/zhangyunhao116/skipmap v0.7.0/go.mod h1:F5TrRZ1YAVSalENORSs6OsmwdOAPHnACa78SZN+ZZwc=
+github.com/zhangyunhao116/wyhash v0.3.2 h1:v2VfcnTCLWv0mjFNg6t2EcZAj8Y91fG7Vb004xHauXI=
+github.com/zhangyunhao116/wyhash v0.3.2/go.mod h1:9okT6cr1VZK9N3Tv0I6qUYDNtQgOfcQgfMRCEXt9d8I=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=


### PR DESCRIPTION
[skipmap](https://github.com/zhangyunhao116/skipmap) is a high-performance, scalable concurrent map, and the `Load` and `Range` are wait-free(skipmap don't need to lock the entire map compared to sync.Map).

Because we call `tcpAddrsMap.Range` per second, which can boost a lot in this situation. We can see `1Range9Delete90Store900Load` in the [benchmark](https://github.com/zhangyunhao116/skipmap#benchmark).

skipmap has been running for a few months in the production environment at my work, hope this can help :)