### PR TITLE
Add an option to allow empty root in the fsHandler

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -230,10 +230,10 @@ type FS struct {
 	// Path to the root directory to serve files from.
 	Root string
 
-	// Empty root specifications are always filled with the absolute path which exists in the current execution location of the application
-	// with this setting you can prevent this, for example if you want to handle absolute and relative paths with the requestUri
-	//
-	// By default the setting is false
+	// AllowEmptyRoot controls what happens when Root is empty. When false (default) it will default to the
+	// current working directory. An empty root is mostly useful when you want to use absolute paths
+	// on windows that are on different filesystems. On linux setting your Root to "/" already allows you to use
+	// absolute paths on any filesystem.
 	AllowEmptyRoot bool
 
 	// List of index file names to try opening during directory access.

--- a/fs.go
+++ b/fs.go
@@ -391,7 +391,7 @@ func (fs *FS) NewRequestHandler() RequestHandler {
 func (fs *FS) initRequestHandler() {
 	root := fs.Root
 
-	// serve files from the current working directory if root is empty
+	// Serve files from the current working directory if Root is empty or if Root is a relative path.
 	if (!fs.AllowEmptyRoot && len(root) == 0) || (len(root) > 0 && !filepath.IsAbs(root)) {
 		path, err := os.Getwd()
 		if err != nil {

--- a/fs.go
+++ b/fs.go
@@ -398,9 +398,9 @@ func (fs *FS) initRequestHandler() {
 			path = "."
 		}
 		root = path + "/" + root
-		// convert the root directory slashes to the native format
-		root = filepath.FromSlash(root)
 	}
+	// convert the root directory slashes to the native format
+	root = filepath.FromSlash(root)
 
 	// strip trailing slashes from the root path
 	for len(root) > 0 && root[len(root)-1] == os.PathSeparator {

--- a/go.sum
+++ b/go.sum
@@ -19,7 +19,6 @@ golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 h1:nhht2DYV/Sn3qOayu8lM+cU1i
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=


### PR DESCRIPTION
Add an option to allow empty root in the fsHandler

this is necessary to restore the capabilities before the commit https://github.com/valyala/fasthttp/commit/c7576cc10cabfc9c993317a2d3f8355497bea156
and to allow further functionality to be docked from the outside which is not affected by setting the root dir afterwards

related to:
https://github.com/gofiber/fiber/pull/1882#issuecomment-1120832500