### PR TITLE
support adding/removing clients from LBClient

### DIFF
--- a/lbclient.go
+++ b/lbclient.go
@@ -50,7 +50,7 @@ type LBClient struct {
 	cs []*lbClient
 
 	once sync.Once
-	mu   sync.Mutex
+	mu   sync.RWMutex
 }
 
 // DefaultLBClientTimeout is the default request timeout used by LBClient
@@ -121,6 +121,7 @@ func (cc *LBClient) RemoveClients(rc func(BalancingClient) bool) int {
 func (cc *LBClient) get() *lbClient {
 	cc.once.Do(cc.init)
 
+	cc.mu.RLock()
 	cs := cc.cs
 
 	minC := cs[0]
@@ -135,6 +136,7 @@ func (cc *LBClient) get() *lbClient {
 			minT = t
 		}
 	}
+	cc.mu.RUnlock()
 	return minC
 }
 

--- a/lbclient.go
+++ b/lbclient.go
@@ -114,11 +114,13 @@ func (cc *LBClient) RemoveClients(rc func(BalancingClient) bool) int {
 	n := 0
 	for _, cs := range cc.cs {
 		if rc(cs.c) {
-			cs = nil
 			continue
 		}
 		cc.cs[n] = cs
 		n++
+	}
+	for i := n; i < len(cc.cs); i++ {
+		cc.cs[i] = nil
 	}
 	cc.cs = cc.cs[:n]
 

--- a/lbclient.go
+++ b/lbclient.go
@@ -92,9 +92,9 @@ func (cc *LBClient) init() {
 	}
 }
 
-// AddClient adds a new HostClient to the balanced clients
+// AddClient adds a new client to the balanced clients
 // returns the new total number of clients
-func (cc *LBClient) AddClient(c *HostClient) int {
+func (cc *LBClient) AddClient(c BalancingClient) int {
 	cc.mu.Lock()
 	cc.cs = append(cc.cs, &lbClient{
 		c:           c,
@@ -107,15 +107,10 @@ func (cc *LBClient) AddClient(c *HostClient) int {
 // RemoveClients removes clients using the provided callback
 // if rc returns true, the passed client will be removed
 // returns the new total number of clients
-func (cc *LBClient) RemoveClients(rc func(*HostClient) bool) int {
+func (cc *LBClient) RemoveClients(rc func(BalancingClient) bool) int {
 	cc.mu.Lock()
 	for idx, cs := range cc.cs {
-		// ignore non HostClient BalancingClients
-		hc, ok := cs.c.(*HostClient)
-		if !ok {
-			continue
-		}
-		if rc(hc) {
+		if rc(cs.c) {
 			cc.cs = append(cc.cs[:idx], cc.cs[idx+1])
 		}
 	}

--- a/lbclient.go
+++ b/lbclient.go
@@ -111,11 +111,17 @@ func (cc *LBClient) AddClient(c BalancingClient) int {
 // returns the new total number of clients
 func (cc *LBClient) RemoveClients(rc func(BalancingClient) bool) int {
 	cc.mu.Lock()
-	for idx, cs := range cc.cs {
+	n := 0
+	for _, cs := range cc.cs {
 		if rc(cs.c) {
-			cc.cs = append(cc.cs[:idx], cc.cs[idx+1:]...)
+			cs = nil
+			continue
 		}
+		cc.cs[n] = cs
+		n++
 	}
+	cc.cs = cc.cs[:n]
+
 	cc.mu.Unlock()
 	return len(cc.cs)
 }

--- a/lbclient.go
+++ b/lbclient.go
@@ -81,6 +81,7 @@ func (cc *LBClient) Do(req *Request, resp *Response) error {
 }
 
 func (cc *LBClient) init() {
+	cc.mu.Lock()
 	if len(cc.Clients) == 0 {
 		panic("BUG: LBClient.Clients cannot be empty")
 	}
@@ -90,6 +91,7 @@ func (cc *LBClient) init() {
 			healthCheck: cc.HealthCheck,
 		})
 	}
+	cc.mu.Unlock()
 }
 
 // AddClient adds a new client to the balanced clients

--- a/lbclient.go
+++ b/lbclient.go
@@ -82,6 +82,7 @@ func (cc *LBClient) Do(req *Request, resp *Response) error {
 
 func (cc *LBClient) init() {
 	cc.mu.Lock()
+	defer cc.mu.Unlock()
 	if len(cc.Clients) == 0 {
 		panic("BUG: LBClient.Clients cannot be empty")
 	}
@@ -91,7 +92,6 @@ func (cc *LBClient) init() {
 			healthCheck: cc.HealthCheck,
 		})
 	}
-	cc.mu.Unlock()
 }
 
 // AddClient adds a new client to the balanced clients

--- a/lbclient.go
+++ b/lbclient.go
@@ -113,7 +113,7 @@ func (cc *LBClient) RemoveClients(rc func(BalancingClient) bool) int {
 	cc.mu.Lock()
 	for idx, cs := range cc.cs {
 		if rc(cs.c) {
-			cc.cs = append(cc.cs[:idx], cc.cs[idx+1])
+			cc.cs = append(cc.cs[:idx], cc.cs[idx+1:]...)
 		}
 	}
 	cc.mu.Unlock()


### PR DESCRIPTION
addresses https://github.com/valyala/fasthttp/issues/504 and is a followup to https://github.com/valyala/fasthttp/pull/556, addressing the outstanding feedback.

Adds support for adding/removing clients from LBClient utilizing a mutex as well as a user-defined callback for determining which HostClients to be removed