### PR TITLE
docs: deprecate ErrAlreadyServing as never returning

### DIFF
--- a/server.go
+++ b/server.go
@@ -20,8 +20,7 @@ import (
 var errNoCertOrKeyProvided = errors.New("cert or key has not provided")
 
 var (
-	// ErrAlreadyServing is returned when calling Serve on a Server
-	// that is already serving connections.
+	// Deprecated: ErrAlreadyServing is never returned from Serve. See issue #633.
 	ErrAlreadyServing = errors.New("Server is already serving connections")
 )
 


### PR DESCRIPTION
This PR adds `// Deprecated:` to the `ErrAlreadyServing` because this error is never returning from the `Serve`. The behavior changed in #731.

We can't just delete exported error to not break compatibility.

IDE understands this syntax and highlighted appropriately:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/3228886/218321488-274a9ffe-9847-4125-8a97-4f0b15cdf0c0.png">
