### PR TITLE
byte to string unsafe conversion in fasthttpadaptor ConvertRequest method

### DIFF
--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -2,12 +2,11 @@ package fasthttpadaptor
 
 import (
 	"bytes"
+	"github.com/valyala/fasthttp"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"unsafe"
-
-	"github.com/valyala/fasthttp"
 )
 
 // ConvertRequest convert a fasthttp.Request to an http.Request
@@ -60,5 +59,6 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 }
 
 func b2s(b []byte) string {
+	/* #nosec G103 */
 	return *(*string)(unsafe.Pointer(&b))
 }

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -11,6 +11,9 @@ import (
 
 // ConvertRequest convert a fasthttp.Request to an http.Request
 // forServer should be set to true when the http.Request is going to passed to a http.Handler.
+//
+// The http.Request must not be used after the fasthttp handler has returned!
+// Memory in use by the http.Request will be reused after your handler has returned!
 func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) error {
 	body := ctx.PostBody()
 	strRequestURI := b2s(ctx.RequestURI())

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -2,11 +2,12 @@ package fasthttpadaptor
 
 import (
 	"bytes"
-	"github.com/valyala/fasthttp"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"unsafe"
+
+	"github.com/valyala/fasthttp"
 )
 
 // ConvertRequest convert a fasthttp.Request to an http.Request

--- a/fasthttpadaptor/request_test.go
+++ b/fasthttpadaptor/request_test.go
@@ -1,0 +1,26 @@
+package fasthttpadaptor
+
+import (
+	"github.com/valyala/fasthttp"
+	"net/http"
+	"testing"
+)
+
+func BenchmarkConvertRequest(b *testing.B) {
+	var httpReq http.Request
+
+	ctx := &fasthttp.RequestCtx{
+		Request: fasthttp.Request{
+			Header:        fasthttp.RequestHeader{},
+			UseHostHeader: false,
+		},
+	}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.Header.Set("x", "test")
+	ctx.Request.SetRequestURI("/test")
+	ctx.Request.SetHost("test")
+
+	for i := 0; i < b.N; i++ {
+		ConvertRequest(ctx, &httpReq, true)
+	}
+}

--- a/fasthttpadaptor/request_test.go
+++ b/fasthttpadaptor/request_test.go
@@ -17,10 +17,12 @@ func BenchmarkConvertRequest(b *testing.B) {
 	}
 	ctx.Request.Header.SetMethod("GET")
 	ctx.Request.Header.Set("x", "test")
+	ctx.Request.Header.Set("y", "test")
 	ctx.Request.SetRequestURI("/test")
 	ctx.Request.SetHost("test")
+	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		ConvertRequest(ctx, &httpReq, true)
+		_ = ConvertRequest(ctx, &httpReq, true)
 	}
 }


### PR DESCRIPTION
I changed the code to prevent string allocation by using unsafe conversion.

I wrote a benchmark test against changes.

Before:

![image](https://user-images.githubusercontent.com/12763626/190019770-e5ba1489-4799-422a-a518-3c5d4c3e28e3.png)

After unsafe conversion: 

![image](https://user-images.githubusercontent.com/12763626/190019683-10bcccfe-310d-4e02-b757-2d7a091ef021.png)
