### PR TITLE
Reduce slice growth in adaptor

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -3,6 +3,7 @@
 package fasthttpadaptor
 
 import (
+	"io"
 	"net/http"
 
 	"github.com/valyala/fasthttp"
@@ -53,7 +54,7 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 			return
 		}
 
-		var w netHTTPResponseWriter
+		w := netHTTPResponseWriter{w: ctx.Response.BodyWriter()}
 		h.ServeHTTP(&w, r.WithContext(ctx))
 
 		ctx.SetStatusCode(w.StatusCode())
@@ -72,19 +73,19 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 			// If the Header does not contain a Content-Type line, Write adds a Content-Type set
 			// to the result of passing the initial 512 bytes of written data to DetectContentType.
 			l := 512
-			if len(w.body) < 512 {
-				l = len(w.body)
+			b := ctx.Response.Body()
+			if len(b) < 512 {
+				l = len(b)
 			}
-			ctx.Response.Header.Set(fasthttp.HeaderContentType, http.DetectContentType(w.body[:l]))
+			ctx.Response.Header.Set(fasthttp.HeaderContentType, http.DetectContentType(b[:l]))
 		}
-		ctx.Write(w.body) //nolint:errcheck
 	}
 }
 
 type netHTTPResponseWriter struct {
 	statusCode int
 	h          http.Header
-	body       []byte
+	w          io.Writer
 }
 
 func (w *netHTTPResponseWriter) StatusCode() int {
@@ -106,6 +107,5 @@ func (w *netHTTPResponseWriter) WriteHeader(statusCode int) {
 }
 
 func (w *netHTTPResponseWriter) Write(p []byte) (int, error) {
-	w.body = append(w.body, p...)
-	return len(p), nil
+	return w.w.Write(p)
 }


### PR DESCRIPTION
This PR improves the performance of `fasthttpadaptor` by reducing the overhead of slice growth.

The current adapter records all written body in a byte slice, which causes horrible overhead when the body is bigger than a few kilobytes. However, this is unnecessary as we can just pass the response writer of fasthttp.

https://github.com/valyala/fasthttp/blob/ea6052464e7221956dedf9b9a523f8f9892c3d3b/fasthttpadaptor/adaptor.go#L108-L111

I compared the performance by modifying the `ServerGet` tests with **32 KiB responses**.

The original `ServerGet` _without the adaptor_:

```
BenchmarkServerGet1ReqPerConn-4                          4658205              2622 ns/op               0 B/op          0 allocs/op
BenchmarkServerGet2ReqPerConn-4                          5202049              2466 ns/op               0 B/op          0 allocs/op
BenchmarkServerGet10ReqPerConn-4                         7114965              1754 ns/op               0 B/op          0 allocs/op
BenchmarkServerGet10KReqPerConn-4                        8304604              1486 ns/op               0 B/op          0 allocs/op
BenchmarkServerGet1ReqPerConn10KClients-4                4690203              2395 ns/op              12 B/op          0 allocs/op
BenchmarkServerGet2ReqPerConn10KClients-4                5133776              2260 ns/op               3 B/op          0 allocs/op
BenchmarkServerGet10ReqPerConn10KClients-4               7322839              1583 ns/op               1 B/op          0 allocs/op
BenchmarkServerGet100ReqPerConn10KClients-4              8498665              1402 ns/op               2 B/op          0 allocs/op
```

The `ServerGet` _with the current adaptor_:

```
BenchmarkAdaptorGet1ReqPerConn-4                 1000000             14145 ns/op           36900 B/op         33 allocs/op
BenchmarkAdaptorGet2ReqPerConn-4                  819870             13954 ns/op           36749 B/op         32 allocs/op
BenchmarkAdaptorGet10ReqPerConn-4                 932516             11769 ns/op           35295 B/op         30 allocs/op
BenchmarkAdaptorGet10KReqPerConn-4               1116939             10816 ns/op           34562 B/op         30 allocs/op
BenchmarkAdaptorGet1ReqPerConn10KClients-4        558528             24187 ns/op           46985 B/op         44 allocs/op
BenchmarkAdaptorGet2ReqPerConn10KClients-4        745404             14326 ns/op           40126 B/op         35 allocs/op
BenchmarkAdaptorGet10ReqPerConn10KClients-4       920809             10949 ns/op           36740 B/op         32 allocs/op
BenchmarkAdaptorGet100ReqPerConn10KClients-4     1320006              8900 ns/op           34945 B/op         30 allocs/op
```

The `ServerGet` _with the patched adaptor_:

```
BenchmarkAdaptorGet1ReqPerConn-4                 3693327              3372 ns/op            1911 B/op         30 allocs/op
BenchmarkAdaptorGet2ReqPerConn-4                 3534920              3360 ns/op            1887 B/op         29 allocs/op
BenchmarkAdaptorGet10ReqPerConn-4                4373206              2716 ns/op            1893 B/op         29 allocs/op
BenchmarkAdaptorGet10KReqPerConn-4               4955851              2424 ns/op            1776 B/op         29 allocs/op
BenchmarkAdaptorGet1ReqPerConn10KClients-4       2716551              4831 ns/op            3189 B/op         31 allocs/op
BenchmarkAdaptorGet2ReqPerConn10KClients-4       3118240              4085 ns/op            2953 B/op         30 allocs/op
BenchmarkAdaptorGet10ReqPerConn10KClients-4      4207117              3088 ns/op            2383 B/op         29 allocs/op
BenchmarkAdaptorGet100ReqPerConn10KClients-4     5002465              2379 ns/op            1926 B/op         29 allocs/op
```