### PR TITLE
fix form empty field error when used with pipe

### DIFF
--- a/http.go
+++ b/http.go
@@ -2001,7 +2001,7 @@ func writeBodyChunked(w *bufio.Writer, r io.Reader) error {
 		n, err = r.Read(buf)
 		if n == 0 {
 			if err == nil {
-				panic("BUG: io.Reader returned 0, nil")
+				continue
 			}
 			if err == io.EOF {
 				if err = writeChunk(w, buf[:0]); err != nil {


### PR DESCRIPTION
Fix towards issue #1408 

- Set the loop to continue instead of panic making room for next read
- Added test case for the same `TestRequestMultipartFormPipeEmptyFormField`