### PR TITLE
fs: fix race condition on global map

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -428,9 +428,8 @@ func (fs *FS) initRequestHandler() {
 	if len(compressedFileSuffixes["br"]) == 0 || len(compressedFileSuffixes["gzip"]) == 0 ||
 		compressedFileSuffixes["br"] == compressedFileSuffixes["gzip"] {
 		// Copy global map
-		origMap := FSCompressedFileSuffixes
-		compressedFileSuffixes = make(map[string]string, len(origMap))
-		for k, v := range origMap {
+		compressedFileSuffixes = make(map[string]string, len(FSCompressedFileSuffixes))
+		for k, v := range FSCompressedFileSuffixes {
 			compressedFileSuffixes[k] = v
 		}
 	}

--- a/fs.go
+++ b/fs.go
@@ -427,7 +427,12 @@ func (fs *FS) initRequestHandler() {
 	compressedFileSuffixes := fs.CompressedFileSuffixes
 	if len(compressedFileSuffixes["br"]) == 0 || len(compressedFileSuffixes["gzip"]) == 0 ||
 		compressedFileSuffixes["br"] == compressedFileSuffixes["gzip"] {
-		compressedFileSuffixes = FSCompressedFileSuffixes
+		// Copy global map
+		origMap := FSCompressedFileSuffixes
+		compressedFileSuffixes = make(map[string]string, len(origMap))
+		for k, v := range origMap {
+			compressedFileSuffixes[k] = v
+		}
 	}
 
 	if len(fs.CompressedFileSuffix) > 0 {


### PR DESCRIPTION
Previously, when creating multiple FS instances with a non-empty "CompressedFileSuffix" field concurrently, a data race on the global "FSCompressedFileSuffixes" might occur.

This was found in fiber, probably the largest web framework based on fasthttp:

    git clone https://github.com/gofiber/fiber.git && cd fiber
    git checkout 182f9f09705eab40c61a618835d46faee79c1e49
    go test -v -race -run Test_App_Static_Prefix_*

        === RUN   Test_App_Static_Prefix_Wildcard
    === PAUSE Test_App_Static_Prefix_Wildcard
    === RUN   Test_App_Static_Prefix
    === PAUSE Test_App_Static_Prefix
    === CONT  Test_App_Static_Prefix
    === CONT  Test_App_Static_Prefix_Wildcard
    ==================
    WARNING: DATA RACE
    Write at 0x00c0001b1c50 by goroutine 7:
      runtime.mapassign_faststr()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/runtime/map_faststr.go:203 +0x0
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2c4
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x84
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix_Wildcard()
          /home/leon/code/fiber/app_test.go:1017 +0x5c
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Previous write at 0x00c0001b1c50 by goroutine 8:
      runtime.mapassign_faststr()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/runtime/map_faststr.go:203 +0x0
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2c4
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x84
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix()
          /home/leon/code/fiber/app_test.go:1042 +0x59
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Goroutine 7 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9

    Goroutine 8 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9
    ==================
    ==================
    WARNING: DATA RACE
    Write at 0x00c0001f43e8 by goroutine 7:
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2d3
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x84
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix_Wildcard()
          /home/leon/code/fiber/app_test.go:1017 +0x5c
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Previous write at 0x00c0001f43e8 by goroutine 8:
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2d3
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x84
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix()
          /home/leon/code/fiber/app_test.go:1042 +0x59
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Goroutine 7 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9

    Goroutine 8 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9
    ==================
    ==================
    WARNING: DATA RACE
    Read at 0x00c0001f43f8 by goroutine 7:
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:435 +0x344
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x84
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix_Wildcard()
          /home/leon/code/fiber/app_test.go:1017 +0x5c
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Previous write at 0x00c0001f43f8 by goroutine 8:
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:435 +0x38c
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x84
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix()
          /home/leon/code/fiber/app_test.go:1042 +0x59
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Goroutine 7 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9

    Goroutine 8 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9
    ==================
    ==================
    WARNING: DATA RACE
    Read at 0x00c0001b1c50 by goroutine 11:
      runtime.mapaccess1_faststr()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/runtime/map_faststr.go:13 +0x0
      github.com/valyala/fasthttp.(*fsHandler).newFSFile()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:1329 +0xec
      github.com/valyala/fasthttp.(*fsHandler).openFSFile()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:1317 +0x7c9
      github.com/valyala/fasthttp.(*fsHandler).handleRequest()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:865 +0x846
      github.com/valyala/fasthttp.(*fsHandler).handleRequest-fm()
          <autogenerated>:1 +0x44
      github.com/gofiber/fiber/v2.(*App).registerStatic.func3()
          /home/leon/code/fiber/router.go:403 +0x15e
      github.com/gofiber/fiber/v2.(*App).next()
          /home/leon/code/fiber/router.go:144 +0x50b
      github.com/gofiber/fiber/v2.(*App).handler()
          /home/leon/code/fiber/router.go:171 +0xf2
      github.com/gofiber/fiber/v2.(*App).handler-fm()
          <autogenerated>:1 +0x44
      github.com/valyala/fasthttp.(*Server).serveConn()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/server.go:2365 +0x1b4a
      github.com/valyala/fasthttp.(*Server).ServeConn()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/server.go:2035 +0x10f
      github.com/gofiber/fiber/v2.(*App).Test.func1()
          /home/leon/code/fiber/app.go:934 +0xd8

    Previous write at 0x00c0001b1c50 by goroutine 7:
      runtime.mapassign_faststr()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/runtime/map_faststr.go:203 +0x0
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:435 +0x37d
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x84
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix_Wildcard()
          /home/leon/code/fiber/app_test.go:1017 +0x5c
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Goroutine 11 (running) created at:
      github.com/gofiber/fiber/v2.(*App).Test()
          /home/leon/code/fiber/app.go:926 +0x645
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix()
          /home/leon/code/fiber/app_test.go:1045 +0xba
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Goroutine 7 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9
    ==================
    ==================
    WARNING: DATA RACE
    Write at 0x00c0001b1c50 by goroutine 8:
      runtime.mapassign_faststr()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/runtime/map_faststr.go:203 +0x0
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2c4
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x2c6
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix()
          /home/leon/code/fiber/app_test.go:1051 +0x29b
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Previous write at 0x00c0001b1c50 by goroutine 7:
      runtime.mapassign_faststr()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/runtime/map_faststr.go:203 +0x0
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2c4
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x2c9
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix_Wildcard()
          /home/leon/code/fiber/app_test.go:1026 +0x29b
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Goroutine 8 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9

    Goroutine 7 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9
    ==================
    ==================
    WARNING: DATA RACE
    Write at 0x00c0001f43e8 by goroutine 8:
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2d3
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x2c6
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix()
          /home/leon/code/fiber/app_test.go:1051 +0x29b
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Previous write at 0x00c0001f43e8 by goroutine 7:
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2d3
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x2c9
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix_Wildcard()
          /home/leon/code/fiber/app_test.go:1026 +0x29b
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Goroutine 8 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9

    Goroutine 7 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9
    ==================
    ==================
    WARNING: DATA RACE
    Read at 0x00c0001f43f8 by goroutine 8:
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:435 +0x344
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x2c6
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix()
          /home/leon/code/fiber/app_test.go:1051 +0x29b
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Previous write at 0x00c0001f43f8 by goroutine 7:
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:435 +0x38c
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x2c9
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix_Wildcard()
          /home/leon/code/fiber/app_test.go:1026 +0x29b
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Goroutine 8 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9

    Goroutine 7 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9
    ==================
    ==================
    WARNING: DATA RACE
    Write at 0x00c0001b1c50 by goroutine 8:
      runtime.mapassign_faststr()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/runtime/map_faststr.go:203 +0x0
      github.com/valyala/fasthttp.(*FS).initRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:434 +0x2c4
      github.com/valyala/fasthttp.(*FS).initRequestHandler-fm()
          <autogenerated>:1 +0x39
      sync.(*Once).doSlow()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:74 +0x101
      sync.(*Once).Do()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/sync/once.go:65 +0x46
      github.com/valyala/fasthttp.(*FS).NewRequestHandler()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:389 +0x9bb
      github.com/gofiber/fiber/v2.(*App).registerStatic()
          /home/leon/code/fiber/router.go:396 +0x984
      github.com/gofiber/fiber/v2.(*App).Static()
          /home/leon/code/fiber/app.go:762 +0x4f0
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix()
          /home/leon/code/fiber/app_test.go:1060 +0x4c5
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47

    Previous read at 0x00c0001b1c50 by goroutine 20:
      runtime.mapaccess1_faststr()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/runtime/map_faststr.go:13 +0x0
      github.com/valyala/fasthttp.(*fsHandler).newFSFile()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:1329 +0xec
      github.com/valyala/fasthttp.(*fsHandler).openFSFile()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:1317 +0x7c9
      github.com/valyala/fasthttp.(*fsHandler).handleRequest()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/fs.go:865 +0x846
      github.com/valyala/fasthttp.(*fsHandler).handleRequest-fm()
          <autogenerated>:1 +0x44
      github.com/gofiber/fiber/v2.(*App).registerStatic.func3()
          /home/leon/code/fiber/router.go:403 +0x15e
      github.com/gofiber/fiber/v2.(*App).next()
          /home/leon/code/fiber/router.go:144 +0x50b
      github.com/gofiber/fiber/v2.(*App).handler()
          /home/leon/code/fiber/router.go:171 +0xf2
      github.com/gofiber/fiber/v2.(*App).handler-fm()
          <autogenerated>:1 +0x44
      github.com/valyala/fasthttp.(*Server).serveConn()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/server.go:2365 +0x1b4a
      github.com/valyala/fasthttp.(*Server).ServeConn()
          /home/leon/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/server.go:2035 +0x10f
      github.com/gofiber/fiber/v2.(*App).Test.func1()
          /home/leon/code/fiber/app.go:934 +0xd8

    Goroutine 8 (running) created at:
      testing.(*T).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x805
      testing.runTests.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2036 +0x8d
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.runTests()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:2034 +0x87c
      testing.(*M).Run()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1906 +0xb44
      main.main()
          _testmain.go:871 +0x2e9

    Goroutine 20 (finished) created at:
      github.com/gofiber/fiber/v2.(*App).Test()
          /home/leon/code/fiber/app.go:926 +0x645
      github.com/gofiber/fiber/v2.Test_App_Static_Prefix_Wildcard()
          /home/leon/code/fiber/app_test.go:1028 +0x304
      testing.tRunner()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1576 +0x216
      testing.(*T).Run.func1()
          /nix/store/8v5zwymidmry0wd3lhj6zggskzsvqrfk-go-1.20.4/share/go/src/testing/testing.go:1629 +0x47
    ==================
        testing.go:1446: race detected during execution of test
    --- FAIL: Test_App_Static_Prefix_Wildcard (0.03s)
    === NAME  Test_App_Static_Prefix
        testing.go:1446: race detected during execution of test
    --- FAIL: Test_App_Static_Prefix (0.03s)
    FAIL
    exit status 1
    FAIL	github.com/gofiber/fiber/v2	0.050s