### PR TITLE
test: refactor to use WriteString

### DIFF
--- a/brotli_test.go
+++ b/brotli_test.go
@@ -107,7 +107,7 @@ func TestCompressHandlerBrotliLevel(t *testing.T) {
 
 	expectedBody := string(createFixedBody(2e4))
 	h := CompressHandlerBrotliLevel(func(ctx *RequestCtx) {
-		ctx.Write([]byte(expectedBody)) //nolint:errcheck
+		ctx.WriteString(expectedBody) //nolint:errcheck
 	}, CompressBrotliDefaultCompression, CompressDefaultCompression)
 
 	var ctx RequestCtx

--- a/examples/multidomain/multidomain.go
+++ b/examples/multidomain/multidomain.go
@@ -37,7 +37,7 @@ func main() {
 		panic(err)
 	}
 	domains["localhost:8080"] = func(ctx *fasthttp.RequestCtx) {
-		ctx.Write([]byte("You are accessing to localhost:8080\n"))
+		ctx.WriteString("You are accessing to localhost:8080\n")
 	}
 
 	err = server.AppendCertEmbed(cert, priv)
@@ -51,7 +51,7 @@ func main() {
 		panic(err)
 	}
 	domains["127.0.0.1:8080"] = func(ctx *fasthttp.RequestCtx) {
-		ctx.Write([]byte("You are accessing to 127.0.0.1:8080\n"))
+		ctx.WriteString("You are accessing to 127.0.0.1:8080\n")
 	}
 
 	err = server.AppendCertEmbed(cert, priv)

--- a/http_test.go
+++ b/http_test.go
@@ -1368,7 +1368,7 @@ func TestResponseGzipStream(t *testing.T) {
 		fmt.Fprintf(w, "foo")
 		w.Flush()
 		time.Sleep(time.Millisecond)
-		_, _ = w.Write([]byte("barbaz"))
+		_, _ = w.WriteString("barbaz")
 		_ = w.Flush()
 		time.Sleep(time.Millisecond)
 		_, _ = fmt.Fprintf(w, "1234")
@@ -1390,11 +1390,11 @@ func TestResponseDeflateStream(t *testing.T) {
 		t.Fatalf("IsBodyStream must return false")
 	}
 	r.SetBodyStreamWriter(func(w *bufio.Writer) {
-		_, _ = w.Write([]byte("foo"))
+		_, _ = w.WriteString("foo")
 		_ = w.Flush()
 		_, _ = fmt.Fprintf(w, "barbaz")
 		_ = w.Flush()
-		_, _ = w.Write([]byte("1234"))
+		_, _ = w.WriteString("1234")
 		if err := w.Flush(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/server_test.go
+++ b/server_test.go
@@ -1942,7 +1942,7 @@ func TestCompressHandler(t *testing.T) {
 
 	expectedBody := string(createFixedBody(2e4))
 	h := CompressHandler(func(ctx *RequestCtx) {
-		ctx.Write([]byte(expectedBody)) //nolint:errcheck
+		ctx.WriteString(expectedBody) //nolint:errcheck
 	})
 
 	var ctx RequestCtx
@@ -2610,7 +2610,7 @@ func TestRequestCtxNoHijackNoResponse(t *testing.T) {
 
 	s := &Server{
 		Handler: func(ctx *RequestCtx) {
-			io.WriteString(ctx, "test") //nolint:errcheck
+			ctx.WriteString("test") //nolint:errcheck
 			ctx.HijackSetNoResponse(true)
 		},
 	}


### PR DESCRIPTION
This PR refactors tests and examples to use `ctx.WriteString(...)` instead of `ctx.Write([]byte(...))`. Also, use `ctx.WriteString("...")` instead of `io.WriteString(ctx, "...")` for consistency.