### PR TITLE
use sync.map is better

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -1370,18 +1370,15 @@ func fsModTime(t time.Time) time.Time {
 	return t.In(time.UTC).Truncate(time.Second)
 }
 
-var (
-	filesLockMap     = make(map[string]*sync.Mutex)
-	filesLockMapLock sync.Mutex
-)
+var filesLockMap sync.Map
 
 func getFileLock(absPath string) *sync.Mutex {
-	filesLockMapLock.Lock()
-	flock := filesLockMap[absPath]
-	if flock == nil {
-		flock = &sync.Mutex{}
-		filesLockMap[absPath] = flock
+	v, exist := filesLockMap.Load(absPath)
+	if exist == false {
+		flock := &sync.Mutex{}
+		filesLockMap.Store(absPath,flock)
+		return flock
 	}
-	filesLockMapLock.Unlock()
-	return flock
+	filelock:=v.(*sync.Mutex)
+	return filelock
 }

--- a/fs.go
+++ b/fs.go
@@ -1373,12 +1373,7 @@ func fsModTime(t time.Time) time.Time {
 var filesLockMap sync.Map
 
 func getFileLock(absPath string) *sync.Mutex {
-	v, exist := filesLockMap.Load(absPath)
-	if exist == false {
-		flock := &sync.Mutex{}
-		filesLockMap.Store(absPath,flock)
-		return flock
-	}
+	v, _ := filesLockMap.LoadOrStore(absPath,&sync.Mutex{})
 	filelock:=v.(*sync.Mutex)
 	return filelock
 }


### PR DESCRIPTION
The same as the pull request of https://github.com/valyala/fasthttp/pull/1106,in the fileslockmap read is more than write ,so sync.map will be better