### PR TITLE
Don't run all race tests on windows

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,3 +1,5 @@
+// go:build !windows || !race
+
 package fasthttp
 
 import (

--- a/fs_test.go
+++ b/fs_test.go
@@ -1,3 +1,6 @@
+// go:build !windows
+// Don't run FS tests on windows as it isn't compatible for now.
+
 package fasthttp
 
 import (

--- a/server_test.go
+++ b/server_test.go
@@ -1,3 +1,5 @@
+// go:build !windows || !race
+
 package fasthttp
 
 import (


### PR DESCRIPTION
It's too slow and gives a lot of false positives in our tests.