### PR TITLE
Introduce FS.CompressRoot

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -797,7 +797,7 @@ func cleanCacheNolock(cache map[string]*fsFile, pendingFiles, filesToRelease []*
 }
 
 func (h *fsHandler) pathToFilePath(path string) string {
-	return h.root + filepath.FromSlash(path)
+	return filepath.FromSlash(h.root + path)
 }
 
 func (h *fsHandler) filePathToCompressed(filePath string) string {
@@ -807,7 +807,7 @@ func (h *fsHandler) filePathToCompressed(filePath string) string {
 	if !strings.HasPrefix(filePath, h.root) {
 		return filePath
 	}
-	return h.compressRoot + filePath[len(h.root):]
+	return filepath.FromSlash(h.compressRoot + filePath[len(h.root):])
 }
 
 func (h *fsHandler) handleRequest(ctx *RequestCtx) {

--- a/fs.go
+++ b/fs.go
@@ -876,7 +876,7 @@ func (h *fsHandler) handleRequest(ctx *RequestCtx) {
 				ctx.RedirectBytes(append(path, '/'), StatusFound)
 				return
 			}
-			ff, err = h.openIndexFile(ctx, pathStr, filePath, mustCompress, fileEncoding)
+			ff, err = h.openIndexFile(ctx, filePath, mustCompress, fileEncoding)
 			if err != nil {
 				ctx.Logger().Printf("cannot open dir index %q: %v", filePath, err)
 				ctx.Error("Directory index is forbidden", StatusForbidden)
@@ -1042,9 +1042,9 @@ func ParseByteRange(byteRange []byte, contentLength int) (startPos, endPos int, 
 	return startPos, endPos, nil
 }
 
-func (h *fsHandler) openIndexFile(ctx *RequestCtx, path, dirPath string, mustCompress bool, fileEncoding string) (*fsFile, error) {
+func (h *fsHandler) openIndexFile(ctx *RequestCtx, dirPath string, mustCompress bool, fileEncoding string) (*fsFile, error) {
 	for _, indexName := range h.indexNames {
-		indexFilePath := filepath.Join(dirPath, indexName)
+		indexFilePath := dirPath + "/" + indexName
 		ff, err := h.openFSFile(indexFilePath, mustCompress, fileEncoding)
 		if err == nil {
 			return ff, nil

--- a/fs.go
+++ b/fs.go
@@ -1174,7 +1174,7 @@ func (h *fsHandler) compressAndOpenFSFile(path, filePath string, fileEncoding st
 	if h.root == h.compressRoot {
 		compressedFilePath = filePath
 	} else {
-		compressedFilePath = filepath.FromSlash(h.compressRoot + path)
+		compressedFilePath = h.compressRoot + path
 		if err := os.MkdirAll(filepath.Dir(compressedFilePath), os.ModePerm); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I want to serve files on read-only Root with FS.Compress.

This may be one of solution, could you review it?

```go
fs := &fasthttp.FS {
    Root: "/read-only/html",
    Compress: true,
    CompressRoot: "/tmp/compressed",
}
```