### PR TITLE
Prevent overflow and panic on large HTTP responses

### DIFF
--- a/http.go
+++ b/http.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net"
 	"os"
@@ -2277,6 +2278,11 @@ func round2(n int) int {
 	x |= x >> 4
 	x |= x >> 8
 	x |= x >> 16
+
+	// Make sure we don't return 0 due to overflow, even on 32 bit systems
+	if x >= uint32(math.MaxInt32) {
+		return math.MaxInt32
+	}
 
 	return int(x + 1)
 }

--- a/http_test.go
+++ b/http_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -1963,6 +1964,7 @@ func TestRound2(t *testing.T) {
 	testRound2(t, 8, 8)
 	testRound2(t, 9, 16)
 	testRound2(t, 0x10001, 0x20000)
+	testRound2(t, math.MaxInt32-1, math.MaxInt32)
 }
 
 func testRound2(t *testing.T, n, expectedRound2 int) {


### PR DESCRIPTION
The `round2` function in `http.go` didn't check for overflow when converting a `uint32` value +1 to an `int`. As a result, it could return 0 for large values, and hence attempting to handle a large response could result in a panic:

```
panic: runtime error: slice bounds out of range [:2930135446] with capacity 0

goroutine 36966 [running]:
github.com/valyala/fasthttp.appendBodyFixedSize(0xa1a1f8?, {0xa49b78?, 0x0?, 0x0?}, 0xa49b78?)
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/http.go:2166 +0x214
github.com/valyala/fasthttp.readBody(0xa1a140?, 0xc0403869c0?, 0xc02ef77cd0?, {0xa49b78?, 0xc02ef77cd0?, 0x6918e5?})
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/http.go:2085 +0x5d
github.com/valyala/fasthttp.(*Response).ReadBody(0xc00060ab60, 0xc0403869c0?, 0x0?)
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/http.go:1379 +0x186
github.com/valyala/fasthttp.(*Response).ReadLimitBody(0xc00060ab60, 0x7d7a98?, 0xc03ed69880?)
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/http.go:1348 +0xd8
github.com/valyala/fasthttp.(*HostClient).doNonNilReqResp(0xc001c47d40, 0xc000628a80, 0xc00060ab60)
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/client.go:1480 +0x570
github.com/valyala/fasthttp.(*HostClient).do(0xc0437abce0?, 0x0?, 0xc00060ab60)
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/client.go:1372 +0x79
github.com/valyala/fasthttp.(*HostClient).Do(0xc001c47d40, 0xc000628a80, 0xc0437abce0?)
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/client.go:1319 +0x91
github.com/valyala/fasthttp.(*Client).Do(0xc0000dc900, 0xc000628a80, 0x0?)
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/client.go:542 +0x59f
github.com/valyala/fasthttp.clientDoDeadline.func1()
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/client.go:1245 +0x79
created by github.com/valyala/fasthttp.clientDoDeadline
	/home/meta/go/pkg/mod/github.com/valyala/fasthttp@v1.38.0/client.go:1243 +0x46d
```

This patch fixes round2 to return a maximum value of `math.MaxInt32`, which seems to make sense given that the calculation is done using a `uint32`, and you probably don't want a bigger buffer than that even on 64 bit systems.