### PR TITLE
Fix for neverending date updater goroutine

### DIFF
--- a/allocation_test.go
+++ b/allocation_test.go
@@ -47,7 +47,9 @@ func TestAllocationClient(t *testing.T) {
 		Handler: func(ctx *RequestCtx) {
 		},
 	}
-	go s.Serve(ln) //nolint:errcheck
+	go func() {
+		_ = s.Serve(ln) //nolint:errcheck
+	}()
 
 	c := &Client{}
 	url := "http://test:test@" + ln.Addr().String() + "/foo?bar=baz"

--- a/server_date.go
+++ b/server_date.go
@@ -12,18 +12,18 @@ type serverDateUpdater struct {
 	date       atomic.Value
 	stopCh     chan struct{}
 
-	zeroLenBuffer   []byte
+	zeroLenBuffer []byte
 
 	slowPathBufferMtx sync.Mutex
-	slowPathBuffer   []byte
-	slowPathLastTime time.Time
+	slowPathBuffer    []byte
+	slowPathLastTime  time.Time
 }
 
 var (
 	serverDateUpdaterData = serverDateUpdater{
-		useCounter:        0,
+		useCounter: 0,
 
-		zeroLenBuffer:     make([]byte, 0),
+		zeroLenBuffer: make([]byte, 0),
 
 		slowPathBuffer:    make([]byte, 0),
 		slowPathBufferMtx: sync.Mutex{},
@@ -68,7 +68,6 @@ func updateServerDate() {
 		}
 	}()
 }
-
 
 func refreshServerDate() {
 	b := AppendHTTPDate(nil, time.Now())

--- a/server_date.go
+++ b/server_date.go
@@ -1,0 +1,93 @@
+package fasthttp
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type serverDateUpdater struct {
+	mtx        sync.Mutex
+	useCounter int32
+	date       atomic.Value
+	stopCh     chan struct{}
+
+	zeroLenBuffer   []byte
+
+	slowPathBufferMtx sync.Mutex
+	slowPathBuffer   []byte
+	slowPathLastTime time.Time
+}
+
+var (
+	serverDateUpdaterData = serverDateUpdater{
+		useCounter:        0,
+
+		zeroLenBuffer:     make([]byte, 0),
+
+		slowPathBuffer:    make([]byte, 0),
+		slowPathBufferMtx: sync.Mutex{},
+		slowPathLastTime:  time.Now().AddDate(0, 0, -1),
+	}
+)
+
+// NOTE: Ensure one call to startServerDateUpdater matches always one call to stopServerDateUpdater
+func startServerDateUpdater() {
+	serverDateUpdaterData.mtx.Lock()
+	defer serverDateUpdaterData.mtx.Unlock()
+
+	serverDateUpdaterData.useCounter += 1
+	if serverDateUpdaterData.useCounter == 1 {
+		serverDateUpdaterData.stopCh = make(chan struct{})
+		go updateServerDate()
+	}
+}
+
+func stopServerDateUpdater() {
+	serverDateUpdaterData.mtx.Lock()
+	defer serverDateUpdaterData.mtx.Unlock()
+
+	serverDateUpdaterData.useCounter -= 1
+	if serverDateUpdaterData.useCounter == 0 {
+		close(serverDateUpdaterData.stopCh)
+		serverDateUpdaterData.date.Store(serverDateUpdaterData.zeroLenBuffer) // Store a dummy non-nil value
+	}
+}
+
+func updateServerDate() {
+	refreshServerDate()
+	go func() {
+		for {
+			select {
+			case <-serverDateUpdaterData.stopCh:
+				return
+
+			case <-time.After(time.Second):
+				refreshServerDate()
+			}
+		}
+	}()
+}
+
+
+func refreshServerDate() {
+	b := AppendHTTPDate(nil, time.Now())
+	serverDateUpdaterData.date.Store(b)
+}
+
+func getServerDate() []byte {
+	b, ok := serverDateUpdaterData.date.Load().([]byte)
+	if !ok || len(b) == 0 {
+		// Slow path, mostly used when requests are manually served by ServeConn
+		serverDateUpdaterData.mtx.Lock()
+		defer serverDateUpdaterData.mtx.Unlock()
+
+		now := time.Now()
+		if now.After(serverDateUpdaterData.slowPathLastTime) {
+			serverDateUpdaterData.slowPathLastTime = now.Add(time.Second)
+			serverDateUpdaterData.slowPathBuffer = AppendHTTPDate(nil, now)
+		}
+		return serverDateUpdaterData.slowPathBuffer
+	}
+	return b
+}


### PR DESCRIPTION
This patch aims to fix issue #1241 

Instead of launching a never ending go routine, the same routine is started and destroyed manually in the main listener loop.

Because connections can be processed by an external listener using the `ServeConn`, a specific behavior is used for this scenario. The slow path (because of mutex usage) returns a buffer that is updated every second.

BTW: Some linting was applied to minimize warnings.