### PR TITLE
test: bind to localhost instead of all interfaces

### DIFF
--- a/prefork/prefork_test.go
+++ b/prefork/prefork_test.go
@@ -21,7 +21,7 @@ func tearDown() {
 }
 
 func getAddr() string {
-	return fmt.Sprintf("0.0.0.0:%d", rand.Intn(9000-3000)+3000)
+	return fmt.Sprintf("127.0.0.1:%d", rand.Intn(9000-3000)+3000)
 }
 
 func Test_IsChild(t *testing.T) {


### PR DESCRIPTION
Without this change modal window appears when running `prefork_test.go` in Windows:

<a href="https://user-images.githubusercontent.com/3228886/218971204-5d36dfbc-3a44-4743-88ca-8d693a1fb335.png"><img src="https://user-images.githubusercontent.com/3228886/218971204-5d36dfbc-3a44-4743-88ca-8d693a1fb335.png"  height="300" ></a>

