### PR TITLE
fix: modify normalizePath

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -631,7 +631,6 @@ func normalizePath(dst, src []byte) []byte {
 
 	if filepath.Separator == '\\' {
 		// remove \.\ parts
-		b = dst
 		for {
 			n := bytes.Index(b, strBackSlashDotBackSlash)
 			if n < 0 {
@@ -652,7 +651,8 @@ func normalizePath(dst, src []byte) []byte {
 			if nn < 0 {
 				nn = 0
 			}
-			n += len(strSlashDotDotBackSlash) - 1
+			nn++
+			n += len(strSlashDotDotBackSlash)
 			copy(b[nn:], b[n:])
 			b = b[:len(b)-n+nn]
 		}

--- a/uri_windows.go
+++ b/uri_windows.go
@@ -4,8 +4,9 @@
 package fasthttp
 
 func addLeadingSlash(dst, src []byte) []byte {
-	// zero length and "C:/" case
-	if len(src) == 0 || (len(src) > 2 && src[1] != ':') {
+	// zero length 、"C:/" and "a" case
+	isDisk := len(src) > 2 && src[1] == ':'
+	if len(src) == 0 || (!isDisk && src[0] != '/') {
 		dst = append(dst, '/')
 	}
 

--- a/uri_windows_test.go
+++ b/uri_windows_test.go
@@ -12,4 +12,12 @@ func TestURIPathNormalizeIssue86(t *testing.T) {
 	var u URI
 
 	testURIPathNormalize(t, &u, `C:\a\b\c\fs.go`, `C:\a\b\c\fs.go`)
+
+	testURIPathNormalize(t, &u, `a`, `/a`)
+
+	testURIPathNormalize(t, &u, "/../../../../../foo", "/foo")
+
+	testURIPathNormalize(t, &u, "/..\\..\\..\\..\\..\\", "/")
+
+	testURIPathNormalize(t, &u, "/..%5c..%5cfoo", "/foo")
 }


### PR DESCRIPTION
old result:
```
uri_test.go:211: Unexpected path "/foofoofoofoofoofoo". Expected "/foo". requestURI="/../../../../../foo"
```