### PR TITLE
chore:remove redundant code

### DIFF
--- a/args.go
+++ b/args.go
@@ -63,7 +63,6 @@ func (a *Args) Reset() {
 
 // CopyTo copies all args to dst.
 func (a *Args) CopyTo(dst *Args) {
-	dst.Reset()
 	dst.args = copyArgs(dst.args, a.args)
 }
 


### PR DESCRIPTION
 the same effect can be achieved if  the  destination slice do not  be reset  in `func (a *Args) CopyTo(dst *Args)` .   