### PR TITLE
Moved setting of the statusCode from (h *ResponseHeader) StatusCode()

### DIFF
--- a/header.go
+++ b/header.go
@@ -129,9 +129,6 @@ func (h *RequestHeader) SetByteRange(startPos, endPos int) {
 
 // StatusCode returns response status code.
 func (h *ResponseHeader) StatusCode() int {
-	if h.statusCode == 0 {
-		return StatusOK
-	}
 	return h.statusCode
 }
 
@@ -2502,6 +2499,9 @@ func (h *ResponseHeader) parseFirstLine(buf []byte) (int, error) {
 			return 0, fmt.Errorf("cannot parse response status code: %w", err)
 		}
 		return 0, fmt.Errorf("cannot parse response status code: %w. Response %q", err, buf)
+	}
+	if h.statusCode == 0 {
+		h.statusCode = 200
 	}
 	if len(b) > n && b[n] != ' ' {
 		if h.secureErrorLogMessage {

--- a/header_test.go
+++ b/header_test.go
@@ -359,8 +359,8 @@ func TestResponseHeaderDefaultStatusCode(t *testing.T) {
 
 	var h ResponseHeader
 	statusCode := h.StatusCode()
-	if statusCode != StatusOK {
-		t.Fatalf("unexpected status code: %d. Expecting %d", statusCode, StatusOK)
+	if statusCode != 0 {
+		t.Fatalf("unexpected status code: %d. Expecting %d", statusCode, 0)
 	}
 }
 


### PR DESCRIPTION
Closes  #1196