### PR TITLE
test: fix typos in function, error message, comment

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -606,7 +606,7 @@ func TestRequestHeaderDel(t *testing.T) {
 
 	cv := h.Cookie("foobar")
 	if len(cv) > 0 {
-		t.Fatalf("unexpected cookie obtianed: %q", cv)
+		t.Fatalf("unexpected cookie obtained: %q", cv)
 	}
 	if h.ContentLength() != 0 {
 		t.Fatalf("unexpected content-length: %d. Expecting 0", h.ContentLength())
@@ -673,7 +673,7 @@ func TestResponseHeaderDel(t *testing.T) {
 	}
 
 	if h.Cookie(&c) {
-		t.Fatalf("unexpected cookie obtianed: %q", &c)
+		t.Fatalf("unexpected cookie obtained: %q", &c)
 	}
 	if h.ContentLength() != 0 {
 		t.Fatalf("unexpected content-length: %d. Expecting 0", h.ContentLength())

--- a/server.go
+++ b/server.go
@@ -2225,7 +2225,7 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 
 			// Reading Headers.
 			//
-			// If we have pipline response in the outgoing buffer,
+			// If we have pipeline response in the outgoing buffer,
 			// we only want to try and read the next headers once.
 			// If we have to wait for the next request we flush the
 			// outgoing buffer first so it doesn't have to wait.

--- a/server_test.go
+++ b/server_test.go
@@ -384,7 +384,7 @@ func TestServerName(t *testing.T) {
 		},
 	}
 
-	getReponse := func() []byte {
+	getResponse := func() []byte {
 		rw := &readWriter{}
 		rw.r.WriteString("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
 
@@ -400,7 +400,7 @@ func TestServerName(t *testing.T) {
 		return resp
 	}
 
-	resp := getReponse()
+	resp := getResponse()
 	if !bytes.Contains(resp, []byte("\r\nServer: "+defaultServerName+"\r\n")) {
 		t.Fatalf("Unexpected response %q expected Server: "+defaultServerName, resp)
 	}
@@ -412,7 +412,7 @@ func TestServerName(t *testing.T) {
 		Name: "foobar",
 	}
 
-	resp = getReponse()
+	resp = getResponse()
 	if !bytes.Contains(resp, []byte("\r\nServer: foobar\r\n")) {
 		t.Fatalf("Unexpected response %q expected Server: foobar", resp)
 	}
@@ -425,7 +425,7 @@ func TestServerName(t *testing.T) {
 		NoDefaultDate:         true,
 	}
 
-	resp = getReponse()
+	resp = getResponse()
 	if bytes.Contains(resp, []byte("\r\nServer: ")) {
 		t.Fatalf("Unexpected response %q expected no Server header", resp)
 	}


### PR DESCRIPTION
Just reading the code found these typos.