### PR TITLE
Fix StatusLine issue

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -52,8 +52,8 @@ func TestResponseHeaderMultiLineValue(t *testing.T) {
 		t.Fatalf("parse response using net/http failed, %s", err)
 	}
 
-	if !bytes.Equal(header.StatusLine(), []byte("SuperOK")) {
-		t.Errorf("parse status line with non-default value failed, got: %s want: SuperOK", header.StatusLine())
+	if !bytes.Equal(header.StatusText(), []byte("SuperOK")) {
+		t.Errorf("parse status line with non-default value failed, got: %s want: SuperOK", header.StatusText())
 	}
 
 	for name, vals := range response.Header {
@@ -83,8 +83,8 @@ func TestResponseHeaderMultiLineName(t *testing.T) {
 		t.Errorf("expected error, got %q (%v)", m, err)
 	}
 
-	if !bytes.Equal(header.StatusLine(), []byte("OK")) {
-		t.Errorf("expected default status line, got: %s", header.StatusLine())
+	if !bytes.Equal(header.StatusText(), []byte("OK")) {
+		t.Errorf("expected default status line, got: %s", header.StatusText())
 	}
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -839,7 +839,7 @@ func TestResponseSkipBody(t *testing.T) {
 
 	// set StatusNoContent with statusLine
 	r.Header.SetStatusCode(StatusNoContent)
-	r.Header.SetStatusLine([]byte("HTTP/1.1 204 NC\r\n"))
+	r.Header.SetStatusText([]byte("NC"))
 	r.SetBodyString("foobar")
 	s = r.String()
 	if strings.Contains(s, "\r\n\r\nfoobar") {


### PR DESCRIPTION
Parsing the status line only parsed the text while the code expects the
full line (as the name of the functions implies). We change the function
names to imply that only the text is meant.

Fixes https://github.com/valyala/fasthttp/issues/1132