### PR TITLE
Fix StatusLine issue

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -52,7 +52,7 @@ func TestResponseHeaderMultiLineValue(t *testing.T) {
 		t.Fatalf("parse response using net/http failed, %s", err)
 	}
 
-	if !bytes.Equal(header.StatusLine(), []byte("SuperOK")) {
+	if !bytes.Equal(header.StatusLine(), []byte("HTTP/1.1 200 SuperOK\r\n")) {
 		t.Errorf("parse status line with non-default value failed, got: %s want: SuperOK", header.StatusLine())
 	}
 
@@ -83,7 +83,7 @@ func TestResponseHeaderMultiLineName(t *testing.T) {
 		t.Errorf("expected error, got %q (%v)", m, err)
 	}
 
-	if !bytes.Equal(header.StatusLine(), []byte("OK")) {
+	if !bytes.Equal(header.StatusLine(), []byte("HTTP/1.1 200 OK\r\n")) {
 		t.Errorf("expected default status line, got: %s", header.StatusLine())
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -16,6 +16,41 @@ import (
 	"github.com/valyala/bytebufferpool"
 )
 
+func TestIssue1132(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range []struct {
+		body     string
+		expected string
+	}{
+		{
+			body:     "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nfoo",
+			expected: "HTTP/1.1 200 OK\r\n",
+		},
+		{
+			body:     "HTTP/1.1 204 NC\r\n\r\n",
+			expected: "HTTP/1.1 204 NC\r\n",
+		},
+	} {
+		t.Run(c.expected, func(t *testing.T) {
+			var r Response
+
+			br := bufio.NewReader(bytes.NewBufferString(c.body))
+			err := r.Read(br)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := r.Header.StatusLine()
+			expected := []byte(c.expected)
+
+			if !bytes.Equal(got, expected) {
+				t.Fatalf("got %q expected %q", got, expected)
+			}
+		})
+	}
+}
+
 func TestResponseEmptyTransferEncoding(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Parsing the status line only parsed the text while the code expects the
full line (as the name of the functions implies).

Fixes https://github.com/valyala/fasthttp/issues/1132