### PR TITLE
client: fix HostClient.Do hangs on ErrConnPoolStrategyNotImpl

### DIFF
--- a/client.go
+++ b/client.go
@@ -1534,6 +1534,7 @@ func (c *HostClient) acquireConn(reqTimeout time.Duration, connectionClose bool)
 			c.conns[n-1] = nil
 			c.conns = c.conns[:n-1]
 		default:
+			c.connsLock.Unlock()
 			return nil, ErrConnPoolStrategyNotImpl
 		}
 	}


### PR DESCRIPTION
The PR fixes the situation when on `ErrConnPoolStrategyNotImpl` error `HostClient.Do()` hangs out.

This error is unlikely to happen in real life but for the sake of completeness I added `c.connLock.Unlock()` and the test.