### PR TITLE
add DisableSpecialHeaders option

### DIFF
--- a/header.go
+++ b/header.go
@@ -361,6 +361,9 @@ func (h *ResponseHeader) SetServerBytes(server []byte) {
 
 // ContentType returns Content-Type header value.
 func (h *RequestHeader) ContentType() []byte {
+	// if h.disableSpecialHeader {
+	// 	return h.Peek(HeaderContentType)
+	// }
 	return h.contentType
 }
 
@@ -574,6 +577,9 @@ func (h *RequestHeader) MultipartFormBoundary() []byte {
 
 // Host returns Host header value.
 func (h *RequestHeader) Host() []byte {
+	if h.disableSpecialHeader {
+		return peekArgBytes(h.h, []byte("Host"))
+	}
 	return h.host
 }
 
@@ -589,6 +595,9 @@ func (h *RequestHeader) SetHostBytes(host []byte) {
 
 // UserAgent returns User-Agent header value.
 func (h *RequestHeader) UserAgent() []byte {
+	if h.disableSpecialHeader {
+		return peekArgBytes(h.h, []byte("Host"))
+	}
 	return h.userAgent
 }
 
@@ -886,8 +895,7 @@ func (h *RequestHeader) Len() int {
 // DisableSpecialHeader disables special header processing.
 // fasthttp will not set any special headers for you, such as Host, Content-Type, User-Agent, etc.
 // You must set everything yourself.
-// If *RequestHeader.Read() is called, special headers will be parsed but not sent.
-// e.g. *RequestHeader.Host() will return something, but the header will not be set when the request is sent.
+// If RequestHeader.Read() is called, special headers will be ignored.
 // This can be used to control case and order of special headers.
 // This is generally not recommended.
 func (h *RequestHeader) DisableSpecialHeader() {

--- a/header.go
+++ b/header.go
@@ -362,7 +362,7 @@ func (h *ResponseHeader) SetServerBytes(server []byte) {
 // ContentType returns Content-Type header value.
 func (h *RequestHeader) ContentType() []byte {
 	if h.disableSpecialHeader {
-		return h.Peek(HeaderContentType)
+		return peekArgBytes(h.h, []byte(HeaderContentType))
 	}
 	return h.contentType
 }
@@ -578,7 +578,7 @@ func (h *RequestHeader) MultipartFormBoundary() []byte {
 // Host returns Host header value.
 func (h *RequestHeader) Host() []byte {
 	if h.disableSpecialHeader {
-		return peekArgBytes(h.h, []byte("Host"))
+		return peekArgBytes(h.h, []byte(HeaderHost))
 	}
 	return h.host
 }
@@ -596,7 +596,7 @@ func (h *RequestHeader) SetHostBytes(host []byte) {
 // UserAgent returns User-Agent header value.
 func (h *RequestHeader) UserAgent() []byte {
 	if h.disableSpecialHeader {
-		return peekArgBytes(h.h, []byte("Host"))
+		return peekArgBytes(h.h, []byte(HeaderUserAgent))
 	}
 	return h.userAgent
 }

--- a/header.go
+++ b/header.go
@@ -361,9 +361,9 @@ func (h *ResponseHeader) SetServerBytes(server []byte) {
 
 // ContentType returns Content-Type header value.
 func (h *RequestHeader) ContentType() []byte {
-	// if h.disableSpecialHeader {
-	// 	return h.Peek(HeaderContentType)
-	// }
+	if h.disableSpecialHeader {
+		return h.Peek(HeaderContentType)
+	}
 	return h.contentType
 }
 

--- a/header.go
+++ b/header.go
@@ -2931,6 +2931,11 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 				continue
 			}
 
+			if h.disableSpecialHeader {
+				h.h = appendArgBytes(h.h, s.key, s.value, argsHasValue)
+				continue
+			}
+
 			switch s.key[0] | 0x20 {
 			case 'h':
 				if caseInsensitiveCompare(s.key, strHost) {

--- a/header_test.go
+++ b/header_test.go
@@ -353,7 +353,7 @@ func TestRequestDisableSpecialHeaders(t *testing.T) {
 
 	kvs := "Host: foobar\r\n" +
 		"User-Agent: ua\r\n" +
-		"non-special:  val\r\n" +
+		"Non-Special: val\r\n" +
 		"\r\n"
 
 	var h RequestHeader
@@ -364,27 +364,15 @@ func TestRequestDisableSpecialHeaders(t *testing.T) {
 	if err := h.Read(br); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Host and User-Agent are not parsed
-	if h.Host() != nil {
-		t.Fatalf("unexpected: %q. Expecting nil", h.Host())
+	// assert order of all headers preserved
+	if h.String() != s {
+		t.Fatalf("Headers not equal: %q. Expecting %q", h.String(), s)
 	}
-	if h.Host() != nil {
-		t.Fatalf("unexpected: %q. Expecting nil", h.UserAgent())
-	}
-	if strings.Contains(h.String(), "Host") {
-		t.Fatalf("special header Host in headers: %q", h.String())
-	}
-	// Host() returns nil, since canonical name was not used
 	h.SetCanonical([]byte("host"), []byte("notfoobar"))
-	if h.Host() != nil {
-		t.Fatalf("unexpected: %q. Expecting %q", h.Host(), "")
-	}
-	// add Host
-	h.SetCanonical([]byte("Host"), []byte("foobar"))
 	if string(h.Host()) != "foobar" {
 		t.Fatalf("unexpected: %q. Expecting %q", h.Host(), "foobar")
 	}
-	if h.String() != "GET / HTTP/1.0\r\nNon-Special: val\r\nhost: notfoobar\r\nHost: foobar\r\n\r\n" {
+	if h.String() != "GET / HTTP/1.0\r\nHost: foobar\r\nUser-Agent: ua\r\nNon-Special: val\r\nhost: notfoobar\r\n\r\n" {
 		t.Fatalf("custom special header ordering failed: %q", h.String())
 	}
 }


### PR DESCRIPTION
This is a PR is response to #1572 

Thanks for your quick response, and for your work in maintaining this package overall. Here is a PR to entirely disable fasthttp setting special headers for you. This way the user has complete control over headers and the burden is on them to make sure things work correctly.

Feedback is welcome
