### PR TITLE
bytesconv: add appropriate build tags for s390x

### DIFF
--- a/bytesconv_32.go
+++ b/bytesconv_32.go
@@ -1,5 +1,5 @@
-//go:build !amd64 && !arm64 && !ppc64 && !ppc64le
-// +build !amd64,!arm64,!ppc64,!ppc64le
+//go:build !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x
+// +build !amd64,!arm64,!ppc64,!ppc64le,!s390x
 
 package fasthttp
 

--- a/bytesconv_32_test.go
+++ b/bytesconv_32_test.go
@@ -1,5 +1,5 @@
-//go:build !amd64 && !arm64 && !ppc64 && !ppc64le
-// +build !amd64,!arm64,!ppc64,!ppc64le
+//go:build !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x
+// +build !amd64,!arm64,!ppc64,!ppc64le,!s390x
 
 package fasthttp
 

--- a/bytesconv_64.go
+++ b/bytesconv_64.go
@@ -1,5 +1,5 @@
-//go:build amd64 || arm64 || ppc64 || ppc64le
-// +build amd64 arm64 ppc64 ppc64le
+//go:build amd64 || arm64 || ppc64 || ppc64le || s390x
+// +build amd64 arm64 ppc64 ppc64le s390x
 
 package fasthttp
 

--- a/bytesconv_64_test.go
+++ b/bytesconv_64_test.go
@@ -1,5 +1,5 @@
-//go:build amd64 || arm64 || ppc64 || ppc64le
-// +build amd64 arm64 ppc64 ppc64le
+//go:build amd64 || arm64 || ppc64 || ppc64le || s390x
+// +build amd64 arm64 ppc64 ppc64le s390x
 
 package fasthttp
 


### PR DESCRIPTION
The bytesconv 32-bit tests fail on s390x, because it is a 64-bit
architecture. Add the appropriate build flags so that 32-bit tests do
not run on this architecture.