### PR TITLE
feat: ability to read body separate from header

### DIFF
--- a/http.go
+++ b/http.go
@@ -1211,7 +1211,7 @@ func (resp *Response) Read(r *bufio.Reader) error {
 // ReadLimitBody reads response headers from the given r,
 // then reads the body using the ReadBody function and limiting the body size.
 //
-// If SkipBody is true then it skips reading the response body.
+// If resp.SkipBody is true then it skips reading the response body.
 //
 // If maxBodySize > 0 and the body size exceeds maxBodySize,
 // then ErrBodyTooLarge is returned.


### PR DESCRIPTION
This PR simply moves reading the message body into its own function for both the `request` and `response` object. 

This is in reference to https://github.com/valyala/fasthttp/issues/1129, and it does not change FastHTTP functionally, simply moves reading the body into its own (exported) function.

This will allow FastHTTP to support streaming protocols for reverse proxying (and potentially in the FastHTTP HostClient as well), by simply adding the ability to read the request/response bodies separate from their headers. 