### PR TITLE
examples/client: fix copy-paste mistake

### DIFF
--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -118,7 +118,7 @@ func httpConnError(err error) (string, bool) {
 	switch {
 	case errors.Is(err, fasthttp.ErrTimeout):
 		errName = "timeout"
-	case errors.Is(err, fasthttp.ErrTimeout):
+	case errors.Is(err, fasthttp.ErrNoFreeConns):
 		errName = "conn_limit"
 	case errors.Is(err, fasthttp.ErrConnectionClosed):
 		errName = "conn_close"


### PR DESCRIPTION
This PR fixes `httpConnError` function (a mistake was made during refactoring #1539).