### PR TITLE
client.go Simplify default UA logic

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -724,7 +724,7 @@ func TestClientDefaultUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if userAgentSeen != string(defaultUserAgent) {
+	if userAgentSeen != defaultUserAgent {
 		t.Fatalf("User-Agent defers %q != %q", userAgentSeen, defaultUserAgent)
 	}
 }

--- a/strings.go
+++ b/strings.go
@@ -2,7 +2,7 @@ package fasthttp
 
 var (
 	defaultServerName  = []byte("fasthttp")
-	defaultUserAgent   = []byte("fasthttp")
+	defaultUserAgent   = "fasthttp"
 	defaultContentType = []byte("text/plain; charset=utf-8")
 )
 


### PR DESCRIPTION
The getClientName() checks if !NoDefaultUserAgentHeader then returns the Client.Name field. But it also saves it to atomic field clientName. This is not needed and logic can be simplified. Previously the clientName vas a byte slice that was copied from c.Name and cached. See 02e0722fb73c6237818b8e5af55957eb919a7334

Fix #1458