### PR TITLE
fix round2_32

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +15,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/valyala/bytebufferpool"
 )
@@ -1965,34 +1963,6 @@ func testSetResponseBodyStreamChunked(t *testing.T, body string, trailer map[str
 		if string(r) != v {
 			t.Fatalf("unexpected trailer %q. Expecting %q. Got %q", k, v, r)
 		}
-	}
-}
-
-func TestRound2ForSliceCap(t *testing.T) {
-	t.Parallel()
-
-	testRound2ForSliceCap(t, 0, 0)
-	testRound2ForSliceCap(t, 1, 1)
-	testRound2ForSliceCap(t, 2, 2)
-	testRound2ForSliceCap(t, 3, 4)
-	testRound2ForSliceCap(t, 4, 4)
-	testRound2ForSliceCap(t, 5, 8)
-	testRound2ForSliceCap(t, 7, 8)
-	testRound2ForSliceCap(t, 8, 8)
-	testRound2ForSliceCap(t, 9, 16)
-	testRound2ForSliceCap(t, 0x10001, 0x20000)
-
-	if unsafe.Sizeof(int(0)) == 4 {
-		testRound2ForSliceCap(t, math.MaxInt32-1, math.MaxInt32)
-	} else {
-		testRound2ForSliceCap(t, math.MaxInt32, math.MaxInt32)
-		testRound2ForSliceCap(t, math.MaxInt64-1, math.MaxInt64-1)
-	}
-}
-
-func testRound2ForSliceCap(t *testing.T, n, expectedRound2 int) {
-	if roundUpForSliceCap(n) != expectedRound2 {
-		t.Fatalf("Unexpected round2(%d)=%d. Expected %d", n, roundUpForSliceCap(n), expectedRound2)
 	}
 }
 

--- a/round2_32.go
+++ b/round2_32.go
@@ -3,6 +3,8 @@
 
 package fasthttp
 
+import "math"
+
 func roundUpForSliceCap(n int) int {
 	if n <= 0 {
 		return 0

--- a/round2_32_test.go
+++ b/round2_32_test.go
@@ -1,0 +1,32 @@
+//go:build !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x
+// +build !amd64,!arm64,!ppc64,!ppc64le,!s390x
+
+package fasthttp
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRound2ForSliceCap(t *testing.T) {
+	t.Parallel()
+
+	testRound2ForSliceCap(t, 0, 0)
+	testRound2ForSliceCap(t, 1, 1)
+	testRound2ForSliceCap(t, 2, 2)
+	testRound2ForSliceCap(t, 3, 4)
+	testRound2ForSliceCap(t, 4, 4)
+	testRound2ForSliceCap(t, 5, 8)
+	testRound2ForSliceCap(t, 7, 8)
+	testRound2ForSliceCap(t, 8, 8)
+	testRound2ForSliceCap(t, 9, 16)
+	testRound2ForSliceCap(t, 0x10001, 0x20000)
+
+	testRound2ForSliceCap(t, math.MaxInt32-1, math.MaxInt32-1)
+}
+
+func testRound2ForSliceCap(t *testing.T, n, expectedRound2 int) {
+	if roundUpForSliceCap(n) != expectedRound2 {
+		t.Fatalf("Unexpected round2(%d)=%d. Expected %d", n, roundUpForSliceCap(n), expectedRound2)
+	}
+}

--- a/round2_64_test.go
+++ b/round2_64_test.go
@@ -1,0 +1,33 @@
+//go:build amd64 || arm64 || ppc64 || ppc64le || s390x
+// +build amd64 arm64 ppc64 ppc64le s390x
+
+package fasthttp
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRound2ForSliceCap(t *testing.T) {
+	t.Parallel()
+
+	testRound2ForSliceCap(t, 0, 0)
+	testRound2ForSliceCap(t, 1, 1)
+	testRound2ForSliceCap(t, 2, 2)
+	testRound2ForSliceCap(t, 3, 4)
+	testRound2ForSliceCap(t, 4, 4)
+	testRound2ForSliceCap(t, 5, 8)
+	testRound2ForSliceCap(t, 7, 8)
+	testRound2ForSliceCap(t, 8, 8)
+	testRound2ForSliceCap(t, 9, 16)
+	testRound2ForSliceCap(t, 0x10001, 0x20000)
+
+	testRound2ForSliceCap(t, math.MaxInt32, math.MaxInt32)
+	testRound2ForSliceCap(t, math.MaxInt64-1, math.MaxInt64-1)
+}
+
+func testRound2ForSliceCap(t *testing.T, n, expectedRound2 int) {
+	if roundUpForSliceCap(n) != expectedRound2 {
+		t.Fatalf("Unexpected round2(%d)=%d. Expected %d", n, roundUpForSliceCap(n), expectedRound2)
+	}
+}


### PR DESCRIPTION
There was a missing import in `round2_32.go`.

I split the tests into per int size files too, since `unsafe.Sizeof(int(0)) == 4` runtime does not allow to pass 64 bit constants to 32 bit functions at compile time. Not sure if there is a better solution.