### PR TITLE
Imporve AppendHTMLEscape fast path

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"net"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -19,19 +18,11 @@ import (
 
 // AppendHTMLEscape appends html-escaped s to dst and returns the extended dst.
 func AppendHTMLEscape(dst []byte, s string) []byte {
-	if strings.IndexByte(s, '&') < 0 &&
-		strings.IndexByte(s, '<') < 0 &&
-		strings.IndexByte(s, '>') < 0 &&
-		strings.IndexByte(s, '"') < 0 &&
-		strings.IndexByte(s, '\'') < 0 {
+	var (
+		prev int
+		sub  string
+	)
 
-		// fast path - nothing to escape
-		return append(dst, s...)
-	}
-
-	// slow path
-	var prev int
-	var sub string
 	for i, n := 0, len(s); i < n; i++ {
 		sub = ""
 		switch s[i] {


### PR DESCRIPTION
The `<` is occurs more frequently in the HTML string.

> Move `<`

```
name                 old time/op  new time/op  delta
AppendHTMLEscape-16  99.3ns ± 1%  93.8ns ± 1%  -5.50%  (p=0.000 n=10+10)
```

And I am wondering maybe we could disable the fast path? Looks like it is not used in most cases.

>  Disable fast path

```
name                 old time/op  new time/op  delta
AppendHTMLEscape-16  99.3ns ± 1%  82.3ns ± 3%  -17.10%  (p=0.000 n=10+10)
```
