### PR TITLE
uri.go fast scheme comparison

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -224,21 +224,7 @@ func (u *URI) SetScheme(scheme string) {
 
 // SetSchemeBytes sets URI scheme, i.e. http, https, ftp, etc.
 func (u *URI) SetSchemeBytes(scheme []byte) {
-	if len(scheme) == 0 {
-		u.scheme = nil
-		return
-	}
-	if bytes.Equal(scheme, strHTTP) {
-		u.scheme = &strHTTP
-		return
-	}
-	if bytes.Equal(scheme, strHTTPS) {
-		u.scheme = &strHTTPS
-		return
-	}
-	newScheme := append([]byte(nil), scheme...) // copy scheme
-	lowercaseBytes(newScheme)
-	u.scheme = &newScheme
+	u.SetScheme(b2s(scheme))
 }
 
 func (u *URI) isHttps() bool {


### PR DESCRIPTION
The methods isHttps() and isHttp() checks that all bytes are equals bytes.Equal().
If the URI is reused for many requests then the bytes.Equal() call is performed on each request.
Another downside is that on SetScheme() memory is once allocated and copied.
FastHttp supports only http and https so instead we may store a strHTTP(S) constant and then just compare by reference.
But in Go byte slices doesn't have doesn't have an identity so we must use a pointer to a byte slice instead.

Also for a custom schemes (ftp, dav) the memory will be allocated instead of pointing to a constant. If really needed this may be changed in the future.