### PR TITLE
server.go Simplify default Server name logic

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -401,8 +401,8 @@ func TestServerName(t *testing.T) {
 	}
 
 	resp := getReponse()
-	if !bytes.Contains(resp, []byte("\r\nServer: "+string(defaultServerName)+"\r\n")) {
-		t.Fatalf("Unexpected response %q expected Server: "+string(defaultServerName), resp)
+	if !bytes.Contains(resp, []byte("\r\nServer: "+defaultServerName+"\r\n")) {
+		t.Fatalf("Unexpected response %q expected Server: "+defaultServerName, resp)
 	}
 
 	// We can't just overwrite s.Name as fasthttp caches the name in an atomic.Value

--- a/strings.go
+++ b/strings.go
@@ -1,7 +1,7 @@
 package fasthttp
 
 var (
-	defaultServerName  = []byte("fasthttp")
+	defaultServerName  = "fasthttp"
 	defaultUserAgent   = "fasthttp"
 	defaultContentType = []byte("text/plain; charset=utf-8")
 )


### PR DESCRIPTION
The serverName atomic.Value field is used as a cache. This is not needed and logic can be simplified. See related #1458