### PR TITLE
fix: (useless check), skip Response body if http method HEAD

### DIFF
--- a/server.go
+++ b/server.go
@@ -2335,7 +2335,7 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 			timeoutResponse.CopyTo(&ctx.Response)
 		}
 
-		if !ctx.IsGet() && ctx.IsHead() {
+		if ctx.IsHead() {
 			ctx.Response.SkipBody = true
 		}
 


### PR DESCRIPTION
The header can't be both a HEAD and GET so checking both doesn't make any sense.