### PR TITLE
fix shutdown fail

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -75,7 +75,6 @@ func (wp *workerPool) Stop() {
 		panic("BUG: workerPool wasn't started")
 	}
 	close(wp.stopCh)
-	wp.stopCh = nil
 
 	// Stop all the workers waiting for incoming connections.
 	// Do not wait for busy workers - they will stop after


### PR DESCRIPTION
When the server accepts the request, calling shutdown will permanently fail to exit.

Here is my test code.
```golang
	wg, ctx := errgroup.WithContext(context.Background())
	wg.Go(func() error {
		ch := make(chan os.Signal, 1)
		signal.Notify(ch, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT)
		select {
		case <-ctx.Done():
			return nil
		case sig := <-ch:
			return fmt.Errorf("server shutdown: %v", sig)
		}
	})
	s := &fasthttp.Server{Handler: r.Handler}
	wg.Go(func() error {
		return s.ListenAndServe(":8080")
	})
	wg.Go(func() error {
		<-ctx.Done()
		return s.Shutdown()
	})
	log.Fatal(wg.Wait())
```

In the logic of Shutdown, after the server accepts the request, `s.open` will never be `0`.
So the server process will not be able to exit.
```golang
	for {
		if open := atomic.LoadInt32(&s.open); open == 0 {
			break
		}
		// This is not an optimal solution but using a sync.WaitGroup
		// here causes data races as it's hard to prevent Add() to be called
		// while Wait() is waiting.
		time.Sleep(time.Millisecond * 100)
	}
```