### PR TITLE
Add BodyStream() method to Response

### DIFF
--- a/http.go
+++ b/http.go
@@ -353,6 +353,9 @@ func (resp *Response) Body() []byte {
 
 // BodyStream returns the response body as a stream.
 func (resp *Response) BodyStream() io.Reader {
+	if resp.bodyStream == nil {
+		return bytes.NewReader(resp.bodyBytes())
+	}
 	return resp.bodyStream
 }
 
@@ -479,6 +482,9 @@ func (resp *Response) BodyInflate() ([]byte, error) {
 }
 
 func (ctx *RequestCtx) RequestBodyStream() io.Reader {
+	if ctx.Request.bodyStream == nil {
+		return bytes.NewReader(ctx.Request.Body())
+	}
 	return ctx.Request.bodyStream
 }
 

--- a/http.go
+++ b/http.go
@@ -351,6 +351,11 @@ func (resp *Response) Body() []byte {
 	return resp.bodyBytes()
 }
 
+// BodyStream returns the response body as a stream.
+func (resp *Response) BodyStream() io.Reader {
+	return resp.bodyStream
+}
+
 func (resp *Response) bodyBytes() []byte {
 	if resp.bodyRaw != nil {
 		return resp.bodyRaw


### PR DESCRIPTION
Fixes #1340

@erikdubbelboer Please let me know if this works. I don't believe it should have an impact on performance since all it does is providing another accessor to a property that is otherwise already there.

PS: I also fixed a panic in `RequestCtx.RequestBodyStream()` if the bodyStream was nil (e.g. if the data was set as non-stream)