### PR TITLE
fix: cannot use custom host in header

### DIFF
--- a/http.go
+++ b/http.go
@@ -1356,11 +1356,13 @@ func (req *Request) onlyMultipartForm() bool {
 func (req *Request) Write(w *bufio.Writer) error {
 	if len(req.Header.Host()) == 0 || req.parsedURI {
 		uri := req.URI()
-		host := uri.Host()
-		if len(host) == 0 {
-			return errRequestHostRequired
+		if len(req.Header.Host()) == 0 {
+			host := uri.Host()
+			if len(host) == 0 {
+				return errRequestHostRequired
+			}
+			req.Header.SetHostBytes(host)
 		}
-		req.Header.SetHostBytes(host)
 		req.Header.SetRequestURIBytes(uri.RequestURI())
 
 		if len(uri.username) > 0 {

--- a/http_test.go
+++ b/http_test.go
@@ -581,7 +581,7 @@ func TestRequestUpdateURI(t *testing.T) {
 	// the requestURI and Host header are properly updated
 	u := r.URI()
 	u.SetPath("/123/432.html")
-	u.SetHost("foobar.com")
+	u.SetHost("foobar.com") // It will not take effect, because the header of r has set the Host.
 	a := u.QueryArgs()
 	a.Set("aaa", "bcse")
 
@@ -589,6 +589,13 @@ func TestRequestUpdateURI(t *testing.T) {
 	if !strings.HasPrefix(s, "GET /123/432.html?aaa=bcse") {
 		t.Fatalf("cannot find %q in %q", "GET /123/432.html?aaa=bcse", s)
 	}
+	if !strings.Contains(s, "\r\nHost: aaa.bbb\r\n") {
+		t.Fatalf("cannot find %q in %q", "\r\nHost: foobar.com\r\n", s)
+	}
+
+	// Now there is no Host in the header of r, use the host in the url
+	r.Header.SetHost("")
+	s = r.String()
 	if !strings.Contains(s, "\r\nHost: foobar.com\r\n") {
 		t.Fatalf("cannot find %q in %q", "\r\nHost: foobar.com\r\n", s)
 	}


### PR DESCRIPTION
Hi, I need fasthttp client to support custom Host in header, so I used the code change from #676 and I just modified a test case.

I think if the host in the request header exists, the host in the url should not be used.
I'm not sure, is this change ok?

Thanks