### PR TITLE
compatible with the old build tags

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,4 +1,5 @@
 // go:build !windows || !race
+// +build !windows !race
 
 package fasthttp
 

--- a/client.go
+++ b/client.go
@@ -1,5 +1,4 @@
 // go:build !windows || !race
-// +build !windows !race
 
 package fasthttp
 

--- a/fs_test.go
+++ b/fs_test.go
@@ -1,4 +1,5 @@
 // go:build !windows
+// +build !windows
 // Don't run FS tests on windows as it isn't compatible for now.
 
 package fasthttp

--- a/server_test.go
+++ b/server_test.go
@@ -1,4 +1,5 @@
 // go:build !windows || !race
+// +build !windows !race
 
 package fasthttp
 


### PR DESCRIPTION
pr [1143](https://github.com/valyala/fasthttp/pull/1143) should be compatible with  the old build-tags 