### PR TITLE
test: close response body

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.51.1
-        args: --enable=nolintlint --enable=gochecknoinits --verbose
+        args: --enable=nolintlint,gochecknoinits,bodyclose --verbose

--- a/fasthttputil/inmemory_listener_test.go
+++ b/fasthttputil/inmemory_listener_test.go
@@ -146,6 +146,7 @@ func testInmemoryListenerHTTPSingle(t *testing.T, client *http.Client, content s
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer func() { _ = res.Body.Close() }()
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/header_test.go
+++ b/header_test.go
@@ -71,6 +71,7 @@ func TestResponseHeaderMultiLineValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse response using net/http failed, %v", err)
 	}
+	defer func() { _ = response.Body.Close() }()
 
 	if !bytes.Equal(header.StatusMessage(), []byte("SuperOK")) {
 		t.Errorf("parse status line with non-default value failed, got: '%q' want: 'SuperOK'", header.StatusMessage())


### PR DESCRIPTION
This PR fixes missing calls to `Response.Body.Close()` in tests. Also, enable `bodyclose` linter that detects such issues.