### PR TITLE
fix: ignore body should not set content-length of streaming 

### DIFF
--- a/http.go
+++ b/http.go
@@ -1287,6 +1287,8 @@ func (req *Request) ContinueReadBodyStream(r *bufio.Reader, maxBodySize int, pre
 		// the end of body is determined by connection close.
 		// So just ignore request body for requests without
 		// 'Content-Length' and 'Transfer-Encoding' headers.
+
+		// refer to https://tools.ietf.org/html/rfc7230#section-3.3.2
 		if !req.Header.ignoreBody() {
 			req.Header.SetContentLength(0)
 		}

--- a/http.go
+++ b/http.go
@@ -1287,7 +1287,9 @@ func (req *Request) ContinueReadBodyStream(r *bufio.Reader, maxBodySize int, pre
 		// the end of body is determined by connection close.
 		// So just ignore request body for requests without
 		// 'Content-Length' and 'Transfer-Encoding' headers.
-		req.Header.SetContentLength(0)
+		if !req.Header.ignoreBody() {
+			req.Header.SetContentLength(0)
+		}
 		return nil
 	}
 

--- a/http_test.go
+++ b/http_test.go
@@ -1053,6 +1053,25 @@ func TestRequestReadNoBody(t *testing.T) {
 	}
 }
 
+func TestRequestReadNoBodyStreaming(t *testing.T) {
+	t.Parallel()
+
+	var r Request
+
+	r.Header.contentLength = -2
+
+	br := bufio.NewReader(bytes.NewBufferString("GET / HTTP/1.1\r\n\r\n"))
+	err := r.ContinueReadBodyStream(br, 0)
+	r.SetHost("foobar")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s := r.String()
+	if strings.Contains(s, "Content-Length: ") {
+		t.Fatalf("unexpected Content-Length")
+	}
+}
+
 func TestResponseWriteTo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
 https://github.com/valyala/fasthttp/pull/1022 only handle ContinueReadBody(), this pr handle ContinueReadBodyStream()