### PR TITLE
Refactor golangci-lint config and remove redundant nolints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.51.1
-        args: --exclude-use-default --enable=nolintlint --enable=gochecknoinits --verbose
+        args: --enable=nolintlint --enable=gochecknoinits --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,37 +12,10 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: 1.20.x
-
-    - name: Get Go cache paths
-      id: go-env
-      run: |
-        echo "::set-output name=cache::$(go env GOCACHE)"
-        echo "::set-output name=modcache::$(go env GOMODCACHE)"
-    - name: Set up Go cache
-      uses: actions/cache@v3
-      with:
-        key: golangci-lint-${{ runner.os }}-go-${{ hashFiles('go.mod') }}
-        restore-keys: golangci-lint-${{ runner.os }}-go-
-        path: |
-          ${{ steps.go-env.outputs.cache }}
-          ${{ steps.go-env.outputs.modcache }}
-
-    - name: Install golangci-lint
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
-
-    - name: Get golangci-lint cache path
-      id: golangci-lint-cache-status
-      run: |
-        echo "::set-output name=dir::$(golangci-lint cache status | head -1 | sed 's/^Dir: //')"
-
-    - name: Set up golangci-lint cache
-      uses: actions/cache@v3
-      with:
-        key: golangci-lint-${{ runner.os }}-golangci-lint-${{ hashFiles('go.mod') }}
-        restore-keys: golangci-lint-${{ runner.os }}-golangci-lint-
-        path: ${{ steps.golangci-lint-cache-status.outputs.dir }}
-
     - run: go version
     - run: diff -u <(echo -n) <(gofmt -d .)
     - name: Run golangci-lint
-      run: golangci-lint run
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.51.1
+        args: --exclude-use-default --enable=nolintlint --enable=gochecknoinits --verbose

--- a/args.go
+++ b/args.go
@@ -44,7 +44,7 @@ var argsPool = &sync.Pool{
 //
 // Args instance MUST NOT be used from concurrently running goroutines.
 type Args struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	args []argsKV
 	buf  []byte

--- a/args_test.go
+++ b/args_test.go
@@ -336,8 +336,8 @@ func testCopyTo(t *testing.T, a *Args) {
 	var b Args
 	a.CopyTo(&b)
 
-	if !reflect.DeepEqual(*a, b) { //nolint
-		t.Fatalf("ArgsCopyTo fail, a: \n%+v\nb: \n%+v\n", *a, b) //nolint
+	if !reflect.DeepEqual(*a, b) { //nolint:govet
+		t.Fatalf("ArgsCopyTo fail, a: \n%+v\nb: \n%+v\n", *a, b) //nolint:govet
 	}
 
 	b.VisitAll(func(k, _ []byte) {

--- a/client.go
+++ b/client.go
@@ -179,7 +179,7 @@ var defaultClient Client
 //
 // The fields of a Client should not be changed while it is in use.
 type Client struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Client name. Used in User-Agent request header.
 	//
@@ -642,7 +642,7 @@ const (
 //
 // It is safe calling HostClient methods from concurrently running goroutines.
 type HostClient struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Comma-separated list of upstream HTTP server host addresses,
 	// which are passed to Dial in a round-robin manner.
@@ -2165,7 +2165,7 @@ func (q *wantConnQueue) clearFront() (cleaned bool) {
 // It is safe calling PipelineClient methods from concurrently running
 // goroutines.
 type PipelineClient struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Address of the host to connect to.
 	Addr string
@@ -2279,7 +2279,7 @@ type PipelineClient struct {
 }
 
 type pipelineConnClient struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	Addr                          string
 	Name                          string

--- a/cookie.go
+++ b/cookie.go
@@ -65,7 +65,7 @@ var cookiePool = &sync.Pool{
 //
 // Cookie instance MUST NOT be used from concurrently running goroutines.
 type Cookie struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	key    []byte
 	value  []byte

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -102,7 +102,7 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	req.Header.SetMethod(expectedMethod)
 	req.SetRequestURI(expectedRequestURI)
 	req.Header.SetHost(expectedHost)
-	req.BodyWriter().Write([]byte(expectedBody)) // nolint:errcheck
+	req.BodyWriter().Write([]byte(expectedBody)) //nolint:errcheck
 	for k, v := range expectedHeader {
 		req.Header.Set(k, v)
 	}

--- a/fasthttputil/inmemory_listener.go
+++ b/fasthttputil/inmemory_listener.go
@@ -121,8 +121,8 @@ func (ln *InmemoryListener) DialWithLocalAddr(local net.Addr) (net.Conn, error) 
 		// Wait until the connection has been accepted.
 		<-accepted
 	} else {
-		sConn.Close() //nolint:errcheck
-		cConn.Close() //nolint:errcheck
+		sConn.Close()
+		cConn.Close()
 		cConn = nil
 	}
 	ln.lock.Unlock()

--- a/fasthttputil/inmemory_listener.go
+++ b/fasthttputil/inmemory_listener.go
@@ -121,8 +121,8 @@ func (ln *InmemoryListener) DialWithLocalAddr(local net.Addr) (net.Conn, error) 
 		// Wait until the connection has been accepted.
 		<-accepted
 	} else {
-		sConn.Close()
-		cConn.Close()
+		_ = sConn.Close()
+		_ = cConn.Close()
 		cConn = nil
 	}
 	ln.lock.Unlock()

--- a/fs.go
+++ b/fs.go
@@ -223,7 +223,7 @@ func NewPathPrefixStripper(prefixSize int) PathRewriteFunc {
 //
 // It is prohibited copying FS values. Create new values instead.
 type FS struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Path to the root directory to serve files from.
 	Root string

--- a/header.go
+++ b/header.go
@@ -24,7 +24,7 @@ const (
 // ResponseHeader instance MUST NOT be used from concurrently running
 // goroutines.
 type ResponseHeader struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	disableNormalizing   bool
 	noHTTP11             bool
@@ -59,7 +59,7 @@ type ResponseHeader struct {
 // RequestHeader instance MUST NOT be used from concurrently running
 // goroutines.
 type RequestHeader struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	disableNormalizing   bool
 	noHTTP11             bool

--- a/http.go
+++ b/http.go
@@ -37,7 +37,7 @@ func SetBodySizePoolLimit(reqBodyLimit, respBodyLimit int) {
 //
 // Request instance MUST NOT be used from concurrently running goroutines.
 type Request struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Request header
 	//
@@ -81,7 +81,7 @@ type Request struct {
 //
 // Response instance MUST NOT be used from concurrently running goroutines.
 type Response struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Response header
 	//

--- a/http_test.go
+++ b/http_test.go
@@ -1371,9 +1371,9 @@ func TestResponseGzipStream(t *testing.T) {
 		w.Flush()
 		time.Sleep(time.Millisecond)
 		w.Write([]byte("barbaz")) //nolint:errcheck
-		w.Flush()                 //nolint:errcheck
+		w.Flush()
 		time.Sleep(time.Millisecond)
-		fmt.Fprintf(w, "1234") //nolint:errcheck
+		fmt.Fprintf(w, "1234")
 		if err := w.Flush(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1392,11 +1392,11 @@ func TestResponseDeflateStream(t *testing.T) {
 		t.Fatalf("IsBodyStream must return false")
 	}
 	r.SetBodyStreamWriter(func(w *bufio.Writer) {
-		w.Write([]byte("foo"))   //nolint:errcheck
-		w.Flush()                //nolint:errcheck
-		fmt.Fprintf(w, "barbaz") //nolint:errcheck
-		w.Flush()                //nolint:errcheck
-		w.Write([]byte("1234"))  //nolint:errcheck
+		w.Write([]byte("foo")) //nolint:errcheck
+		w.Flush()
+		fmt.Fprintf(w, "barbaz")
+		w.Flush()
+		w.Write([]byte("1234")) //nolint:errcheck
 		if err := w.Flush(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/http_test.go
+++ b/http_test.go
@@ -1370,10 +1370,10 @@ func TestResponseGzipStream(t *testing.T) {
 		fmt.Fprintf(w, "foo")
 		w.Flush()
 		time.Sleep(time.Millisecond)
-		w.Write([]byte("barbaz")) //nolint:errcheck
-		w.Flush()
+		_, _ = w.Write([]byte("barbaz"))
+		_ = w.Flush()
 		time.Sleep(time.Millisecond)
-		fmt.Fprintf(w, "1234")
+		_, _ = fmt.Fprintf(w, "1234")
 		if err := w.Flush(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1392,11 +1392,11 @@ func TestResponseDeflateStream(t *testing.T) {
 		t.Fatalf("IsBodyStream must return false")
 	}
 	r.SetBodyStreamWriter(func(w *bufio.Writer) {
-		w.Write([]byte("foo")) //nolint:errcheck
-		w.Flush()
-		fmt.Fprintf(w, "barbaz")
-		w.Flush()
-		w.Write([]byte("1234")) //nolint:errcheck
+		_, _ = w.Write([]byte("foo"))
+		_ = w.Flush()
+		_, _ = fmt.Fprintf(w, "barbaz")
+		_ = w.Flush()
+		_, _ = w.Write([]byte("1234"))
 		if err := w.Flush(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/lbclient.go
+++ b/lbclient.go
@@ -25,7 +25,7 @@ type BalancingClient interface {
 //
 // It is safe calling LBClient methods from concurrently running goroutines.
 type LBClient struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Clients must contain non-zero clients list.
 	// Incoming requests are balanced among these clients.

--- a/nocopy.go
+++ b/nocopy.go
@@ -5,7 +5,7 @@ package fasthttp
 //
 // See https://github.com/golang/go/issues/8005#issuecomment-190753527 for details.
 // and also: https://stackoverflow.com/questions/52494458/nocopy-minimal-example
-type noCopy struct{} //nolint:unused
+type noCopy struct{}
 
-func (*noCopy) Lock()   {} //nolint:unused
-func (*noCopy) Unlock() {} //nolint:unused
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}

--- a/server.go
+++ b/server.go
@@ -148,7 +148,7 @@ type ServeHandler func(c net.Conn) error
 //
 // It is safe to call Server methods from concurrently running goroutines.
 type Server struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Handler for processing incoming requests.
 	//
@@ -577,7 +577,7 @@ func CompressHandlerBrotliLevel(h RequestHandler, brotliLevel, otherLevel int) R
 // running goroutines. The only exception is TimeoutError*, which may be called
 // while other goroutines accessing RequestCtx.
 type RequestCtx struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	// Incoming request.
 	//
@@ -1950,12 +1950,12 @@ func acceptConn(s *Server, ln net.Listener, lastPerIPErrorTime *time.Time) (net.
 
 		if tc, ok := c.(*net.TCPConn); ok && s.TCPKeepalive {
 			if err := tc.SetKeepAlive(s.TCPKeepalive); err != nil {
-				tc.Close() //nolint:errcheck
+				tc.Close()
 				return nil, err
 			}
 			if s.TCPKeepalivePeriod > 0 {
 				if err := tc.SetKeepAlivePeriod(s.TCPKeepalivePeriod); err != nil {
-					tc.Close() //nolint:errcheck
+					tc.Close()
 					return nil, err
 				}
 			}

--- a/server.go
+++ b/server.go
@@ -1950,12 +1950,12 @@ func acceptConn(s *Server, ln net.Listener, lastPerIPErrorTime *time.Time) (net.
 
 		if tc, ok := c.(*net.TCPConn); ok && s.TCPKeepalive {
 			if err := tc.SetKeepAlive(s.TCPKeepalive); err != nil {
-				tc.Close()
+				_ = tc.Close()
 				return nil, err
 			}
 			if s.TCPKeepalivePeriod > 0 {
 				if err := tc.SetKeepAlivePeriod(s.TCPKeepalivePeriod); err != nil {
-					tc.Close()
+					_ = tc.Close()
 					return nil, err
 				}
 			}

--- a/uri.go
+++ b/uri.go
@@ -40,7 +40,7 @@ var uriPool = &sync.Pool{
 //
 // URI instance MUST NOT be used from concurrently running goroutines.
 type URI struct {
-	noCopy noCopy //nolint:unused,structcheck
+	noCopy noCopy
 
 	pathOriginal []byte
 	scheme       []byte


### PR DESCRIPTION
This PR does the following:
- add additional linter run options in GitHub lint's workflow;
- remove unused `//nolint` comments;
- use [`golangci-lint-action`](https://github.com/golangci/golangci-lint-action) because it's shorted and caches data.

Options:
- `--verbose` for clear visibility of which set of linters is run;
- `--enable=gochecknoinits` enables `gochecknoinits` (the repo has one `init()` which already `nolint`ed);
- `--enable=nolintlint` enables linter that reports redundant `//nolint` comments.

`structcheck` linter is deprecated and automatically disabled by `golangci-lint`.