### PR TITLE
docs: fix grammar issues and typos in comments

### DIFF
--- a/client.go
+++ b/client.go
@@ -687,7 +687,7 @@ type HostClient struct {
 	// listed in Addr.
 	//
 	// You can change this value while the HostClient is being used
-	// using HostClient.SetMaxConns(value)
+	// with HostClient.SetMaxConns(value)
 	//
 	// DefaultMaxConnsPerHost is used if not set.
 	MaxConns int

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ExampleHostClient() {
-	// Perpare a client, which fetches webpages via HTTP proxy listening
+	// Prepare a client, which fetches webpages via HTTP proxy listening
 	// on the localhost:8080.
 	c := &fasthttp.HostClient{
 		Addr: "localhost:8080",

--- a/compress.go
+++ b/compress.go
@@ -413,7 +413,7 @@ func newCompressWriterPoolMap() []*sync.Pool {
 }
 
 func isFileCompressible(f *os.File, minCompressRatio float64) bool {
-	// Try compressing the first 4kb of of the file
+	// Try compressing the first 4kb of the file
 	// and see if it can be compressed by more than
 	// the given minCompressRatio.
 	b := bytebufferpool.Get()

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ConvertRequest convert a fasthttp.Request to an http.Request
-// forServer should be set to true when the http.Request is going to passed to a http.Handler.
+// forServer should be set to true when the http.Request is going to be passed to a http.Handler.
 //
 // The http.Request must not be used after the fasthttp handler has returned!
 // Memory in use by the http.Request will be reused after your handler has returned!

--- a/fasthttpproxy/proxy_env.go
+++ b/fasthttpproxy/proxy_env.go
@@ -20,7 +20,7 @@ const (
 )
 
 // FasthttpProxyHTTPDialer returns a fasthttp.DialFunc that dials using
-// the the env(HTTP_PROXY, HTTPS_PROXY and NO_PROXY) configured HTTP proxy.
+// the env(HTTP_PROXY, HTTPS_PROXY and NO_PROXY) configured HTTP proxy.
 //
 // Example usage:
 //

--- a/fs.go
+++ b/fs.go
@@ -1304,7 +1304,7 @@ func (h *fsHandler) openFSFile(filePath string, mustCompress bool, fileEncoding 
 		}
 
 		// Only re-create the compressed file if there was more than a second between the mod times.
-		// On MacOS the gzip seems to truncate the nanoseconds in the mod time causing the original file
+		// On macOS the gzip seems to truncate the nanoseconds in the mod time causing the original file
 		// to look newer than the gzipped file.
 		if fileInfoOriginal.ModTime().Sub(fileInfo.ModTime()) >= time.Second {
 			// The compressed file became stale. Re-create it.

--- a/fs_test.go
+++ b/fs_test.go
@@ -111,7 +111,7 @@ func TestPathNotFoundFunc(t *testing.T) {
 }
 
 func TestServeFileHead(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	var ctx RequestCtx
 	var req Request
@@ -199,7 +199,7 @@ func (pw pureWriter) Write(p []byte) (nn int, err error) {
 }
 
 func TestServeFileCompressed(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	var ctx RequestCtx
 	ctx.Init(&Request{}, nil, nil)
@@ -265,7 +265,7 @@ func TestServeFileCompressed(t *testing.T) {
 }
 
 func TestServeFileUncompressed(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	var ctx RequestCtx
 	var req Request
@@ -298,7 +298,7 @@ func TestServeFileUncompressed(t *testing.T) {
 }
 
 func TestFSByteRangeConcurrent(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -332,7 +332,7 @@ func TestFSByteRangeConcurrent(t *testing.T) {
 }
 
 func TestFSByteRangeSingleThread(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -475,7 +475,7 @@ func testParseByteRangeError(t *testing.T, v string, contentLength int) {
 }
 
 func TestFSCompressConcurrent(t *testing.T) {
-	// Don't run this test on Windows, the Windows Github actions are to slow and timeout too often.
+	// Don't run this test on Windows, the Windows GitHub actions are too slow and timeout too often.
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
@@ -517,7 +517,7 @@ func TestFSCompressConcurrent(t *testing.T) {
 }
 
 func TestFSCompressSingleThread(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -617,7 +617,7 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 }
 
 func TestFSHandlerSingleThread(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	requestHandler := FSHandler(".", 0)
 
@@ -639,7 +639,7 @@ func TestFSHandlerSingleThread(t *testing.T) {
 }
 
 func TestFSHandlerConcurrent(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	requestHandler := FSHandler(".", 0)
 
@@ -787,7 +787,7 @@ func testFileExtension(t *testing.T, path string, compressed bool, compressedFil
 }
 
 func TestServeFileContentType(t *testing.T) {
-	// This test can't run parallel as files in / might by changed by other tests.
+	// This test can't run parallel as files in / might be changed by other tests.
 
 	var ctx RequestCtx
 	var req Request

--- a/header.go
+++ b/header.go
@@ -1495,7 +1495,7 @@ func (h *ResponseHeader) SetCanonical(key, value []byte) {
 
 // SetCookie sets the given response cookie.
 //
-// It is save re-using the cookie after the function returns.
+// It is safe re-using the cookie after the function returns.
 func (h *ResponseHeader) SetCookie(cookie *Cookie) {
 	h.cookies = setArgBytes(h.cookies, cookie.Key(), cookie.Cookie(), argsHasValue)
 }

--- a/http.go
+++ b/http.go
@@ -893,7 +893,7 @@ func (req *Request) parsePostArgs() {
 // isn't 'multipart/form-data'.
 var ErrNoMultipartForm = errors.New("request has no multipart/form-data Content-Type")
 
-// MultipartForm returns requests's multipart form.
+// MultipartForm returns request's multipart form.
 //
 // Returns ErrNoMultipartForm if request's Content-Type
 // isn't 'multipart/form-data'.

--- a/lbclient.go
+++ b/lbclient.go
@@ -70,7 +70,7 @@ func (cc *LBClient) DoTimeout(req *Request, resp *Response, timeout time.Duratio
 	return cc.get().DoDeadline(req, resp, deadline)
 }
 
-// Do calls calculates deadline using LBClient.Timeout and calls DoDeadline
+// Do calculates timeout using LBClient.Timeout and calls DoTimeout
 // on the least loaded client.
 func (cc *LBClient) Do(req *Request, resp *Response) error {
 	timeout := cc.Timeout

--- a/server.go
+++ b/server.go
@@ -130,7 +130,7 @@ func ListenAndServeTLSEmbed(addr string, certData, keyData []byte, handler Reque
 // RequestHandler must process incoming requests.
 //
 // RequestHandler must call ctx.TimeoutError() before returning
-// if it keeps references to ctx and/or its' members after the return.
+// if it keeps references to ctx and/or its members after the return.
 // Consider wrapping RequestHandler into TimeoutHandler if response time
 // must be limited.
 type RequestHandler func(ctx *RequestCtx)
@@ -377,12 +377,12 @@ type Server struct {
 	// which will close it when needed.
 	KeepHijackedConns bool
 
-	// CloseOnShutdown when true adds a `Connection: close` header when when the server is shutting down.
+	// CloseOnShutdown when true adds a `Connection: close` header when the server is shutting down.
 	CloseOnShutdown bool
 
 	// StreamRequestBody enables request body streaming,
 	// and calls the handler sooner when given body is
-	// larger then the current limit.
+	// larger than the current limit.
 	StreamRequestBody bool
 
 	// ConnState specifies an optional callback function that is
@@ -567,7 +567,7 @@ func CompressHandlerBrotliLevel(h RequestHandler, brotliLevel, otherLevel int) R
 // It is forbidden copying RequestCtx instances.
 //
 // RequestHandler should avoid holding references to incoming RequestCtx and/or
-// its' members after the return.
+// its members after the return.
 // If holding RequestCtx references after the return is unavoidable
 // (for instance, ctx is passed to a separate goroutine and ctx lifetime cannot
 // be controlled), then the RequestHandler MUST call ctx.TimeoutError()
@@ -1003,7 +1003,7 @@ func (ctx *RequestCtx) PostArgs() *Args {
 	return ctx.Request.PostArgs()
 }
 
-// MultipartForm returns requests's multipart form.
+// MultipartForm returns request's multipart form.
 //
 // Returns ErrNoMultipartForm if request's content-type
 // isn't 'multipart/form-data'.
@@ -1480,7 +1480,7 @@ func (ctx *RequestCtx) SetBodyStream(bodyStream io.Reader, bodySize int) {
 // SetBodyStreamWriter registers the given stream writer for populating
 // response body.
 //
-// Access to RequestCtx and/or its' members is forbidden from sw.
+// Access to RequestCtx and/or its members is forbidden from sw.
 //
 // This function may be used in the following cases:
 //
@@ -1864,7 +1864,7 @@ func (s *Server) Serve(ln net.Listener) error {
 // When Shutdown is called, Serve, ListenAndServe, and ListenAndServeTLS immediately return nil.
 // Make sure the program doesn't exit and waits instead for Shutdown to return.
 //
-// Shutdown does not close keepalive connections so its recommended to set ReadTimeout and IdleTimeout to something else than 0.
+// Shutdown does not close keepalive connections so it's recommended to set ReadTimeout and IdleTimeout to something else than 0.
 func (s *Server) Shutdown() error {
 	return s.ShutdownWithContext(context.Background())
 }
@@ -1875,7 +1875,7 @@ func (s *Server) Shutdown() error {
 // When ShutdownWithContext is called, Serve, ListenAndServe, and ListenAndServeTLS immediately return nil.
 // Make sure the program doesn't exit and waits instead for Shutdown to return.
 //
-// ShutdownWithContext does not close keepalive connections so its recommended to set ReadTimeout and IdleTimeout to something else than 0.
+// ShutdownWithContext does not close keepalive connections so it's recommended to set ReadTimeout and IdleTimeout to something else than 0.
 func (s *Server) ShutdownWithContext(ctx context.Context) (err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/timer.go
+++ b/timer.go
@@ -18,7 +18,7 @@ func initTimer(t *time.Timer, timeout time.Duration) *time.Timer {
 func stopTimer(t *time.Timer) {
 	if !t.Stop() {
 		// Collect possibly added time from the channel
-		// if timer has been stopped and nobody collected its' value.
+		// if timer has been stopped and nobody collected its value.
 		select {
 		case <-t.C:
 		default:
@@ -44,7 +44,7 @@ func AcquireTimer(timeout time.Duration) *time.Timer {
 // ReleaseTimer returns the time.Timer acquired via AcquireTimer to the pool
 // and prevents the Timer from firing.
 //
-// Do not access the released time.Timer or read from it's channel otherwise
+// Do not access the released time.Timer or read from its channel otherwise
 // data races may occur.
 func ReleaseTimer(t *time.Timer) {
 	stopTimer(t)


### PR DESCRIPTION
This PR fixes only comments.

Changes:
- remove duplicated words;
- `its` writes without apostrophe;
- correct typos;
- `Github` -> `GitHub`, `MacOS` -> `macOS`.