### PR TITLE
Fixed an error caused of character when @ > 1 during proxy authentication

### DIFF
--- a/fasthttpproxy/http.go
+++ b/fasthttpproxy/http.go
@@ -34,9 +34,12 @@ func FasthttpHTTPDialer(proxy string) fasthttp.DialFunc {
 func FasthttpHTTPDialerTimeout(proxy string, timeout time.Duration) fasthttp.DialFunc {
 	var auth string
 	if strings.Contains(proxy, "@") {
-		split := strings.Split(proxy, "@")
-		auth = base64.StdEncoding.EncodeToString([]byte(split[0]))
-		proxy = split[1]
+		index := strings.LastIndex(proxy, "@")
+		auth = base64.StdEncoding.EncodeToString([]byte(proxy[:index]))
+		proxy = proxy[index:][1:]
+		//split := strings.Split(proxy, "@")
+		//auth = base64.StdEncoding.EncodeToString([]byte(split[0]))
+		//proxy = split[1]
 	}
 
 	return func(addr string) (net.Conn, error) {


### PR DESCRIPTION
Example:
`c := &fasthttp.Client{
	Dial: fasthttpproxy.FasthttpHTTPDialerTimeout("admin:adminpass@123@localhost:9050", time.Second * 2),
}`
