### PR TITLE
GitHub actions/setup-go@v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version: 1.20.x
     - run: go version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,23 +13,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Get Go cache paths
-        id: go-env
-        run: |
-          echo "::set-output name=cache::$(go env GOCACHE)"
-          echo "::set-output name=modcache::$(go env GOMODCACHE)"
-      - name: Set up Go cache
-        uses: actions/cache@v3
-        with:
-          key: golangci-lint-${{ runner.os }}-go-${{ hashFiles('go.mod') }}
-          restore-keys: golangci-lint-${{ runner.os }}-go-
-          path: |
-            ${{ steps.go-env.outputs.cache }}
-            ${{ steps.go-env.outputs.modcache }}
 
       - run: go version
       - run: go test ./...


### PR DESCRIPTION
https://github.com/actions/setup-go/releases/tag/v4.0.0 enables cache by default.