### PR TITLE
fix: handling non-disc cases that do not begin with /

### DIFF
--- a/uri_windows.go
+++ b/uri_windows.go
@@ -4,10 +4,10 @@
 package fasthttp
 
 func addLeadingSlash(dst, src []byte) []byte {
-	// zero length and "C:/" case
-	if len(src) == 0 || (len(src) > 2 && src[1] != ':') {
+	// zero length 、"C:/" and "a" case
+	isDesk := len(src) > 2 && src[1] == ':'
+	if len(src) == 0 || (!isDesk && src[0] != '/') {
 		dst = append(dst, '/')
 	}
-
 	return dst
 }

--- a/uri_windows_test.go
+++ b/uri_windows_test.go
@@ -12,4 +12,7 @@ func TestURIPathNormalizeIssue86(t *testing.T) {
 	var u URI
 
 	testURIPathNormalize(t, &u, `C:\a\b\c\fs.go`, `C:\a\b\c\fs.go`)
+
+	// only "a"
+	testURIPathNormalize(t, &u, `a/b`, `/a/b`)
 }


### PR DESCRIPTION
Windows processing logic only considers non-disk characters and empty strings.
such as `"a/b"` will not add `'/'`