### PR TITLE
Correct typos in comments and tests

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -387,7 +387,7 @@ func TestArgsStringCompose(t *testing.T) {
 	expectedS := "foo=bar&aa=bbb&%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82=%D0%BC%D0%B8%D1%80&bb&=xxxx&cvx=&novalue"
 	s := a.String()
 	if s != expectedS {
-		t.Fatalf("Unexpected string %q. Exected %q", s, expectedS)
+		t.Fatalf("Unexpected string %q. Expected %q", s, expectedS)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -811,7 +811,7 @@ type HostClient struct {
 	pendingRequests int32
 
 	// pendingClientRequests counts the number of requests that a Client is currently running using this HostClient.
-	// It will be incremented ealier than pendingRequests and will be used by Client to see if the HostClient is still in use.
+	// It will be incremented earlier than pendingRequests and will be used by Client to see if the HostClient is still in use.
 	pendingClientRequests int32
 
 	connsCleanerRun bool

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -85,7 +85,7 @@ func sendPostRequest() {
 			if err == io.EOF || err == nil {
 				fmt.Printf("DEBUG Parsed Response: %v\n", respEntity)
 			} else {
-				fmt.Fprintf(os.Stderr, "ERR failed to parse reponse: %v\n", err)
+				fmt.Fprintf(os.Stderr, "ERR failed to parse response: %v\n", err)
 			}
 		} else {
 			fmt.Fprintf(os.Stderr, "ERR invalid HTTP response code: %d\n", statusCode)

--- a/header.go
+++ b/header.go
@@ -3083,7 +3083,7 @@ func (s *headerScanner) next() bool {
 	n++
 	for len(s.b) > n && s.b[n] == ' ' {
 		n++
-		// the newline index is a relative index, and lines below trimed `s.b` by `n`,
+		// the newline index is a relative index, and lines below trimmed `s.b` by `n`,
 		// so the relative newline index also shifted forward. it's safe to decrease
 		// to a minus value, it means it's invalid, and will find the newline again.
 		s.nextNewLine--

--- a/header_test.go
+++ b/header_test.go
@@ -1883,7 +1883,7 @@ func TestRequestHeaderCookie(t *testing.T) {
 	h.SetCookie("привет", "мир")
 
 	if string(h.Cookie("foo")) != "bar" {
-		t.Fatalf("Unexpected cookie value %q. Exepcted %q", h.Cookie("foo"), "bar")
+		t.Fatalf("Unexpected cookie value %q. Expected %q", h.Cookie("foo"), "bar")
 	}
 	if string(h.Cookie("привет")) != "мир" {
 		t.Fatalf("Unexpected cookie value %q. Expected %q", h.Cookie("привет"), "мир")
@@ -1905,7 +1905,7 @@ func TestRequestHeaderCookie(t *testing.T) {
 	}
 
 	if !bytes.Equal(h1.Cookie("foo"), h.Cookie("foo")) {
-		t.Fatalf("Unexpected cookie value %q. Exepcted %q", h1.Cookie("foo"), h.Cookie("foo"))
+		t.Fatalf("Unexpected cookie value %q. Expected %q", h1.Cookie("foo"), h.Cookie("foo"))
 	}
 	h1.DelCookie("foo")
 	if len(h1.Cookie("foo")) > 0 {
@@ -1956,7 +1956,7 @@ func TestResponseHeaderCookieIssue4(t *testing.T) {
 	c.SetKey("foo")
 	h.Cookie(c)
 	if string(c.Value()) != "bar" {
-		t.Fatalf("Unexpected cookie value %q. Exepcted %q", c.Value(), "bar")
+		t.Fatalf("Unexpected cookie value %q. Expected %q", c.Value(), "bar")
 	}
 
 	if string(h.Peek(HeaderSetCookie)) != "foo=bar" {
@@ -1998,7 +1998,7 @@ func TestRequestHeaderCookieIssue313(t *testing.T) {
 	}
 
 	if string(h.Cookie("foo")) != "bar" {
-		t.Fatalf("Unexpected cookie value %q. Exepcted %q", h.Cookie("foo"), "bar")
+		t.Fatalf("Unexpected cookie value %q. Expected %q", h.Cookie("foo"), "bar")
 	}
 
 	if string(h.Peek(HeaderCookie)) != "foo=bar" {

--- a/http_test.go
+++ b/http_test.go
@@ -1750,7 +1750,7 @@ func TestRequestWriteRequestURINoHost(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if err := bw.Flush(); err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	var req1 Request
@@ -2382,7 +2382,7 @@ func TestReadBodyChunked(t *testing.T) {
 	// big body
 	testReadBodyChunked(t, 3*1024*1024)
 
-	// smaler body after big one
+	// smaller body after big one
 	testReadBodyChunked(t, 12343)
 }
 
@@ -2762,7 +2762,7 @@ func TestResponseImmediateHeaderFlushFixedLength(t *testing.T) {
 	}
 
 	if strings.Contains(w.String(), "xxx") {
-		t.Fatalf("Did not expext body to be written yet")
+		t.Fatalf("Did not expect body to be written yet")
 	}
 
 	<-cb
@@ -2844,7 +2844,7 @@ func TestResponseImmediateHeaderFlushChunked(t *testing.T) {
 	}
 
 	if strings.Contains(w.String(), "xxx") {
-		t.Fatalf("Did not expext body to be written yet")
+		t.Fatalf("Did not expect body to be written yet")
 	}
 
 	<-cb

--- a/server.go
+++ b/server.go
@@ -1234,7 +1234,7 @@ func (ctx *RequestCtx) RemoteAddr() net.Addr {
 
 // SetRemoteAddr sets remote address to the given value.
 //
-// Set nil value to resore default behaviour for using
+// Set nil value to restore default behaviour for using
 // connection remote address.
 func (ctx *RequestCtx) SetRemoteAddr(remoteAddr net.Addr) {
 	ctx.remoteAddr = remoteAddr

--- a/server_test.go
+++ b/server_test.go
@@ -1916,7 +1916,7 @@ func TestServerContinueHandler(t *testing.T) {
 	// The same server should not fail when handling the three different types of requests
 	// Regular requests
 	// Expect 100 continue accepted
-	// Exepect 100 continue denied
+	// Expect 100 continue denied
 	rw := &readWriter{}
 	for i := 0; i < 25; i++ {
 
@@ -1925,7 +1925,7 @@ func TestServerContinueHandler(t *testing.T) {
 		rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")
 		sendRequest(rw, StatusOK, "foobar")
 
-		// Regular Expect 100 continue reqeuests that are accepted
+		// Regular Expect 100 continue requests that are accepted
 		rw.r.Reset()
 		rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")
 		sendRequest(rw, StatusOK, "foobar")
@@ -2666,7 +2666,7 @@ func TestTimeoutHandlerSuccess(t *testing.T) {
 	serverCh := make(chan struct{})
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		close(serverCh)
 	}()
@@ -2677,7 +2677,7 @@ func TestTimeoutHandlerSuccess(t *testing.T) {
 		go func() {
 			conn, err := ln.Dial()
 			if err != nil {
-				t.Errorf("unexepcted error: %v", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 			if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -2724,7 +2724,7 @@ func TestTimeoutHandlerTimeout(t *testing.T) {
 	serverCh := make(chan struct{})
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		close(serverCh)
 	}()
@@ -2789,7 +2789,7 @@ func TestTimeoutHandlerTimeoutReuse(t *testing.T) {
 	}
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 
@@ -3358,7 +3358,7 @@ func TestShutdown(t *testing.T) {
 	serveCh := make(chan struct{})
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		_, err := ln.Dial()
 		if err == nil {
@@ -3370,7 +3370,7 @@ func TestShutdown(t *testing.T) {
 	go func() {
 		conn, err := ln.Dial()
 		if err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -3384,7 +3384,7 @@ func TestShutdown(t *testing.T) {
 	shutdownCh := make(chan struct{})
 	go func() {
 		if err := s.Shutdown(); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		shutdownCh <- struct{}{}
 	}()
@@ -3420,7 +3420,7 @@ func TestCloseOnShutdown(t *testing.T) {
 	serveCh := make(chan struct{})
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		_, err := ln.Dial()
 		if err == nil {
@@ -3432,7 +3432,7 @@ func TestCloseOnShutdown(t *testing.T) {
 	go func() {
 		conn, err := ln.Dial()
 		if err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -3446,7 +3446,7 @@ func TestCloseOnShutdown(t *testing.T) {
 	shutdownCh := make(chan struct{})
 	go func() {
 		if err := s.Shutdown(); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		shutdownCh <- struct{}{}
 	}()
@@ -3481,12 +3481,12 @@ func TestShutdownReuse(t *testing.T) {
 	}
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	conn, err := ln.Dial()
 	if err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -3494,17 +3494,17 @@ func TestShutdownReuse(t *testing.T) {
 	br := bufio.NewReader(conn)
 	verifyResponse(t, br, StatusOK, "aaa/bbb", "real response")
 	if err := s.Shutdown(); err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	ln = fasthttputil.NewInmemoryListener()
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	conn, err = ln.Dial()
 	if err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -3512,7 +3512,7 @@ func TestShutdownReuse(t *testing.T) {
 	br = bufio.NewReader(conn)
 	verifyResponse(t, br, StatusOK, "aaa/bbb", "real response")
 	if err := s.Shutdown(); err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -3528,12 +3528,12 @@ func TestShutdownDone(t *testing.T) {
 	}
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	conn, err := ln.Dial()
 	if err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -3542,7 +3542,7 @@ func TestShutdownDone(t *testing.T) {
 		// Shutdown won't return if the connection doesn't close,
 		// which doesn't happen until we read the response.
 		if err := s.Shutdown(); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	// We can only reach this point and get a valid response
@@ -3567,12 +3567,12 @@ func TestShutdownErr(t *testing.T) {
 
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	conn, err := ln.Dial()
 	if err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -3581,7 +3581,7 @@ func TestShutdownErr(t *testing.T) {
 		// Shutdown won't return if the connection doesn't close,
 		// which doesn't happen until we read the response.
 		if err := s.Shutdown(); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	// We can only reach this point and get a valid response
@@ -3601,12 +3601,12 @@ func TestShutdownCloseIdleConns(t *testing.T) {
 	}
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	conn, err := ln.Dial()
 	if err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
@@ -3626,7 +3626,7 @@ func TestShutdownCloseIdleConns(t *testing.T) {
 		t.Fatal("idle connections not closed on shutdown")
 	case err = <-shutdownErr:
 		if err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}
 }
@@ -3643,14 +3643,14 @@ func TestShutdownWithContext(t *testing.T) {
 	}
 	go func() {
 		if err := s.Serve(ln); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	time.Sleep(1 * time.Second)
 	go func() {
 		conn, err := ln.Dial()
 		if err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 
 		if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
@@ -3696,18 +3696,18 @@ func TestMultipleServe(t *testing.T) {
 
 	go func() {
 		if err := s.Serve(ln1); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 	go func() {
 		if err := s.Serve(ln2); err != nil {
-			t.Errorf("unexepcted error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 	}()
 
 	conn, err := ln1.Dial()
 	if err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -3717,7 +3717,7 @@ func TestMultipleServe(t *testing.T) {
 
 	conn, err = ln2.Dial()
 	if err != nil {
-		t.Fatalf("unexepcted error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/stackless/func_timing_test.go
+++ b/stackless/func_timing_test.go
@@ -19,7 +19,7 @@ func BenchmarkFuncOverhead(b *testing.B) {
 		}
 	})
 	if n != uint64(b.N) {
-		b.Fatalf("unexected n: %d. Expecting %d", n, b.N)
+		b.Fatalf("unexpected n: %d. Expecting %d", n, b.N)
 	}
 }
 
@@ -35,6 +35,6 @@ func BenchmarkFuncPure(b *testing.B) {
 		}
 	})
 	if n != uint64(b.N) {
-		b.Fatalf("unexected n: %d. Expecting %d", n, b.N)
+		b.Fatalf("unexpected n: %d. Expecting %d", n, b.N)
 	}
 }

--- a/uri_test.go
+++ b/uri_test.go
@@ -314,13 +314,13 @@ func testURIParseScheme(t *testing.T, uri, expectedScheme, expectedHost, expecte
 		t.Fatalf("Unexpected scheme %q. Expecting %q for uri %q", u.Scheme(), expectedScheme, uri)
 	}
 	if string(u.Host()) != expectedHost {
-		t.Fatalf("Unexepcted host %q. Expecting %q for uri %q", u.Host(), expectedHost, uri)
+		t.Fatalf("Unexpected host %q. Expecting %q for uri %q", u.Host(), expectedHost, uri)
 	}
 	if string(u.RequestURI()) != expectedRequestURI {
-		t.Fatalf("Unexepcted requestURI %q. Expecting %q for uri %q", u.RequestURI(), expectedRequestURI, uri)
+		t.Fatalf("Unexpected requestURI %q. Expecting %q for uri %q", u.RequestURI(), expectedRequestURI, uri)
 	}
 	if string(u.hash) != expectedHash {
-		t.Fatalf("Unexepcted hash %q. Expecting %q for uri %q", u.hash, expectedHash, uri)
+		t.Fatalf("Unexpected hash %q. Expecting %q for uri %q", u.hash, expectedHash, uri)
 	}
 }
 


### PR DESCRIPTION
Changes:
- Exected -> Expected
- ealier -> earlier
- reponse -> response
- trimed -> trimmed
- resore -> restore
- unexected -> unexpected