### PR TITLE
Enable gofumpt linter; format code `gofumpt -w .`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,8 @@ jobs:
       with:
         go-version: 1.20.x
     - run: go version
-    - run: diff -u <(echo -n) <(gofmt -d .)
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.51.1
-        args: --enable=nolintlint,gochecknoinits,bodyclose --verbose
+        args: --enable=nolintlint,gochecknoinits,bodyclose,gofumpt --verbose

--- a/args_test.go
+++ b/args_test.go
@@ -182,7 +182,7 @@ func TestArgsEscape(t *testing.T) {
 
 	// Test all characters
 	k := "f.o,1:2/4"
-	var v = make([]byte, 256)
+	v := make([]byte, 256)
 	for i := 0; i < 256; i++ {
 		v[i] = byte(i)
 	}
@@ -210,7 +210,7 @@ func TestPathEscape(t *testing.T) {
 	testPathEscape(t, "*") // See https://github.com/golang/go/issues/11202
 
 	// Test all characters
-	var pathSegment = make([]byte, 256)
+	pathSegment := make([]byte, 256)
 	for i := 0; i < 256; i++ {
 		pathSegment[i] = byte(i)
 	}

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -204,7 +204,7 @@ func ParseUfloat(buf []byte) (float64, error) {
 	}
 	b := buf
 	var v uint64
-	var offset = 1.0
+	offset := 1.0
 	var pointFound bool
 	for i, c := range b {
 		if c < '0' || c > '9' {

--- a/bytesconv_table_gen.go
+++ b/bytesconv_table_gen.go
@@ -90,7 +90,7 @@ func main() {
 		// meaning to individual path segments. This package
 		// only manipulates the path as a whole, so we allow those
 		// last three as well. That leaves only ? to escape.
-		var a = quotedArgShouldEscapeTable
+		a := quotedArgShouldEscapeTable
 
 		for _, v := range `$&+,/:;=@` {
 			a[v] = 0
@@ -106,7 +106,7 @@ func main() {
 	fmt.Fprintf(w, "const quotedArgShouldEscapeTable = %q\n", quotedArgShouldEscapeTable)
 	fmt.Fprintf(w, "const quotedPathShouldEscapeTable = %q\n", quotedPathShouldEscapeTable)
 
-	if err := os.WriteFile("bytesconv_table.go", w.Bytes(), 0660); err != nil {
+	if err := os.WriteFile("bytesconv_table.go", w.Bytes(), 0o660); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/client_timing_wait_test.go
+++ b/client_timing_wait_test.go
@@ -40,7 +40,6 @@ func benchmarkClientGetEndToEndWaitConnInmemory(b *testing.B, parallelism int) {
 	ch := make(chan struct{})
 	sleepDuration := 50 * time.Millisecond
 	go func() {
-
 		if err := Serve(ln, newFasthttpSleepEchoHandler(sleepDuration)); err != nil {
 			b.Errorf("error when serving requests: %v", err)
 		}

--- a/cookie.go
+++ b/cookie.go
@@ -411,7 +411,6 @@ func (c *Cookie) ParseBytes(src []byte) error {
 					}
 				}
 			}
-
 		} else if len(kv.value) != 0 {
 			// Case insensitive switch on first char
 			switch kv.value[0] | 0x20 {

--- a/fasthttpproxy/proxy_env.go
+++ b/fasthttpproxy/proxy_env.go
@@ -47,7 +47,6 @@ func FasthttpProxyHTTPDialerTimeout(timeout time.Duration) fasthttp.DialFunc {
 	authHTTPSStorage := &atomic.Value{}
 
 	return func(addr string) (net.Conn, error) {
-
 		port, _, err := net.SplitHostPort(addr)
 		if err != nil {
 			return nil, fmt.Errorf("unexpected addr format: %w", err)

--- a/fasthttputil/pipeconns.go
+++ b/fasthttputil/pipeconns.go
@@ -218,8 +218,7 @@ var (
 	errConnectionClosed = errors.New("connection closed")
 )
 
-type timeoutError struct {
-}
+type timeoutError struct{}
 
 func (e *timeoutError) Error() string {
 	return "timeout"
@@ -233,10 +232,8 @@ func (e *timeoutError) Timeout() bool {
 	return true
 }
 
-var (
-	// ErrTimeout is returned from Read() or Write() on timeout.
-	ErrTimeout = &timeoutError{}
-)
+// ErrTimeout is returned from Read() or Write() on timeout.
+var ErrTimeout = &timeoutError{}
 
 func (c *pipeConn) Close() error {
 	return c.pc.Close()

--- a/fs_test.go
+++ b/fs_test.go
@@ -156,7 +156,7 @@ func TestServeFileSmallNoReadFrom(t *testing.T) {
 	tempdir := t.TempDir()
 
 	if err := os.WriteFile(
-		path.Join(tempdir, "hello"), []byte(teststr), 0666); err != nil {
+		path.Join(tempdir, "hello"), []byte(teststr), 0o666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/header_test.go
+++ b/header_test.go
@@ -1518,7 +1518,6 @@ func TestRequestHeaderConnectionClose(t *testing.T) {
 	if string(h1.Peek(HeaderConnection)) != "close" {
 		t.Fatalf("unexpected connection value: %q. Expecting %q", h.Peek("Connection"), "close")
 	}
-
 }
 
 func TestRequestHeaderSetCookie(t *testing.T) {
@@ -1753,7 +1752,6 @@ func TestResponseHeaderAddTrailerError(t *testing.T) {
 	if trailer := string(h.Peek(HeaderTrailer)); trailer != expectedTrailer {
 		t.Fatalf("unexpected trailer %q. Expected %q", trailer, expectedTrailer)
 	}
-
 }
 
 func TestRequestHeaderAddTrailerError(t *testing.T) {
@@ -1769,7 +1767,6 @@ func TestRequestHeaderAddTrailerError(t *testing.T) {
 	if trailer := string(h.Peek(HeaderTrailer)); trailer != expectedTrailer {
 		t.Fatalf("unexpected trailer %q. Expected %q", trailer, expectedTrailer)
 	}
-
 }
 
 func TestResponseHeaderCookie(t *testing.T) {
@@ -2789,7 +2786,8 @@ func testRequestHeaderReadSecuredError(t *testing.T, h *RequestHeader, headers s
 }
 
 func testResponseHeaderReadSuccess(t *testing.T, h *ResponseHeader, headers string, expectedStatusCode, expectedContentLength int,
-	expectedContentType string) {
+	expectedContentType string,
+) {
 	r := bytes.NewBufferString(headers)
 	br := bufio.NewReader(r)
 	err := h.Read(br)
@@ -2800,7 +2798,8 @@ func testResponseHeaderReadSuccess(t *testing.T, h *ResponseHeader, headers stri
 }
 
 func testRequestHeaderReadSuccess(t *testing.T, h *RequestHeader, headers string, expectedContentLength int,
-	expectedRequestURI, expectedHost, expectedReferer, expectedContentType string, expectedTrailer map[string]string) {
+	expectedRequestURI, expectedHost, expectedReferer, expectedContentType string, expectedTrailer map[string]string,
+) {
 	r := bytes.NewBufferString(headers)
 	br := bufio.NewReader(r)
 	err := h.Read(br)
@@ -2832,7 +2831,8 @@ func verifyResponseHeaderConnection(t *testing.T, h *ResponseHeader, expectConne
 }
 
 func verifyRequestHeader(t *testing.T, h *RequestHeader, expectedContentLength int,
-	expectedRequestURI, expectedHost, expectedReferer, expectedContentType string) {
+	expectedRequestURI, expectedHost, expectedReferer, expectedContentType string,
+) {
 	if h.ContentLength() != expectedContentLength {
 		t.Fatalf("Unexpected Content-Length %d. Expected %d", h.ContentLength(), expectedContentLength)
 	}
@@ -2922,6 +2922,7 @@ func TestRequestHeader_PeekAll(t *testing.T) {
 	expectRequestHeaderAll(t, h, HeaderHost, [][]byte{})
 	expectRequestHeaderAll(t, h, "aaa", [][]byte{})
 }
+
 func expectRequestHeaderAll(t *testing.T, h *RequestHeader, key string, expectedValue [][]byte) {
 	if len(h.PeekAll(key)) != len(expectedValue) {
 		t.Fatalf("Unexpected size for key %q: %d. Expected %d", key, len(h.PeekAll(key)), len(expectedValue))

--- a/header_timing_test.go
+++ b/header_timing_test.go
@@ -186,7 +186,7 @@ func BenchmarkRemoveNewLines(b *testing.B) {
 		expectedValue string
 	}
 
-	var testcases = []testcase{
+	testcases := []testcase{
 		{value: "MaliciousValue", expectedValue: "MaliciousValue"},
 		{value: "MaliciousValue\r\n", expectedValue: "MaliciousValue  "},
 		{value: "Malicious\nValue", expectedValue: "Malicious Value"},

--- a/http.go
+++ b/http.go
@@ -1287,13 +1287,11 @@ func (req *Request) ReadBody(r *bufio.Reader, contentLength int, maxBodySize int
 
 	if contentLength >= 0 {
 		bodyBuf.B, err = readBody(r, contentLength, maxBodySize, bodyBuf.B)
-
 	} else if contentLength == -1 {
 		bodyBuf.B, err = readBodyChunked(r, maxBodySize, bodyBuf.B)
 		if err == nil && len(bodyBuf.B) == 0 {
 			req.Header.SetContentLength(0)
 		}
-
 	} else {
 		bodyBuf.B, err = readBodyIdentity(r, maxBodySize, bodyBuf.B)
 		req.Header.SetContentLength(len(bodyBuf.B))

--- a/http_test.go
+++ b/http_test.go
@@ -2070,7 +2070,8 @@ func TestResponseReadWithoutBody(t *testing.T) {
 }
 
 func testResponseReadWithoutBody(t *testing.T, resp *Response, s string, skipBody bool,
-	expectedStatusCode, expectedContentLength int, expectedContentType string, expectedTrailer map[string]string) {
+	expectedStatusCode, expectedContentLength int, expectedContentType string, expectedTrailer map[string]string,
+) {
 	r := bytes.NewBufferString(s)
 	rb := bufio.NewReader(r)
 	resp.SkipBody = skipBody
@@ -2140,7 +2141,8 @@ func TestResponseSuccess(t *testing.T) {
 }
 
 func testResponseSuccess(t *testing.T, statusCode int, contentType, serverName, body string,
-	expectedStatusCode int, expectedContentType, expectedServerName string) {
+	expectedStatusCode int, expectedContentType, expectedServerName string,
+) {
 	var resp Response
 	resp.SetStatusCode(statusCode)
 	resp.Header.Set("Content-Type", contentType)
@@ -2310,7 +2312,6 @@ func TestResponseReadSuccess(t *testing.T) {
 	// chunked response with chunk extension
 	testResponseReadSuccess(t, resp, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n3;ext\r\naaa\r\n0\r\nFoo6: bar6\r\n\r\n",
 		200, -1, "text/html", "aaa", map[string]string{"Foo6": "bar6"})
-
 }
 
 func TestResponseReadError(t *testing.T) {
@@ -2349,8 +2350,8 @@ func testResponseReadError(t *testing.T, resp *Response, response string) {
 }
 
 func testResponseReadSuccess(t *testing.T, resp *Response, response string, expectedStatusCode, expectedContentLength int,
-	expectedContentType, expectedBody string, expectedTrailer map[string]string) {
-
+	expectedContentType, expectedBody string, expectedTrailer map[string]string,
+) {
 	r := bytes.NewBufferString(response)
 	rb := bufio.NewReader(r)
 	err := resp.Read(rb)
@@ -3119,7 +3120,6 @@ func TestRequestMultipartFormPipeEmptyFormField(t *testing.T) {
 	var b bytes.Buffer
 	bw := bufio.NewWriter(&b)
 	err := writeBodyChunked(bw, pr)
-
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/prefork/prefork_test.go
+++ b/prefork/prefork_test.go
@@ -73,7 +73,6 @@ func Test_listen(t *testing.T) {
 	addr := getAddr()
 
 	ln, err := p.listen(addr)
-
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -106,7 +105,6 @@ func Test_setTCPListenerFiles(t *testing.T) {
 	addr := getAddr()
 
 	err := p.setTCPListenerFiles(addr)
-
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/server.go
+++ b/server.go
@@ -19,10 +19,8 @@ import (
 
 var errNoCertOrKeyProvided = errors.New("cert or key has not provided")
 
-var (
-	// Deprecated: ErrAlreadyServing is never returned from Serve. See issue #633.
-	ErrAlreadyServing = errors.New("Server is already serving connections")
-)
+// Deprecated: ErrAlreadyServing is never returned from Serve. See issue #633.
+var ErrAlreadyServing = errors.New("Server is already serving connections")
 
 // ServeConn serves HTTP requests from the given connection
 // using the given handler.

--- a/server_test.go
+++ b/server_test.go
@@ -1727,6 +1727,7 @@ func TestSetStandardFormValueFunc(t *testing.T) {
 		t.Fatalf("unexpected value %q. Expecting %q", v, "port")
 	}
 }
+
 func TestRequestCtxUserValue(t *testing.T) {
 	t.Parallel()
 
@@ -2082,7 +2083,8 @@ func TestServeConnKeepRequestAndResponseUntilResetUserValues(t *testing.T) {
 					resultRespStr = closerCtx.Response.String()
 
 					return nil
-				}})
+				},
+			})
 		})
 		if err != nil {
 			t.Errorf("unexpected error in ServeConn: %v", err)
@@ -2178,7 +2180,8 @@ func TestServeConnHijackResetUserValues(t *testing.T) {
 					close(ch)
 
 					return nil
-				}},
+				},
+			},
 			)
 		})
 		if err != nil {

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -116,9 +116,7 @@ func DialDualStackTimeout(addr string, timeout time.Duration) (net.Conn, error) 
 	return defaultDialer.DialDualStackTimeout(addr, timeout)
 }
 
-var (
-	defaultDialer = &TCPDialer{Concurrency: 1000}
-)
+var defaultDialer = &TCPDialer{Concurrency: 1000}
 
 // Resolver represents interface of the tcp resolver.
 type Resolver interface {

--- a/uri.go
+++ b/uri.go
@@ -268,9 +268,7 @@ func (u *URI) SetHostBytes(host []byte) {
 	lowercaseBytes(u.host)
 }
 
-var (
-	ErrorInvalidURI = errors.New("invalid uri")
-)
+var ErrorInvalidURI = errors.New("invalid uri")
 
 // Parse initializes URI from the given host and uri.
 //

--- a/uri_test.go
+++ b/uri_test.go
@@ -239,7 +239,6 @@ func TestURICopyTo(t *testing.T) {
 	if !reflect.DeepEqual(u, copyU) { //nolint:govet
 		t.Fatalf("URICopyTo fail, u: \n%+v\ncopyu: \n%+v\n", u, copyU) //nolint:govet
 	}
-
 }
 
 func TestURIFullURI(t *testing.T) {
@@ -417,7 +416,8 @@ func TestURIParse(t *testing.T) {
 }
 
 func testURIParse(t *testing.T, u *URI, host, uri,
-	expectedURI, expectedHost, expectedPath, expectedPathOriginal, expectedArgs, expectedHash string) {
+	expectedURI, expectedHost, expectedPath, expectedPathOriginal, expectedArgs, expectedHash string,
+) {
 	u.Parse([]byte(host), []byte(uri)) //nolint:errcheck
 
 	if !bytes.Equal(u.FullURI(), []byte(expectedURI)) {

--- a/userdata_test.go
+++ b/userdata_test.go
@@ -102,7 +102,6 @@ func TestUserDataDelete(t *testing.T) {
 		u.Set(key, i)
 		testUserDataGet(t, &u, []byte(key), i)
 	}
-
 }
 
 func TestUserDataSetAndRemove(t *testing.T) {


### PR DESCRIPTION
This PR:

- Formats all code with the command [`gofumpt -w .`](https://github.com/mvdan/gofumpt) (removed empty lines, replaces `var a =` with `a :=`, `}` indentation, octal literals etc.)
- Enables `gofumpt` linter in golangci-lint args to ensure everyone will follow the consistent style in future PRs;
- Removes `gofmt` because it's rules are a subset of `gofumpt`.