### PR TITLE
Update tlsClientHandshake

### DIFF
--- a/client.go
+++ b/client.go
@@ -1994,7 +1994,7 @@ func (c *HostClient) cachedTLSConfig(addr string) *tls.Config {
 // ErrTLSHandshakeTimeout indicates there is a timeout from tls handshake.
 var ErrTLSHandshakeTimeout = errors.New("tls handshake timed out")
 
-func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.Time) (conn net.Conn, err error) {
+func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.Time) (_ net.Conn, err error) {
 	defer func() {
 		if err != nil {
 			rawConn.Close()

--- a/client.go
+++ b/client.go
@@ -1994,14 +1994,14 @@ func (c *HostClient) cachedTLSConfig(addr string) *tls.Config {
 // ErrTLSHandshakeTimeout indicates there is a timeout from tls handshake.
 var ErrTLSHandshakeTimeout = errors.New("tls handshake timed out")
 
-func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.Time) (_ net.Conn, err error) {
+func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.Time) (_ net.Conn, retErr error) {
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			rawConn.Close()
 		}
 	}()
-	conn = tls.Client(rawConn, tlsConfig)
-	err = conn.SetReadDeadline(deadline)
+	conn := tls.Client(rawConn, tlsConfig)
+	err := conn.SetReadDeadline(deadline)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -1998,7 +1998,6 @@ func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.T
 	defer func() {
 		if err != nil {
 			rawConn.Close()
-			return nil, err
 		}
 	}()
 	conn = tls.Client(rawConn, tlsConfig)

--- a/client.go
+++ b/client.go
@@ -2001,11 +2001,7 @@ func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.T
 		}
 	}()
 	conn := tls.Client(rawConn, tlsConfig)
-	err := conn.SetReadDeadline(deadline)
-	if err != nil {
-		return nil, err
-	}
-	err = conn.SetWriteDeadline(deadline)
+	err := conn.SetDeadline(deadline)
 	if err != nil {
 		return nil, err
 	}
@@ -2016,11 +2012,7 @@ func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.T
 	if err != nil {
 		return nil, err
 	}
-	err = conn.SetReadDeadline(time.Time{})
-	if err != nil {
-		return nil, err
-	}
-	err = conn.SetWriteDeadline(time.Time{})
+	err = conn.SetDeadline(time.Time{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I have such a code in a production crawlers for more than 1 year and it was just fine.
Also we can cleanup peercertificates+verifiedChains slice with nils since they are not used after handshake and in case of many concurrent connections to the same server may occupy some space.
```go
tlsConn.Handshake()
...
state := tlsConn.ConnectionState()
for i := range state.PeerCertificates {
    state.PeerCertificates[i] = nil
}
for i := range state.VerifiedChains { // they contains references to peerCertificates
    state.VerifiedChains[i] = nil
}
```
in some cases it can free up pretty high amount of in-use space