### PR TITLE
Allow connection close for custom streams

### DIFF
--- a/client.go
+++ b/client.go
@@ -2905,11 +2905,10 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	if customStreamBody && resp.bodyStream != nil {
 		rbs := resp.bodyStream
 		resp.bodyStream = newCloseReader(rbs, func() error {
-			closeConn = closeConn || resp.ConnectionClose()
 			if r, ok := rbs.(*requestStream); ok {
 				releaseRequestStream(r)
 			}
-			if closeConn {
+			if closeConn || resp.ConnectionClose() {
 				hc.closeConn(cc)
 			} else {
 				hc.releaseConn(cc)

--- a/client.go
+++ b/client.go
@@ -2905,7 +2905,7 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	if customStreamBody && resp.bodyStream != nil {
 		rbs := resp.bodyStream
 		resp.bodyStream = newCloseReader(rbs, func() error {
-			closeConn = closeConn || req.ConnectionClose() || resp.ConnectionClose()
+			closeConn = closeConn || resp.ConnectionClose()
 			if r, ok := rbs.(*requestStream); ok {
 				releaseRequestStream(r)
 			}

--- a/client.go
+++ b/client.go
@@ -2905,6 +2905,7 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	if customStreamBody && resp.bodyStream != nil {
 		rbs := resp.bodyStream
 		resp.bodyStream = newCloseReader(rbs, func() error {
+			closeConn = closeConn || req.ConnectionClose() || resp.ConnectionClose()
 			if r, ok := rbs.(*requestStream); ok {
 				releaseRequestStream(r)
 			}

--- a/http.go
+++ b/http.go
@@ -1106,8 +1106,8 @@ func (resp *Response) Reset() {
 	if responseBodyPoolSizeLimit >= 0 && resp.body != nil {
 		resp.ReleaseBody(responseBodyPoolSizeLimit)
 	}
-	resp.Header.Reset()
 	resp.resetSkipHeader()
+	resp.Header.Reset()
 	resp.SkipBody = false
 	resp.raddr = nil
 	resp.laddr = nil


### PR DESCRIPTION
We do use fasthttp for our project as a proxy between an uplink connection and a target. We discovered the following scenario where we run into an issue that we can't solve without a minor change to the fasthttp client.

The scenario that we have is the following:

From the upsteam connection we get a request which is replied with a steam of data from the target. All works fine using fasthttp and the customStream body. We simply copy from the target reader to the upstream writer. Now the upstream suddenly closes the TCP connection and we get an error while trying to copy our data from the target.

Now we definitelly want to close the still open connection to the target. The only thing we can do from within the handler is set `fastRequest.SetConnectionClose()` and `fastResponse.SetConnectionClose()`. Though, the TCP connection will not be closed since it is too late when we set those values. The TCP connection is released and eventually re-used by the next upstream connection which would then result into an unexpected error.

If the closeConn check is done again in the newCloseReader wrapper function we could set the ConnectionClose() property from the outside and the connection will be closed once we release our request handler.