### PR TITLE
Fix goroutine leaks of updateServsrDate (#1241).

### DIFF
--- a/header.go
+++ b/header.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -2041,6 +2043,26 @@ func isOnlyCRLF(b []byte) bool {
 	return true
 }
 
+func updateServerDate() {
+	refreshServerDate()
+	go func() {
+		for {
+			time.Sleep(time.Second)
+			refreshServerDate()
+		}
+	}()
+}
+
+var (
+	serverDate     atomic.Value
+	serverDateOnce sync.Once // serverDateOnce.Do(updateServerDate)
+)
+
+func refreshServerDate() {
+	b := AppendHTTPDate(nil, time.Now())
+	serverDate.Store(b)
+}
+
 // Write writes response header to w.
 func (h *ResponseHeader) Write(w *bufio.Writer) error {
 	_, err := w.Write(h.Header())
@@ -2116,6 +2138,7 @@ func (h *ResponseHeader) AppendBytes(dst []byte) []byte {
 	}
 
 	if !h.noDefaultDate {
+		serverDateOnce.Do(updateServerDate)
 		dst = appendHeaderLine(dst, strDate, serverDate.Load().([]byte))
 	}
 

--- a/header.go
+++ b/header.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -2043,26 +2041,6 @@ func isOnlyCRLF(b []byte) bool {
 	return true
 }
 
-func updateServerDate() {
-	refreshServerDate()
-	go func() {
-		for {
-			time.Sleep(time.Second)
-			refreshServerDate()
-		}
-	}()
-}
-
-var (
-	serverDate     atomic.Value
-	serverDateOnce sync.Once // serverDateOnce.Do(updateServerDate)
-)
-
-func refreshServerDate() {
-	b := AppendHTTPDate(nil, time.Now())
-	serverDate.Store(b)
-}
-
 // Write writes response header to w.
 func (h *ResponseHeader) Write(w *bufio.Writer) error {
 	_, err := w.Write(h.Header())
@@ -2138,7 +2116,6 @@ func (h *ResponseHeader) AppendBytes(dst []byte) []byte {
 	}
 
 	if !h.noDefaultDate {
-		serverDateOnce.Do(updateServerDate)
 		dst = appendHeaderLine(dst, strDate, serverDate.Load().([]byte))
 	}
 

--- a/server.go
+++ b/server.go
@@ -1832,7 +1832,7 @@ func (s *Server) Serve(ln net.Listener) error {
 		}
 		s.setState(c, StateNew)
 		if !s.NoDefaultDate {
-			s.updateServerDate()
+			s.updateServerDateWithDone()
 		}
 		atomic.AddInt32(&s.open, 1)
 		if !wp.Serve(c) {
@@ -1993,7 +1993,7 @@ var (
 // ServeConn closes c before returning.
 func (s *Server) ServeConn(c net.Conn) error {
 	if !s.NoDefaultDate {
-		s.updateServerDate()
+		s.updateServerDateWithDone()
 	}
 	if s.MaxConnsPerIP > 0 {
 		pic := wrapPerIPConn(s, c)
@@ -2925,7 +2925,7 @@ func (c ConnState) String() string {
 	return stateName[c]
 }
 
-func (s *Server) updateServerDate() {
+func (s *Server) updateServerDateWithDone() {
 	serverDateOnce.Do(func() {
 		refreshServerDate()
 		go func() {
@@ -2940,14 +2940,4 @@ func (s *Server) updateServerDate() {
 			}
 		}()
 	})
-}
-
-var (
-	serverDate     atomic.Value
-	serverDateOnce sync.Once // serverDateOnce.Do(updateServerDate)
-)
-
-func refreshServerDate() {
-	b := AppendHTTPDate(nil, time.Now())
-	serverDate.Store(b)
 }


### PR DESCRIPTION
Fixes: #1241 

* updateServerDate's goroutine makes available to catch s.done closing