### PR TITLE
Request.SetTimeout

### DIFF
--- a/http.go
+++ b/http.go
@@ -2290,3 +2290,7 @@ func round2(n int) int {
 
 	return int(x + 1)
 }
+
+func (req *Request) SetTimeout(t time.Duration) {
+	req.timeout = t
+}

--- a/http.go
+++ b/http.go
@@ -2291,6 +2291,10 @@ func round2(n int) int {
 	return int(x + 1)
 }
 
+// SetTimeout sets timeout for the request.
+//
+// req.SetTimeout(t); c.Do(&req, &resp) is equivalent to
+// c.DoTimeout(&req, &resp, t)
 func (req *Request) SetTimeout(t time.Duration) {
 	req.timeout = t
 }


### PR DESCRIPTION
This functionally works the same as e.g. Client.DoTimeout(), but we can also use it for Client.DoRedirect(). There is no way as far as I can tell to set a timeout on a DoRedirect call, so this makes it possible.