### PR TITLE
docs: add missing dot to ConvertRequest comment

### DIFF
--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -10,7 +10,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// ConvertRequest convert a fasthttp.Request to an http.Request
+// ConvertRequest converts a fasthttp.Request to an http.Request.
 // forServer should be set to true when the http.Request is going to be passed to a http.Handler.
 //
 // The http.Request must not be used after the fasthttp handler has returned!


### PR DESCRIPTION
Without a dot the [comment](https://pkg.go.dev/github.com/valyala/fasthttp/fasthttpadaptor#ConvertRequest) looks as:
<img width="984" alt="image" src="https://user-images.githubusercontent.com/3228886/224507254-633149c3-e1aa-429e-9129-6ffc740af550.png">
