### PR TITLE
BodyDecoded() for request and responses

### DIFF
--- a/header.go
+++ b/header.go
@@ -371,6 +371,21 @@ func (h *RequestHeader) SetContentTypeBytes(contentType []byte) {
 	h.contentType = append(h.contentType[:0], contentType...)
 }
 
+// ContentEncoding returns Content-Encoding header value.
+func (h *RequestHeader) ContentEncoding() []byte {
+	return peekArgBytes(h.h, strContentEncoding)
+}
+
+// SetContentEncoding sets Content-Encoding header value.
+func (h *RequestHeader) SetContentEncoding(contentEncoding string) {
+	h.SetBytesK(strContentEncoding, contentEncoding)
+}
+
+// SetContentEncodingBytes sets Content-Encoding header value.
+func (h *RequestHeader) SetContentEncodingBytes(contentEncoding []byte) {
+	h.setNonSpecial(strContentEncoding, contentEncoding)
+}
+
 // SetMultipartFormBoundary sets the following Content-Type:
 // 'multipart/form-data; boundary=...'
 // where ... is substituted by the given boundary.

--- a/http_test.go
+++ b/http_test.go
@@ -1145,8 +1145,8 @@ func TestRequestReadGzippedBody(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if string(r.Header.Peek(HeaderContentEncoding)) != "gzip" {
-		t.Fatalf("unexpected content-encoding: %q. Expecting %q", r.Header.Peek(HeaderContentEncoding), "gzip")
+	if string(r.Header.ContentEncoding()) != "gzip" {
+		t.Fatalf("unexpected content-encoding: %q. Expecting %q", r.Header.ContentEncoding(), "gzip")
 	}
 	if r.Header.ContentLength() != len(body) {
 		t.Fatalf("unexpected content-length: %d. Expecting %d", r.Header.ContentLength(), len(body))

--- a/http_test.go
+++ b/http_test.go
@@ -347,6 +347,12 @@ func testResponseBodyStreamDeflate(t *testing.T, body []byte, bodySize int) {
 	if !bytes.Equal(respBody, body) {
 		t.Fatalf("unexpected body: %q. Expecting %q", respBody, body)
 	}
+	// check for invalid
+	resp.SetBodyRaw([]byte("invalid"))
+	_, errDeflate := resp.BodyInflate()
+	if errDeflate == nil || errDeflate.Error() != "zlib: invalid header" {
+		t.Fatalf("expected error: 'zlib: invalid header' but was %v", errDeflate)
+	}
 }
 
 func testResponseBodyStreamGzip(t *testing.T, body []byte, bodySize int) {
@@ -375,6 +381,12 @@ func testResponseBodyStreamGzip(t *testing.T, body []byte, bodySize int) {
 	if !bytes.Equal(respBody, body) {
 		t.Fatalf("unexpected body: %q. Expecting %q", respBody, body)
 	}
+	// check for invalid
+	resp.SetBodyRaw([]byte("invalid"))
+	_, errUnzip := resp.BodyGunzip()
+	if errUnzip == nil || errUnzip.Error() != "unexpected EOF" {
+		t.Fatalf("expected error: 'unexpected EOF' but was %v", errUnzip)
+	}
 }
 
 func TestResponseWriteGzipNilBody(t *testing.T) {
@@ -402,6 +414,46 @@ func TestResponseWriteDeflateNilBody(t *testing.T) {
 	}
 	if err := bw.Flush(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResponseBodyUncompressed(t *testing.T) {
+	body := "body"
+	var r Response
+	r.SetBodyStream(bytes.NewReader([]byte(body)), len(body))
+
+	w := &bytes.Buffer{}
+	bw := bufio.NewWriter(w)
+	if err := r.WriteDeflate(bw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resp Response
+	br := bufio.NewReader(w)
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ce := resp.Header.ContentEncoding()
+	if string(ce) != "deflate" {
+		t.Fatalf("unexpected Content-Encoding: %s", ce)
+	}
+	respBody, err := resp.BodyUncompressed()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(respBody) != body {
+		t.Fatalf("unexpected body: %q. Expecting %q", respBody, body)
+	}
+
+	// check for invalid encoding
+	resp.Header.SetContentEncoding("invalid")
+	_, decodeErr := resp.BodyUncompressed()
+	if decodeErr != ErrContentEncodingUnsupported {
+		t.Fatalf("unexpected error: %v", decodeErr)
 	}
 }
 


### PR DESCRIPTION
The new method returns a body and uncompress if it's gzipped.

For some reason I thought that the GetBody() will do the uncomression for me itself. And today I had a new client who sends me compressed requests. So I implemented the method but it should be in the library for simplicity. Also this allows to developers to see it in auto-completion list so they will check it and avoid the mistake that I made.