### PR TITLE
fix: reset request after reset user values on keep-alive connections

### DIFF
--- a/server.go
+++ b/server.go
@@ -2118,6 +2118,7 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 			br, err = acquireByteReader(&ctx)
 		}
 
+		reqReset = false
 		ctx.Request.isTLS = isTLS
 		ctx.Response.Header.noDefaultContentType = s.NoDefaultContentType
 		ctx.Response.Header.noDefaultDate = s.NoDefaultDate

--- a/server.go
+++ b/server.go
@@ -2302,8 +2302,6 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 		if !ctx.IsGet() && ctx.IsHead() {
 			ctx.Response.SkipBody = true
 		}
-		reqReset = true
-		ctx.Request.Reset()
 
 		hijackHandler = ctx.hijackHandler
 		ctx.hijackHandler = nil
@@ -2403,6 +2401,9 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 
 		s.setState(c, StateIdle)
 		ctx.userValues.Reset()
+
+		reqReset = true
+		ctx.Request.Reset()
 
 		if atomic.LoadInt32(&s.stop) == 1 {
 			err = nil


### PR DESCRIPTION
This fix the use cases that reference a `RequestCtx` into user values that implements `io.Closer`

Example:
```go
func handler(ctx *fasthttp.RequestCtx) {
	rd := acquireRequestDuration()
	rd.ctx = ctx
	rd.start = time.Now()

	ctx.SetUserValue("__http::requestDuration__", rd)
}

func (rd *requestDuration) Close() error {
	duration := time.Since(rd.start)
	statusCode := strconv.Itoa(rd.ctx.Response.StatusCode())
	method := string(rd.ctx.Request.Header.Method())  // ISSUE: INVALID VALUE
	path := string(rd.ctx.Request.URI().Path())  // ISSUE: INVALID VALUE

	requestsDurationHistogramVec.WithLabelValues(
		statusCode, method, path,
	).Observe(duration.Seconds())

	releaseRequestDuration(rd)

	return nil
}
```