### PR TITLE
fix adapter support http2

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -109,3 +109,5 @@ func (w *netHTTPResponseWriter) WriteHeader(statusCode int) {
 func (w *netHTTPResponseWriter) Write(p []byte) (int, error) {
 	return w.w.Write(p)
 }
+
+func (w *netHTTPResponseWriter) Flush() {}

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -25,8 +25,12 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 	}
 
 	r.Method = b2s(ctx.Method())
-	r.Proto = "HTTP/1.1"
-	r.ProtoMajor = 1
+	r.Proto = b2s(ctx.Request.Header.Protocol())
+	if r.Proto == "HTTP/2" {
+		r.ProtoMajor = 2
+	} else {
+		r.ProtoMajor = 1
+	}
 	r.ProtoMinor = 1
 	r.ContentLength = int64(len(body))
 	r.RemoteAddr = ctx.RemoteAddr().String()


### PR DESCRIPTION
Since the [adapter](fasthttpadaptor/request.go) hardcode `HTTP/1.1`:
```go
	r.Proto = "HTTP/1.1"
	r.ProtoMajor = 1
```

Maybe this is better?
```go
	r.Proto = b2s(ctx.Request.Header.Protocol())
	if r.Proto == "HTTP/2" {
		r.ProtoMajor = 2
	} else {
		r.ProtoMajor = 1
	}
```

With this change, compose  `fasthttp` and `grpc` together is possible.

Usage:
```go
// start server
ws := &fasthttp.Server{...}
http2.ConfigureServer(ws)
ws.ServeTLS(...)

// transform to grpc request
if bytes.Equal(ctx.Request.Header.ContentType(), grpcContentType) {
    fh := fasthttpadaptor.NewFastHTTPHandler(a.Rpc)
    fh(ctx)
    return
}
```
