### PR TITLE
Auto add 'Vary' header after compression

### DIFF
--- a/header.go
+++ b/header.go
@@ -344,8 +344,8 @@ func (h *ResponseHeader) SetContentEncodingBytes(contentEncoding []byte) {
 	h.contentEncoding = append(h.contentEncoding[:0], contentEncoding...)
 }
 
-// AddVaryBytes add value to the 'Vary' header if it's not included
-func (h *ResponseHeader) AddVaryBytes(value []byte) {
+// addVaryBytes add value to the 'Vary' header if it's not included
+func (h *ResponseHeader) addVaryBytes(value []byte) {
 	v := h.peek(strVary)
 	if len(v) == 0 {
 		// 'Vary' is not set

--- a/header.go
+++ b/header.go
@@ -344,6 +344,18 @@ func (h *ResponseHeader) SetContentEncodingBytes(contentEncoding []byte) {
 	h.contentEncoding = append(h.contentEncoding[:0], contentEncoding...)
 }
 
+// AddVaryBytes add value to the 'Vary' header if it's not included
+func (h *ResponseHeader) AddVaryBytes(value []byte) {
+	v := h.peek(strVary)
+	if len(v) == 0 {
+		// 'Vary' is not set
+		h.SetBytesV(HeaderVary, value)
+	} else if !bytes.Contains(v, value) {
+		// 'Vary' is set and not contains target value
+		h.SetBytesV(HeaderVary, append(append(v, ','), value...))
+	} // else: 'Vary' is set and contains target value
+}
+
 // Server returns Server header value.
 func (h *ResponseHeader) Server() []byte {
 	return h.server

--- a/header_test.go
+++ b/header_test.go
@@ -3007,3 +3007,65 @@ func TestResponseHeader_Keys(t *testing.T) {
 		t.Fatalf("Unexpected value %q. Expected %q", actualTrailerKeys, expectedTrailerKeys)
 	}
 }
+
+func TestAddVaryHeader(t *testing.T) {
+	t.Parallel()
+
+	var h ResponseHeader
+
+	h.AddVaryBytes([]byte("Accept-Encoding"))
+	got := string(h.Peek("Vary"))
+	expected := "Accept-Encoding"
+	if got != expected {
+		t.Errorf("expected %q got %q", expected, got)
+	}
+
+	var buf bytes.Buffer
+	h.WriteTo(&buf) //nolint:errcheck
+
+	if n := strings.Count(buf.String(), "Vary: "); n != 1 {
+		t.Errorf("Vary occurred %d times", n)
+	}
+}
+
+func TestAddVaryHeaderExisting(t *testing.T) {
+	t.Parallel()
+
+	var h ResponseHeader
+
+	h.Set("Vary", "Accept")
+	h.AddVaryBytes([]byte("Accept-Encoding"))
+	got := string(h.Peek("Vary"))
+	expected := "Accept,Accept-Encoding"
+	if got != expected {
+		t.Errorf("expected %q got %q", expected, got)
+	}
+
+	var buf bytes.Buffer
+	h.WriteTo(&buf) //nolint:errcheck
+
+	if n := strings.Count(buf.String(), "Vary: "); n != 1 {
+		t.Errorf("Vary occurred %d times", n)
+	}
+}
+
+func TestAddVaryHeaderExistingAcceptEncoding(t *testing.T) {
+	t.Parallel()
+
+	var h ResponseHeader
+
+	h.Set("Vary", "Accept-Encoding")
+	h.AddVaryBytes([]byte("Accept-Encoding"))
+	got := string(h.Peek("Vary"))
+	expected := "Accept-Encoding"
+	if got != expected {
+		t.Errorf("expected %q got %q", expected, got)
+	}
+
+	var buf bytes.Buffer
+	h.WriteTo(&buf) //nolint:errcheck
+
+	if n := strings.Count(buf.String(), "Vary: "); n != 1 {
+		t.Errorf("Vary occurred %d times", n)
+	}
+}

--- a/header_test.go
+++ b/header_test.go
@@ -3013,7 +3013,7 @@ func TestAddVaryHeader(t *testing.T) {
 
 	var h ResponseHeader
 
-	h.AddVaryBytes([]byte("Accept-Encoding"))
+	h.addVaryBytes([]byte("Accept-Encoding"))
 	got := string(h.Peek("Vary"))
 	expected := "Accept-Encoding"
 	if got != expected {
@@ -3034,7 +3034,7 @@ func TestAddVaryHeaderExisting(t *testing.T) {
 	var h ResponseHeader
 
 	h.Set("Vary", "Accept")
-	h.AddVaryBytes([]byte("Accept-Encoding"))
+	h.addVaryBytes([]byte("Accept-Encoding"))
 	got := string(h.Peek("Vary"))
 	expected := "Accept,Accept-Encoding"
 	if got != expected {
@@ -3055,7 +3055,7 @@ func TestAddVaryHeaderExistingAcceptEncoding(t *testing.T) {
 	var h ResponseHeader
 
 	h.Set("Vary", "Accept-Encoding")
-	h.AddVaryBytes([]byte("Accept-Encoding"))
+	h.addVaryBytes([]byte("Accept-Encoding"))
 	got := string(h.Peek("Vary"))
 	expected := "Accept-Encoding"
 	if got != expected {

--- a/http.go
+++ b/http.go
@@ -21,6 +21,7 @@ import (
 var (
 	requestBodyPoolSizeLimit  = -1
 	responseBodyPoolSizeLimit = -1
+	addVaryHeaderForCompress  = false
 )
 
 // SetBodySizePoolLimit set the max body size for bodies to be returned to the pool.
@@ -28,6 +29,12 @@ var (
 func SetBodySizePoolLimit(reqBodyLimit, respBodyLimit int) {
 	requestBodyPoolSizeLimit = reqBodyLimit
 	responseBodyPoolSizeLimit = respBodyLimit
+}
+
+// SetAddVaryHeaderForCompression enables(or disables if enable is false) the
+// 'Vary: Accept-Encoding' header when compression is used.
+func SetAddVaryHeaderForCompression(enable bool) {
+	addVaryHeaderForCompress = enable
 }
 
 // Request represents HTTP request.
@@ -1723,6 +1730,9 @@ func (resp *Response) brotliBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strBr)
+	if addVaryHeaderForCompress {
+		resp.Header.Set("Vary", "Accept-Encoding")
+	}
 	return nil
 }
 
@@ -1778,6 +1788,9 @@ func (resp *Response) gzipBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strGzip)
+	if addVaryHeaderForCompress {
+		resp.Header.Set("Vary", "Accept-Encoding")
+	}
 	return nil
 }
 
@@ -1833,6 +1846,9 @@ func (resp *Response) deflateBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strDeflate)
+	if addVaryHeaderForCompress {
+		resp.Header.Set("Vary", "Accept-Encoding")
+	}
 	return nil
 }
 

--- a/http.go
+++ b/http.go
@@ -1723,7 +1723,7 @@ func (resp *Response) brotliBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strBr)
-	resp.Header.Set("Vary", "Accept-Encoding")
+	resp.Header.AddVaryBytes(strAcceptEncoding)
 	return nil
 }
 
@@ -1779,7 +1779,7 @@ func (resp *Response) gzipBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strGzip)
-	resp.Header.Set("Vary", "Accept-Encoding")
+	resp.Header.AddVaryBytes(strAcceptEncoding)
 	return nil
 }
 
@@ -1835,7 +1835,7 @@ func (resp *Response) deflateBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strDeflate)
-	resp.Header.Set("Vary", "Accept-Encoding")
+	resp.Header.AddVaryBytes(strAcceptEncoding)
 	return nil
 }
 

--- a/http.go
+++ b/http.go
@@ -1723,7 +1723,7 @@ func (resp *Response) brotliBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strBr)
-	resp.Header.AddVaryBytes(strAcceptEncoding)
+	resp.Header.addVaryBytes(strAcceptEncoding)
 	return nil
 }
 
@@ -1779,7 +1779,7 @@ func (resp *Response) gzipBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strGzip)
-	resp.Header.AddVaryBytes(strAcceptEncoding)
+	resp.Header.addVaryBytes(strAcceptEncoding)
 	return nil
 }
 
@@ -1835,7 +1835,7 @@ func (resp *Response) deflateBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strDeflate)
-	resp.Header.AddVaryBytes(strAcceptEncoding)
+	resp.Header.addVaryBytes(strAcceptEncoding)
 	return nil
 }
 

--- a/http.go
+++ b/http.go
@@ -21,7 +21,6 @@ import (
 var (
 	requestBodyPoolSizeLimit  = -1
 	responseBodyPoolSizeLimit = -1
-	addVaryHeaderForCompress  = false
 )
 
 // SetBodySizePoolLimit set the max body size for bodies to be returned to the pool.
@@ -29,12 +28,6 @@ var (
 func SetBodySizePoolLimit(reqBodyLimit, respBodyLimit int) {
 	requestBodyPoolSizeLimit = reqBodyLimit
 	responseBodyPoolSizeLimit = respBodyLimit
-}
-
-// SetAddVaryHeaderForCompression enables(or disables if enable is false) the
-// 'Vary: Accept-Encoding' header when compression is used.
-func SetAddVaryHeaderForCompression(enable bool) {
-	addVaryHeaderForCompress = enable
 }
 
 // Request represents HTTP request.
@@ -1730,9 +1723,7 @@ func (resp *Response) brotliBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strBr)
-	if addVaryHeaderForCompress {
-		resp.Header.Set("Vary", "Accept-Encoding")
-	}
+	resp.Header.Set("Vary", "Accept-Encoding")
 	return nil
 }
 
@@ -1788,9 +1779,7 @@ func (resp *Response) gzipBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strGzip)
-	if addVaryHeaderForCompress {
-		resp.Header.Set("Vary", "Accept-Encoding")
-	}
+	resp.Header.Set("Vary", "Accept-Encoding")
 	return nil
 }
 
@@ -1846,9 +1835,7 @@ func (resp *Response) deflateBody(level int) error {
 		resp.bodyRaw = nil
 	}
 	resp.Header.SetContentEncodingBytes(strDeflate)
-	if addVaryHeaderForCompress {
-		resp.Header.Set("Vary", "Accept-Encoding")
-	}
+	resp.Header.Set("Vary", "Accept-Encoding")
 	return nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -1960,6 +1960,10 @@ func TestCompressHandler(t *testing.T) {
 	if string(ce) != "" {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "")
 	}
+	vary := resp.Header.Peek("Vary")
+	if string(vary) != "" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
+	}
 	body := resp.Body()
 	if string(body) != expectedBody {
 		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
@@ -1979,6 +1983,10 @@ func TestCompressHandler(t *testing.T) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "gzip")
+	}
+	vary = resp.Header.Peek("Vary")
+	if string(vary) != "" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
 	}
 	body, err := resp.BodyGunzip()
 	if err != nil {
@@ -2003,6 +2011,10 @@ func TestCompressHandler(t *testing.T) {
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "gzip")
 	}
+	vary = resp.Header.Peek("Vary")
+	if string(vary) != "" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
+	}
 	body, err = resp.BodyGunzip()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2026,7 +2038,156 @@ func TestCompressHandler(t *testing.T) {
 	if string(ce) != "deflate" {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "deflate")
 	}
+	vary = resp.Header.Peek("Vary")
+	if string(vary) != "" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
+	}
 	body, err = resp.BodyInflate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != expectedBody {
+		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
+	}
+}
+
+func TestCompressHandlerVary(t *testing.T) {
+	t.Parallel()
+
+	expectedBody := string(createFixedBody(2e4))
+	// enable 'Vary' header
+	SetAddVaryHeaderForCompression(true)
+	// Restore default value
+	defer SetAddVaryHeaderForCompression(false)
+
+	h := CompressHandlerBrotliLevel(func(ctx *RequestCtx) {
+		ctx.WriteString(expectedBody) //nolint:errcheck
+	}, CompressBrotliBestSpeed, CompressBestSpeed)
+
+	var ctx RequestCtx
+	var resp Response
+
+	// verify uncompressed response
+	h(&ctx)
+	s := ctx.Response.String()
+	br := bufio.NewReader(bytes.NewBufferString(s))
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ce := resp.Header.ContentEncoding()
+	if string(ce) != "" {
+		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "")
+	}
+	vary := resp.Header.Peek("Vary")
+	if string(vary) != "" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
+	}
+	body := resp.Body()
+	if string(body) != expectedBody {
+		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
+	}
+
+	// verify gzip-compressed response
+	ctx.Request.Reset()
+	ctx.Response.Reset()
+	ctx.Request.Header.Set("Accept-Encoding", "gzip, deflate, sdhc")
+
+	h(&ctx)
+	s = ctx.Response.String()
+	br = bufio.NewReader(bytes.NewBufferString(s))
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ce = resp.Header.ContentEncoding()
+	if string(ce) != "gzip" {
+		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "gzip")
+	}
+	vary = resp.Header.Peek("Vary")
+	if string(vary) != "Accept-Encoding" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "Accept-Encoding")
+	}
+	body, err := resp.BodyGunzip()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != expectedBody {
+		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
+	}
+
+	// an attempt to compress already compressed response
+	ctx.Request.Reset()
+	ctx.Response.Reset()
+	ctx.Request.Header.Set("Accept-Encoding", "gzip, deflate, sdhc")
+	hh := CompressHandler(h)
+	hh(&ctx)
+	s = ctx.Response.String()
+	br = bufio.NewReader(bytes.NewBufferString(s))
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ce = resp.Header.ContentEncoding()
+	if string(ce) != "gzip" {
+		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "gzip")
+	}
+	vary = resp.Header.Peek("Vary")
+	if string(vary) != "Accept-Encoding" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "Accept-Encoding")
+	}
+	body, err = resp.BodyGunzip()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != expectedBody {
+		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
+	}
+
+	// verify deflate-compressed response
+	ctx.Request.Reset()
+	ctx.Response.Reset()
+	ctx.Request.Header.Set(HeaderAcceptEncoding, "foobar, deflate, sdhc")
+
+	h(&ctx)
+	s = ctx.Response.String()
+	br = bufio.NewReader(bytes.NewBufferString(s))
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ce = resp.Header.ContentEncoding()
+	if string(ce) != "deflate" {
+		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "deflate")
+	}
+	vary = resp.Header.Peek("Vary")
+	if string(vary) != "Accept-Encoding" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "Accept-Encoding")
+	}
+	body, err = resp.BodyInflate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != expectedBody {
+		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
+	}
+
+	// verify br-compressed response
+	ctx.Request.Reset()
+	ctx.Response.Reset()
+	ctx.Request.Header.Set(HeaderAcceptEncoding, "gzip, deflate, br")
+
+	h(&ctx)
+	s = ctx.Response.String()
+	br = bufio.NewReader(bytes.NewBufferString(s))
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ce = resp.Header.ContentEncoding()
+	if string(ce) != "br" {
+		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "br")
+	}
+	vary = resp.Header.Peek("Vary")
+	if string(vary) != "Accept-Encoding" {
+		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "Accept-Encoding")
+	}
+	body, err = resp.BodyUnbrotli()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1960,10 +1960,6 @@ func TestCompressHandler(t *testing.T) {
 	if string(ce) != "" {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "")
 	}
-	vary := resp.Header.Peek("Vary")
-	if string(vary) != "" {
-		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
-	}
 	body := resp.Body()
 	if string(body) != expectedBody {
 		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
@@ -1983,10 +1979,6 @@ func TestCompressHandler(t *testing.T) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "gzip")
-	}
-	vary = resp.Header.Peek("Vary")
-	if string(vary) != "" {
-		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
 	}
 	body, err := resp.BodyGunzip()
 	if err != nil {
@@ -2011,10 +2003,6 @@ func TestCompressHandler(t *testing.T) {
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "gzip")
 	}
-	vary = resp.Header.Peek("Vary")
-	if string(vary) != "" {
-		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
-	}
 	body, err = resp.BodyGunzip()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2038,10 +2026,6 @@ func TestCompressHandler(t *testing.T) {
 	if string(ce) != "deflate" {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "deflate")
 	}
-	vary = resp.Header.Peek("Vary")
-	if string(vary) != "" {
-		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
-	}
 	body, err = resp.BodyInflate()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2055,10 +2039,6 @@ func TestCompressHandlerVary(t *testing.T) {
 	t.Parallel()
 
 	expectedBody := string(createFixedBody(2e4))
-	// enable 'Vary' header
-	SetAddVaryHeaderForCompression(true)
-	// Restore default value
-	defer SetAddVaryHeaderForCompression(false)
 
 	h := CompressHandlerBrotliLevel(func(ctx *RequestCtx) {
 		ctx.WriteString(expectedBody) //nolint:errcheck

--- a/strings.go
+++ b/strings.go
@@ -57,6 +57,7 @@ var (
 	strProxyAuthenticate  = []byte(HeaderProxyAuthenticate)
 	strProxyAuthorization = []byte(HeaderProxyAuthorization)
 	strWWWAuthenticate    = []byte(HeaderWWWAuthenticate)
+	strVary               = []byte(HeaderVary)
 
 	strCookieExpires        = []byte("expires")
 	strCookieDomain         = []byte("domain")


### PR DESCRIPTION
Add config `SetAddVaryHeaderForCompression` to enable 'Vary: Accept-Encoding' header when compression is used.

Added a config variable `addVaryHeaderForCompress` to control this feature, with setter `SetAddVaryHeaderForCompression`.
To remain backward compatible, it's false by default.
When enabled, 'Vary: Accept-Encoding' header will be added when compression is used.

fix #1583