### PR TITLE
Fix scheme check for not yet parsed requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -1367,7 +1367,7 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 	req.secureErrorLogMessage = c.SecureErrorLogMessage
 	req.Header.secureErrorLogMessage = c.SecureErrorLogMessage
 
-	if c.IsTLS != req.uri.isHttps() {
+	if c.IsTLS != req.URI().isHttps() {
 		return false, ErrHostClientRedirectToDifferentScheme
 	}
 


### PR DESCRIPTION
At this point the request might not be parsed yet and set. In that case uri is empty and isHttps() returns always false. I don't expect this is intended?

Otherwise URL() must be called before actually passing the request to client.Do()