### PR TITLE
client: fix Do hangs when configure host client fails

### DIFF
--- a/client.go
+++ b/client.go
@@ -527,6 +527,7 @@ func (c *Client) Do(req *Request, resp *Response) error {
 
 		if c.ConfigureClient != nil {
 			if err := c.ConfigureClient(hc); err != nil {
+				c.mLock.Unlock()
 				return err
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -2734,6 +2734,30 @@ func TestClientTLSHandshakeTimeout(t *testing.T) {
 	}
 }
 
+func TestClientConfigureClientFailed(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{
+		ConfigureClient: func(hc *HostClient) error {
+			return fmt.Errorf("failed to configure")
+		},
+	}
+
+	req := Request{}
+	req.SetRequestURI("http://example.com")
+
+	err := c.Do(&req, &Response{})
+	if err == nil {
+		t.Fatal("expected error (failed to configure)")
+	}
+
+	c.ConfigureClient = nil
+	err = c.Do(&req, &Response{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestHostClientMaxConnWaitTimeoutSuccess(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR fixes a situation when the second call to `client.Do` hangs when  using`c.ConfigureClient(hc)` on the first call `client.Do`.

Without the fix, `TestClientConfigureClientFailed` get stuck because mutex `c.mLock` is never unlocked. And timed out with the stack trace:

```
go test -timeout 30s -run ^TestClientConfigureClientFailed$ github.com/valyala/fasthttp -count=1 -v -race

=== RUN   TestClientConfigureClientFailed
=== PAUSE TestClientConfigureClientFailed
=== CONT  TestClientConfigureClientFailed
panic: test timed out after 30s
running tests:
	TestClientConfigureClientFailed (30s)

goroutine 33 [running]:
testing.(*M).startAlarm.func1()
	/usr/local/Cellar/go/1.20.1/libexec/src/testing/testing.go:2241 +0x219
created by time.goFunc
	/usr/local/Cellar/go/1.20.1/libexec/src/time/sleep.go:176 +0x48

goroutine 1 [chan receive]:
testing.tRunner.func1()
	/usr/local/Cellar/go/1.20.1/libexec/src/testing/testing.go:1542 +0x8eb
testing.tRunner(0xc000083040, 0xc000095b48)
	/usr/local/Cellar/go/1.20.1/libexec/src/testing/testing.go:1582 +0x255
testing.runTests(0xc0000bcbe0?, {0x1c4d020, 0x1b5, 0x1b5}, {0x1c?, 0x1e?, 0x1c51620?})
	/usr/local/Cellar/go/1.20.1/libexec/src/testing/testing.go:2034 +0x87d
testing.(*M).Run(0xc0000bcbe0)
	/usr/local/Cellar/go/1.20.1/libexec/src/testing/testing.go:1906 +0xb45
main.main()
	_testmain.go:1141 +0x2ea

goroutine 18 [sleep]:
time.Sleep(0x12a05f200)
	/usr/local/Cellar/go/1.20.1/libexec/src/runtime/time.go:195 +0x135
github.com/valyala/fasthttp.(*FS).initRequestHandler.func1()
	/Users/redko.o/src/github.com/valyala/fasthttp/fs.go:478 +0x1e6
created by github.com/valyala/fasthttp.(*FS).initRequestHandler
	/Users/redko.o/src/github.com/valyala/fasthttp/fs.go:455 +0x96f

goroutine 19 [sleep]:
time.Sleep(0x12a05f200)
	/usr/local/Cellar/go/1.20.1/libexec/src/runtime/time.go:195 +0x135
github.com/valyala/fasthttp.(*FS).initRequestHandler.func1()
	/Users/redko.o/src/github.com/valyala/fasthttp/fs.go:478 +0x1e6
created by github.com/valyala/fasthttp.(*FS).initRequestHandler
	/Users/redko.o/src/github.com/valyala/fasthttp/fs.go:455 +0x96f

goroutine 20 [sleep]:
time.Sleep(0x12a05f200)
	/usr/local/Cellar/go/1.20.1/libexec/src/runtime/time.go:195 +0x135
github.com/valyala/fasthttp.(*FS).initRequestHandler.func1()
	/Users/redko.o/src/github.com/valyala/fasthttp/fs.go:478 +0x1e6
created by github.com/valyala/fasthttp.(*FS).initRequestHandler
	/Users/redko.o/src/github.com/valyala/fasthttp/fs.go:455 +0x96f

goroutine 21 [sync.Mutex.Lock]:
sync.runtime_SemacquireMutex(0x1b9b6e8?, 0x4?, 0x10a58e0?)
	/usr/local/Cellar/go/1.20.1/libexec/src/runtime/sema.go:77 +0x26
sync.(*Mutex).lockSlow(0xc0000d2520)
	/usr/local/Cellar/go/1.20.1/libexec/src/sync/mutex.go:171 +0x213
sync.(*Mutex).Lock(0xc0000d2520)
	/usr/local/Cellar/go/1.20.1/libexec/src/sync/mutex.go:90 +0x65
github.com/valyala/fasthttp.(*Client).Do(0xc0000d2480, 0xc0000a8e00, 0x17f540c?)
	/Users/redko.o/src/github.com/valyala/fasthttp/client.go:487 +0x265
github.com/valyala/fasthttp.TestClientConfigureClientFailed(0xc0000831e0)
	/Users/redko.o/src/github.com/valyala/fasthttp/client_test.go:2755 +0x365
testing.tRunner(0xc0000831e0, 0x1837ed8)
	/usr/local/Cellar/go/1.20.1/libexec/src/testing/testing.go:1576 +0x217
created by testing.(*T).Run
	/usr/local/Cellar/go/1.20.1/libexec/src/testing/testing.go:1629 +0x806
FAIL	github.com/valyala/fasthttp	30.396s
```