### PR TITLE
Rename unexported funcs, vars to match common Go

### DIFF
--- a/client.go
+++ b/client.go
@@ -470,9 +470,9 @@ func (c *Client) Do(req *Request, resp *Response) error {
 	host := uri.Host()
 
 	isTLS := false
-	if uri.isHttps() {
+	if uri.isHTTPS() {
 		isTLS = true
-	} else if !uri.isHttp() {
+	} else if !uri.isHTTP() {
 		return fmt.Errorf("unsupported protocol %q. http and https are supported", uri.Scheme())
 	}
 
@@ -1308,7 +1308,7 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 	req.secureErrorLogMessage = c.SecureErrorLogMessage
 	req.Header.secureErrorLogMessage = c.SecureErrorLogMessage
 
-	if c.IsTLS != req.URI().isHttps() {
+	if c.IsTLS != req.URI().isHTTPS() {
 		return false, ErrHostClientRedirectToDifferentScheme
 	}
 
@@ -2003,11 +2003,11 @@ func AddMissingPort(addr string, isTLS bool) string {
 		return addr
 	}
 
-	isIp6 := addr[0] == '['
-	if isIp6 {
+	isIP6 := addr[0] == '['
+	if isIP6 {
 		// if the IPv6 has opening bracket but closing bracket is the last char then it doesn't have a port
-		isIp6WithoutPort := addr[addrLen-1] == ']'
-		if !isIp6WithoutPort {
+		isIP6WithoutPort := addr[addrLen-1] == ']'
+		if !isIP6WithoutPort {
 			return addr
 		}
 	} else { // IPv4

--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -51,7 +51,7 @@ func TestRstConnResponseWhileSending(t *testing.T) {
 		}
 	}()
 
-	svrUrl := "http://" + srv.Addr().String()
+	srvURL := "http://" + srv.Addr().String()
 	client := HostClient{Addr: srv.Addr().String()}
 
 	for i := 0; i < 100; i++ {
@@ -62,7 +62,7 @@ func TestRstConnResponseWhileSending(t *testing.T) {
 
 		req.Header.SetMethod("POST")
 		req.SetBodyStream(strings.NewReader(payload), len(payload))
-		req.SetRequestURI(svrUrl)
+		req.SetRequestURI(srvURL)
 
 		err = client.Do(req, resp)
 		if err != nil {
@@ -113,7 +113,7 @@ func TestRstConnClosedWithoutResponse(t *testing.T) {
 		}
 	}()
 
-	svrUrl := "http://" + srv.Addr().String()
+	srvURL := "http://" + srv.Addr().String()
 	client := HostClient{Addr: srv.Addr().String()}
 
 	for i := 0; i < 100; i++ {
@@ -124,7 +124,7 @@ func TestRstConnClosedWithoutResponse(t *testing.T) {
 
 		req.Header.SetMethod("POST")
 		req.SetBodyStream(strings.NewReader(payload), len(payload))
-		req.SetRequestURI(svrUrl)
+		req.SetRequestURI(srvURL)
 
 		err = client.Do(req, resp)
 

--- a/http.go
+++ b/http.go
@@ -852,9 +852,9 @@ func (req *Request) URI() *URI {
 // Use this method if a single URI may be reused across multiple requests.
 // Otherwise, you can just use SetRequestURI() and it will be parsed as new URI.
 // The URI is copied and can be safely modified later.
-func (req *Request) SetURI(newUri *URI) {
-	if newUri != nil {
-		newUri.CopyTo(&req.uri)
+func (req *Request) SetURI(newURI *URI) {
+	if newURI != nil {
+		newURI.CopyTo(&req.uri)
 		req.parsedURI = true
 		return
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1171,7 +1171,7 @@ func TestServerServeTLSEmbed(t *testing.T) {
 				ctx.Error("expecting tls", StatusBadRequest)
 				return
 			}
-			if !ctx.URI().isHttps() {
+			if !ctx.URI().isHTTPS() {
 				ctx.Error(fmt.Sprintf("unexpected scheme=%q. Expecting %q", ctx.URI().Scheme(), "https"), StatusBadRequest)
 				return
 			}

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -338,8 +338,8 @@ func (d *TCPDialer) tryDial(network string, addr *net.TCPAddr, deadline time.Tim
 		dialer.LocalAddr = d.LocalAddr
 	}
 
-	ctx, cancel_ctx := context.WithDeadline(context.Background(), deadline)
-	defer cancel_ctx()
+	ctx, cancelCtx := context.WithDeadline(context.Background(), deadline)
+	defer cancelCtx()
 	conn, err := dialer.DialContext(ctx, network, addr.String())
 	if err != nil && ctx.Err() == context.DeadlineExceeded {
 		return nil, ErrDialTimeout

--- a/uri.go
+++ b/uri.go
@@ -217,11 +217,11 @@ func (u *URI) SetSchemeBytes(scheme []byte) {
 	lowercaseBytes(u.scheme)
 }
 
-func (u *URI) isHttps() bool {
+func (u *URI) isHTTPS() bool {
 	return bytes.Equal(u.scheme, strHTTPS)
 }
 
-func (u *URI) isHttp() bool {
+func (u *URI) isHTTP() bool {
 	return len(u.scheme) == 0 || bytes.Equal(u.scheme, strHTTP)
 }
 

--- a/uri_test.go
+++ b/uri_test.go
@@ -326,23 +326,23 @@ func testURIParseScheme(t *testing.T, uri, expectedScheme, expectedHost, expecte
 
 func TestIsHttp(t *testing.T) {
 	var u URI
-	if !u.isHttp() || u.isHttps() {
+	if !u.isHTTP() || u.isHTTPS() {
 		t.Fatalf("http scheme is assumed by default and not https")
 	}
 	u.SetSchemeBytes([]byte{})
-	if !u.isHttp() || u.isHttps() {
+	if !u.isHTTP() || u.isHTTPS() {
 		t.Fatalf("empty scheme must be threaten as http and not https")
 	}
 	u.SetScheme("http")
-	if !u.isHttp() || u.isHttps() {
+	if !u.isHTTP() || u.isHTTPS() {
 		t.Fatalf("scheme must be threaten as http and not https")
 	}
 	u.SetScheme("https")
-	if !u.isHttps() || u.isHttp() {
+	if !u.isHTTPS() || u.isHTTP() {
 		t.Fatalf("scheme must be threaten as https and not http")
 	}
 	u.SetScheme("dav")
-	if u.isHttps() || u.isHttp() {
+	if u.isHTTPS() || u.isHTTP() {
 		t.Fatalf("scheme must be threaten as not http and not https")
 	}
 }


### PR DESCRIPTION
This PR makes stylistic changes in internal code. It renames unexported functions and variables to match the common Go style:

- cancel_ctx -> cancelCtx
- svrUrl -> srvUrl (should be `srv` from `server`, not `svr`)
- isHttps -> isHTTPS
- isHttp -> isHTTP
- isIp6 -> isIP6
- isIp6WithoutPort -> isIP6WithoutPort

See https://github.com/golang/go/wiki/CodeReviewComments#initialisms and https://go.dev/doc/effective_go#mixed-caps.