### PR TITLE
fix: client may remove hostclient incorrectly

### DIFF
--- a/client.go
+++ b/client.go
@@ -569,6 +569,7 @@ func (c *Client) mCleaner(m map[string]*HostClient) {
 	}
 
 	for {
+		time.Sleep(sleep)
 		c.mLock.Lock()
 		for k, v := range m {
 			v.connsLock.Lock()
@@ -585,7 +586,6 @@ func (c *Client) mCleaner(m map[string]*HostClient) {
 		if mustStop {
 			break
 		}
-		time.Sleep(sleep)
 	}
 }
 


### PR DESCRIPTION
The cleaner may remove hostclient unexpectedly.
I find that client will start cleaner when the first hostclient created.
<img width="513" alt="image" src="https://user-images.githubusercontent.com/37136584/209786140-66fd519e-3c49-467b-8200-617bb2ebfa05.png">
The cleaner will remove hostclient if there is no conn in the hostclient. And cleaner will start judge logic immediately. At the same time, hostclient will create conn. So if client get the connsLock before hostclient create conn, the hostclient will be removed.
<img width="825" alt="image" src="https://user-images.githubusercontent.com/37136584/209789075-82fc8bda-1b67-4797-8a65-a70143db023e.png">
 It may cause resource leak.