### PR TITLE
Add `ConnPoolStrategy` field to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ tags
 *.fasthttp.gz
 *.fasthttp.br
 .idea
+.vscode
 .DS_Store
 vendor/

--- a/client.go
+++ b/client.go
@@ -297,6 +297,9 @@ type Client struct {
 	// By default will use isIdempotent function
 	RetryIf RetryIfFunc
 
+	// Connection pool strategy. Can be either LIFO or FIFO (default).
+	ConnPoolStrategy ConnPoolStrategyType
+
 	// ConfigureClient configures the fasthttp.HostClient.
 	ConfigureClient func(hc *HostClient) error
 
@@ -510,6 +513,7 @@ func (c *Client) Do(req *Request, resp *Response) error {
 			DisablePathNormalizing:        c.DisablePathNormalizing,
 			MaxConnWaitTimeout:            c.MaxConnWaitTimeout,
 			RetryIf:                       c.RetryIf,
+			ConnPoolStrategy:              c.ConnPoolStrategy,
 			clientReaderPool:              &c.readerPool,
 			clientWriterPool:              &c.writerPool,
 		}


### PR DESCRIPTION
Add `ConnPoolStrategy` field to `fasthttp.Client`.

PTAL @erikdubbelboer 