### PR TITLE
HostClient: addMissingPort() refactoring

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -246,13 +246,30 @@ func (u *URI) Reset() {
 	// is calculated on each call to RequestURI().
 }
 
-// Host returns host part, i.e. aaa.com of http://aaa.com/foo/bar?baz=123#qwe .
+// Host returns host part or host:port if the port was specified.
+//
+// http://aaa.com/foo/bar?baz=123#qwe returns aaa.com
+// http://aaa.com:8080/foo/bar?baz=123#qwe returns aaa.com:8080
 //
 // Host is always lowercased.
 //
 // The returned bytes are valid until the next URI method call.
 func (u *URI) Host() []byte {
 	return u.host
+}
+
+// HostWithPort returns host:port
+// If the port wasn't specified then it will be set to protocol's default
+//
+// http://aaa.com/foo/bar?baz=123#qwe returns aaa.com:80
+// https://aaa.com/foo/bar?baz=123#qwe returns aaa.com:443
+// http://aaa.com:8080/foo/bar?baz=123#qwe returns aaa.com:8080
+//
+// Host is always lowercased.
+//
+// The returned bytes are valid until the next URI method call.
+func (u *URI) HostWithPort() []byte {
+	return []byte(addMissingPort(string(u.host), u.isHttps()))
 }
 
 // SetHost sets host for the uri.

--- a/uri.go
+++ b/uri.go
@@ -329,13 +329,13 @@ func (u *URI) parse(host, uri []byte, isTLS bool) error {
 		}
 	}
 
+	// parseHost overrides input host so copy it
 	u.host = append(u.host, host...)
-	if parsedHost, err := parseHost(u.host); err != nil {
+	parsedHost, err := parseHost(u.host)
+	if err != nil {
 		return err
-	} else {
-		u.host = parsedHost
 	}
-	lowercaseBytes(u.host)
+	u.SetHostBytes(parsedHost)
 
 	b := uri
 	queryIndex := bytes.IndexByte(b, '?')

--- a/uri_test.go
+++ b/uri_test.go
@@ -476,7 +476,7 @@ func TestSetHost(t *testing.T) {
 	defer ReleaseURI(u)
 
 	// set http with a standard 80 port
-	u.Parse(nil, []byte("http://example.com/"))
+	u.Parse(nil, []byte("http://example.com/")) //nolint:errcheck
 	assertHostAndPort(t, u, "example.com", "example.com:80", ":80")
 	// set https with a standard 443 port
 	u.Update("https://example.com/")

--- a/uri_test.go
+++ b/uri_test.go
@@ -470,3 +470,35 @@ func TestNoOverwriteInput(t *testing.T) {
 		t.Errorf("%q", u.String())
 	}
 }
+
+func TestSetHost(t *testing.T) {
+	u := AcquireURI()
+	defer ReleaseURI(u)
+
+	// set http with a standard 80 port
+	u.Parse(nil, []byte("http://example.com/"))
+	assertHostAndPort(t, u, "example.com", "example.com:80", ":80")
+	// set https with a standard 443 port
+	u.Update("https://example.com/")
+	assertHostAndPort(t, u, "example.com", "example.com:443", ":443")
+	// set http with a custom port
+	u.Update("http://example.com:8080/")
+	assertHostAndPort(t, u, "example.com:8080", "example.com:8080", ":8080")
+
+	u.SetHost("[:1]")
+	assertHostAndPort(t, u, "[:1]", "[:1]:80", ":80")
+	u.SetHost("[:1]:8080")
+	assertHostAndPort(t, u, "[:1]:8080", "[:1]:8080", ":8080")
+}
+
+func assertHostAndPort(t *testing.T, u *URI, expectedHost string, expectedHostWithPort string, expectedPort string) {
+	if string(u.Host()) != expectedHost {
+		t.Fail()
+	}
+	if string(u.HostWithPort()) != expectedHostWithPort {
+		t.Fail()
+	}
+	if string(u.Port()) != expectedPort {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Please see commit messages for details
Now instead of
```
&HostClient{
		Addr: "localhost:80",
```
We can use simply:

```
&HostClient{
		Addr: "localhost",
```