### PR TITLE
feature: Keep the memory usage of the service at a stable level

### DIFF
--- a/http.go
+++ b/http.go
@@ -22,8 +22,8 @@ var (
 	responseBodyPoolSizeLimit = -1
 )
 
-// SetBodySizePoolLimit set the max body limit in request and response
-// if the body size larger than the limit,it will be released
+// SetBodySizePoolLimit set the max body size for bodies to be returned to the pool.
+// If the body size is larger it will be released instead of put back into the pool for reuse.
 func SetBodySizePoolLimit(reqBodyLimit, respBodyLimit int) {
 	requestBodyPoolSizeLimit = reqBodyLimit
 	responseBodyPoolSizeLimit = respBodyLimit

--- a/http.go
+++ b/http.go
@@ -18,13 +18,13 @@ import (
 )
 
 var (
-	requestBodyMaxLimit  = 0
-	responseBodyMaxLimit = 0
+	requestBodyMaxLimit  = -1
+	responseBodyMaxLimit = -1
 )
 
-// SetBodyLimit set the max body limit in request and response
+// SetBodySizePoolLimit set the max body limit in request and response
 // if the body size larger than the limit,it will be released
-func SetBodyLimit(reqBodyMaxLimit, respBodyMaxLimit int) {
+func SetBodySizePoolLimit(reqBodyMaxLimit, respBodyMaxLimit int) {
 	requestBodyMaxLimit = reqBodyMaxLimit
 	responseBodyMaxLimit = respBodyMaxLimit
 }
@@ -969,7 +969,7 @@ func readMultipartForm(r io.Reader, boundary string, size, maxInMemoryFileSize i
 
 // Reset clears request contents.
 func (req *Request) Reset() {
-	if requestBodyMaxLimit > 0 && req.body != nil {
+	if requestBodyMaxLimit >= 0 && req.body != nil {
 		req.ReleaseBody(requestBodyMaxLimit)
 	}
 	req.Header.Reset()
@@ -1001,7 +1001,7 @@ func (req *Request) RemoveMultipartFormFiles() {
 
 // Reset clears response contents.
 func (resp *Response) Reset() {
-	if responseBodyMaxLimit > 0 && resp.body != nil {
+	if responseBodyMaxLimit >= 0 && resp.body != nil {
 		resp.ReleaseBody(responseBodyMaxLimit)
 	}
 	resp.Header.Reset()

--- a/http.go
+++ b/http.go
@@ -1012,8 +1012,6 @@ func (resp *Response) Reset() {
 	resp.ImmediateHeaderFlush = false
 }
 
-
-
 func (resp *Response) resetSkipHeader() {
 	resp.ResetBody()
 }

--- a/http.go
+++ b/http.go
@@ -1001,8 +1001,8 @@ func (req *Request) RemoveMultipartFormFiles() {
 
 // Reset clears response contents.
 func (resp *Response) Reset() {
-	if responseBodyMaxLimit >= 0 && resp.body != nil {
-		resp.ReleaseBody(responseBodyMaxLimit)
+	if responseBodyPoolSizeLimit >= 0 && resp.body != nil {
+		resp.ReleaseBody(responseBodyPoolSizeLimit)
 	}
 	resp.Header.Reset()
 	resp.resetSkipHeader()

--- a/http.go
+++ b/http.go
@@ -969,8 +969,8 @@ func readMultipartForm(r io.Reader, boundary string, size, maxInMemoryFileSize i
 
 // Reset clears request contents.
 func (req *Request) Reset() {
-	if requestBodyMaxLimit >= 0 && req.body != nil {
-		req.ReleaseBody(requestBodyMaxLimit)
+	if requestBodyPoolSizeLimit >= 0 && req.body != nil {
+		req.ReleaseBody(requestBodyPoolSizeLimit)
 	}
 	req.Header.Reset()
 	req.resetSkipHeader()

--- a/http.go
+++ b/http.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	requestBodyMaxLimit  = -1
-	responseBodyMaxLimit = -1
+	requestBodyPoolSizeLimit  = -1
+	responseBodyPoolSizeLimit = -1
 )
 
 // SetBodySizePoolLimit set the max body limit in request and response

--- a/http.go
+++ b/http.go
@@ -24,9 +24,9 @@ var (
 
 // SetBodySizePoolLimit set the max body limit in request and response
 // if the body size larger than the limit,it will be released
-func SetBodySizePoolLimit(reqBodyMaxLimit, respBodyMaxLimit int) {
-	requestBodyMaxLimit = reqBodyMaxLimit
-	responseBodyMaxLimit = respBodyMaxLimit
+func SetBodySizePoolLimit(reqBodyLimit, respBodyLimit int) {
+	requestBodyPoolSizeLimit = reqBodyLimit
+	responseBodyPoolSizeLimit = respBodyLimit
 }
 
 // Request represents HTTP request.

--- a/http.go
+++ b/http.go
@@ -17,6 +17,18 @@ import (
 	"github.com/valyala/bytebufferpool"
 )
 
+var (
+	requestBodyMaxLimit  = 0
+	responseBodyMaxLimit = 0
+)
+
+// SetBodyLimit set the max body limit in request and response
+// if the body size larger than the limit,it will be released
+func SetBodyLimit(reqBodyMaxLimit, respBodyMaxLimit int) {
+	requestBodyMaxLimit = reqBodyMaxLimit
+	responseBodyMaxLimit = respBodyMaxLimit
+}
+
 // Request represents HTTP request.
 //
 // It is forbidden copying Request instances. Create new instances
@@ -957,6 +969,9 @@ func readMultipartForm(r io.Reader, boundary string, size, maxInMemoryFileSize i
 
 // Reset clears request contents.
 func (req *Request) Reset() {
+	if requestBodyMaxLimit > 0 && req.body != nil {
+		req.ReleaseBody(requestBodyMaxLimit)
+	}
 	req.Header.Reset()
 	req.resetSkipHeader()
 	req.timeout = 0
@@ -986,6 +1001,9 @@ func (req *Request) RemoveMultipartFormFiles() {
 
 // Reset clears response contents.
 func (resp *Response) Reset() {
+	if responseBodyMaxLimit > 0 && resp.body != nil {
+		resp.ReleaseBody(responseBodyMaxLimit)
+	}
 	resp.Header.Reset()
 	resp.resetSkipHeader()
 	resp.SkipBody = false
@@ -993,6 +1011,8 @@ func (resp *Response) Reset() {
 	resp.laddr = nil
 	resp.ImmediateHeaderFlush = false
 }
+
+
 
 func (resp *Response) resetSkipHeader() {
 	resp.ResetBody()


### PR DESCRIPTION
add request and response body size limit, it prevents the large body from slowly stretching the memory of the entire service