### PR TITLE
Fixed transfer-encoding for empty chunked payload

### DIFF
--- a/http.go
+++ b/http.go
@@ -1268,7 +1268,7 @@ func (req *Request) ContinueReadBody(r *bufio.Reader, maxBodySize int, preParseM
 		return err
 	}
 
-	if req.Header.ContentLength() == -1 {
+	if contentLength == -1 {
 		err = req.Header.ReadTrailer(r)
 		if err != nil && err != io.EOF {
 			return err
@@ -1290,6 +1290,9 @@ func (req *Request) ReadBody(r *bufio.Reader, contentLength int, maxBodySize int
 
 	} else if contentLength == -1 {
 		bodyBuf.B, err = readBodyChunked(r, maxBodySize, bodyBuf.B)
+		if err == nil && len(bodyBuf.B) == 0 {
+			req.Header.SetContentLength(0)
+		}
 
 	} else {
 		bodyBuf.B, err = readBodyIdentity(r, maxBodySize, bodyBuf.B)

--- a/http_test.go
+++ b/http_test.go
@@ -2011,6 +2011,25 @@ func TestRequestReadChunked(t *testing.T) {
 	verifyTrailer(t, rb, map[string]string{"Trail": "test"}, true)
 }
 
+func TestRequestChunkedEmpty(t *testing.T) {
+	t.Parallel()
+
+	var req Request
+
+	s := "POST /foo HTTP/1.1\r\nHost: google.com\r\nTransfer-Encoding: chunked\r\nContent-Type: aa/bb\r\n\r\n0\r\n\r\n"
+	r := bytes.NewBufferString(s)
+	rb := bufio.NewReader(r)
+	err := req.Read(rb)
+	if err != nil {
+		t.Fatalf("Unexpected error when reading chunked request: %v", err)
+	}
+	expectedBody := ""
+	if string(req.Body()) != expectedBody {
+		t.Fatalf("Unexpected body %q. Expected %q", req.Body(), expectedBody)
+	}
+	expectRequestHeaderGet(t, &req.Header, HeaderTransferEncoding, "")
+}
+
 // See: https://github.com/erikdubbelboer/fasthttp/issues/34
 func TestRequestChunkedWhitespace(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
In release [v1.32.0](https://github.com/valyala/fasthttp/releases/tag/v1.32.0), there was a backwards incompatible change introduced as a (seemingly unintended) side-effect of [adding trailer support](https://github.com/valyala/fasthttp/pull/1165/commits/b2a0c32465dba2c024d127552733c9d10effa2b6).

The relevant scenario is in the case of a chunk-encoded request containing only a terminating chunk as its body payload (`0/r/n/r/n`). Previously, the[ content length would be set to the length of the body](https://github.com/valyala/fasthttp/pull/1165/commits/b2a0c32465dba2c024d127552733c9d10effa2b6#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48L1154) (0, in this case) whereas afterwards it [stopped doing that for chunked transfers](https://github.com/valyala/fasthttp/pull/1165/commits/b2a0c32465dba2c024d127552733c9d10effa2b6#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48R1164). 

The consequence of this for the above scenario is that the `Transfer-Encoding: chunked` header that would previously have been removed ([when setting the CL](https://github.com/valyala/fasthttp/blob/master/header.go#L295)) persists. If this request is then (re)used, it will result in a desync, since the header will be sent with no body at all.

