### PR TITLE
http.go: close form file if copyZeroAlloc fails

### DIFF
--- a/http.go
+++ b/http.go
@@ -992,6 +992,7 @@ func WriteMultipartForm(w io.Writer, f *multipart.Form, boundary string) error {
 				return fmt.Errorf("cannot open form file %q (%q): %w", k, fv.Filename, err)
 			}
 			if _, err = copyZeroAlloc(vw, fh); err != nil {
+				_ = fh.Close()
 				return fmt.Errorf("error when copying form file %q (%q): %w", k, fv.Filename, err)
 			}
 			if err = fh.Close(); err != nil {


### PR DESCRIPTION
This PR adds a call to close form file in `WriteMultipartForm` when copy error occured.

The line below shows that we need to call `fh.Close()`:
```go
if err = fh.Close(); err != nil {
	return fmt.Errorf("cannot close form file %q (%q): %w", k, fv.Filename, err)
} 
```