### PR TITLE
Enable gocritic linter; fix lint issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.54.2
-        args: --enable=nolintlint,gochecknoinits,bodyclose,gofumpt --verbose
+        args: --enable=nolintlint,gochecknoinits,bodyclose,gofumpt,gocritic --verbose

--- a/args.go
+++ b/args.go
@@ -552,13 +552,14 @@ func decodeArgAppend(dst, src []byte) []byte {
 	}
 
 	idx := 0
-	if idxPercent == -1 {
+	switch {
+	case idxPercent == -1:
 		idx = idxPlus
-	} else if idxPlus == -1 {
+	case idxPlus == -1:
 		idx = idxPercent
-	} else if idxPercent > idxPlus {
+	case idxPercent > idxPlus:
 		idx = idxPlus
-	} else {
+	default:
 		idx = idxPercent
 	}
 
@@ -567,7 +568,8 @@ func decodeArgAppend(dst, src []byte) []byte {
 	// slow path
 	for i := idx; i < len(src); i++ {
 		c := src[i]
-		if c == '%' {
+		switch c {
+		case '%':
 			if i+2 >= len(src) {
 				return append(dst, src[i:]...)
 			}
@@ -579,9 +581,9 @@ func decodeArgAppend(dst, src []byte) []byte {
 				dst = append(dst, x1<<4|x2)
 				i += 2
 			}
-		} else if c == '+' {
+		case '+':
 			dst = append(dst, ' ')
-		} else {
+		default:
 			dst = append(dst, c)
 		}
 	}

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -82,10 +82,8 @@ func testParseIPv4(t *testing.T, ipStr string, isValid bool) {
 		if s != ipStr {
 			t.Fatalf("unexpected ip parsed %q. Expecting %q", s, ipStr)
 		}
-	} else {
-		if err == nil {
-			t.Fatalf("expecting error when parsing ip %q", ipStr)
-		}
+	} else if err == nil {
+		t.Fatalf("expecting error when parsing ip %q", ipStr)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -1343,7 +1343,7 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 			userAgent = defaultUserAgent
 		}
 		if userAgent != "" {
-			req.Header.userAgent = append(req.Header.userAgent[:], userAgent...)
+			req.Header.userAgent = append(req.Header.userAgent[:0], userAgent...)
 		}
 	}
 
@@ -2303,7 +2303,7 @@ func (c *pipelineConnClient) DoDeadline(req *Request, resp *Response, deadline t
 			userAgent = defaultUserAgent
 		}
 		if userAgent != "" {
-			req.Header.userAgent = append(req.Header.userAgent[:], userAgent...)
+			req.Header.userAgent = append(req.Header.userAgent[:0], userAgent...)
 		}
 	}
 
@@ -2410,7 +2410,7 @@ func (c *pipelineConnClient) Do(req *Request, resp *Response) error {
 			userAgent = defaultUserAgent
 		}
 		if userAgent != "" {
-			req.Header.userAgent = append(req.Header.userAgent[:], userAgent...)
+			req.Header.userAgent = append(req.Header.userAgent[:0], userAgent...)
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -669,10 +669,12 @@ func TestClientHeaderCase(t *testing.T) {
 
 	code, body, err := c.Get(nil, "http://example.com")
 	if err != nil {
-		t.Error(err)
-	} else if code != 200 {
+		t.Fatal(err)
+	}
+	if code != 200 {
 		t.Errorf("expected status code 200 got %d", code)
-	} else if string(body) != "This is the data in the first chunk and this is the second one " {
+	}
+	if string(body) != "This is the data in the first chunk and this is the second one " {
 		t.Errorf("wrong body: %q", body)
 	}
 }

--- a/header.go
+++ b/header.go
@@ -1298,19 +1298,20 @@ func (h *ResponseHeader) setSpecialHeader(key, value []byte) bool {
 
 	switch key[0] | 0x20 {
 	case 'c':
-		if caseInsensitiveCompare(strContentType, key) {
+		switch {
+		case caseInsensitiveCompare(strContentType, key):
 			h.SetContentTypeBytes(value)
 			return true
-		} else if caseInsensitiveCompare(strContentLength, key) {
+		case caseInsensitiveCompare(strContentLength, key):
 			if contentLength, err := parseContentLength(value); err == nil {
 				h.contentLength = contentLength
 				h.contentLengthBytes = append(h.contentLengthBytes[:0], value...)
 			}
 			return true
-		} else if caseInsensitiveCompare(strContentEncoding, key) {
+		case caseInsensitiveCompare(strContentEncoding, key):
 			h.SetContentEncodingBytes(value)
 			return true
-		} else if caseInsensitiveCompare(strConnection, key) {
+		case caseInsensitiveCompare(strConnection, key):
 			if bytes.Equal(strClose, value) {
 				h.SetConnectionClose()
 			} else {
@@ -1361,16 +1362,17 @@ func (h *RequestHeader) setSpecialHeader(key, value []byte) bool {
 
 	switch key[0] | 0x20 {
 	case 'c':
-		if caseInsensitiveCompare(strContentType, key) {
+		switch {
+		case caseInsensitiveCompare(strContentType, key):
 			h.SetContentTypeBytes(value)
 			return true
-		} else if caseInsensitiveCompare(strContentLength, key) {
+		case caseInsensitiveCompare(strContentLength, key):
 			if contentLength, err := parseContentLength(value); err == nil {
 				h.contentLength = contentLength
 				h.contentLengthBytes = append(h.contentLengthBytes[:0], value...)
 			}
 			return true
-		} else if caseInsensitiveCompare(strConnection, key) {
+		case caseInsensitiveCompare(strConnection, key):
 			if bytes.Equal(strClose, value) {
 				h.SetConnectionClose()
 			} else {
@@ -1378,7 +1380,7 @@ func (h *RequestHeader) setSpecialHeader(key, value []byte) bool {
 				h.setNonSpecial(key, value)
 			}
 			return true
-		} else if caseInsensitiveCompare(strCookie, key) {
+		case caseInsensitiveCompare(strCookie, key):
 			h.collectCookies()
 			h.cookies = parseRequestCookies(h.cookies, value)
 			return true
@@ -2791,16 +2793,17 @@ func (h *RequestHeader) parseFirstLine(buf []byte) (int, error) {
 	protoStr := strHTTP11
 	// parse requestURI
 	n = bytes.LastIndexByte(b, ' ')
-	if n < 0 {
+	switch {
+	case n < 0:
 		h.noHTTP11 = true
 		n = len(b)
 		protoStr = strHTTP10
-	} else if n == 0 {
+	case n == 0:
 		if h.secureErrorLogMessage {
 			return 0, fmt.Errorf("requestURI cannot be empty")
 		}
 		return 0, fmt.Errorf("requestURI cannot be empty in %q", buf)
-	} else if !bytes.Equal(b[n+1:], strHTTP11) {
+	case !bytes.Equal(b[n+1:], strHTTP11):
 		h.noHTTP11 = true
 		protoStr = b[n+1:]
 	}
@@ -3268,15 +3271,16 @@ func normalizeHeaderValue(ov, ob []byte, headerLength int) (nv, nb []byte, nhl i
 	lineStart := false
 	for read := 0; read < length; read++ {
 		c := ov[read]
-		if c == rChar || c == nChar {
+		switch {
+		case c == rChar || c == nChar:
 			shrunk++
 			if c == nChar {
 				lineStart = true
 			}
 			continue
-		} else if lineStart && c == '\t' {
+		case lineStart && c == '\t':
 			c = ' '
-		} else {
+		default:
 			lineStart = false
 		}
 		nv[write] = c
@@ -3335,15 +3339,16 @@ func removeNewLines(raw []byte) []byte {
 	foundN := bytes.IndexByte(raw, nChar)
 	start := 0
 
-	if foundN != -1 {
+	switch {
+	case foundN != -1:
 		if foundR > foundN {
 			start = foundN
 		} else if foundR != -1 {
 			start = foundR
 		}
-	} else if foundR != -1 {
+	case foundR != -1:
 		start = foundR
-	} else {
+	default:
 		return raw
 	}
 

--- a/header_test.go
+++ b/header_test.go
@@ -1977,8 +1977,7 @@ func TestResponseHeaderCookieIssue4(t *testing.T) {
 	}
 	cookieSeen := false
 	h.VisitAll(func(key, _ []byte) {
-		switch string(key) {
-		case HeaderSetCookie:
+		if string(key) == HeaderSetCookie {
 			cookieSeen = true
 		}
 	})
@@ -1998,8 +1997,7 @@ func TestResponseHeaderCookieIssue4(t *testing.T) {
 	}
 	cookieSeen = false
 	h.VisitAll(func(key, _ []byte) {
-		switch string(key) {
-		case HeaderSetCookie:
+		if string(key) == HeaderSetCookie {
 			cookieSeen = true
 		}
 	})
@@ -2022,8 +2020,7 @@ func TestRequestHeaderCookieIssue313(t *testing.T) {
 	}
 	cookieSeen := false
 	h.VisitAll(func(key, _ []byte) {
-		switch string(key) {
-		case HeaderCookie:
+		if string(key) == HeaderCookie {
 			cookieSeen = true
 		}
 	})
@@ -2040,8 +2037,7 @@ func TestRequestHeaderCookieIssue313(t *testing.T) {
 	}
 	cookieSeen = false
 	h.VisitAll(func(key, _ []byte) {
-		switch string(key) {
-		case HeaderCookie:
+		if string(key) == HeaderCookie {
 			cookieSeen = true
 		}
 	})

--- a/http.go
+++ b/http.go
@@ -814,14 +814,15 @@ func (req *Request) ResetBody() {
 // CopyTo copies req contents to dst except of body stream.
 func (req *Request) CopyTo(dst *Request) {
 	req.copyToSkipBody(dst)
-	if req.bodyRaw != nil {
+	switch {
+	case req.bodyRaw != nil:
 		dst.bodyRaw = append(dst.bodyRaw[:0], req.bodyRaw...)
 		if dst.body != nil {
 			dst.body.Reset()
 		}
-	} else if req.body != nil {
+	case req.body != nil:
 		dst.bodyBuffer().Set(req.body.B)
-	} else if dst.body != nil {
+	case dst.body != nil:
 		dst.body.Reset()
 	}
 }
@@ -846,14 +847,15 @@ func (req *Request) copyToSkipBody(dst *Request) {
 // CopyTo copies resp contents to dst except of body stream.
 func (resp *Response) CopyTo(dst *Response) {
 	resp.copyToSkipBody(dst)
-	if resp.bodyRaw != nil {
+	switch {
+	case resp.bodyRaw != nil:
 		dst.bodyRaw = append(dst.bodyRaw, resp.bodyRaw...)
 		if dst.body != nil {
 			dst.body.Reset()
 		}
-	} else if resp.body != nil {
+	case resp.body != nil:
 		dst.bodyBuffer().Set(resp.body.B)
-	} else if dst.body != nil {
+	case dst.body != nil:
 		dst.body.Reset()
 	}
 }
@@ -1284,14 +1286,15 @@ func (req *Request) ReadBody(r *bufio.Reader, contentLength int, maxBodySize int
 	bodyBuf := req.bodyBuffer()
 	bodyBuf.Reset()
 
-	if contentLength >= 0 {
+	switch {
+	case contentLength >= 0:
 		bodyBuf.B, err = readBody(r, contentLength, maxBodySize, bodyBuf.B)
-	} else if contentLength == -1 {
+	case contentLength == -1:
 		bodyBuf.B, err = readBodyChunked(r, maxBodySize, bodyBuf.B)
 		if err == nil && len(bodyBuf.B) == 0 {
 			req.Header.SetContentLength(0)
 		}
-	} else {
+	default:
 		bodyBuf.B, err = readBodyIdentity(r, maxBodySize, bodyBuf.B)
 		req.Header.SetContentLength(len(bodyBuf.B))
 	}
@@ -1427,19 +1430,20 @@ func (resp *Response) ReadBody(r *bufio.Reader, maxBodySize int) (err error) {
 	bodyBuf.Reset()
 
 	contentLength := resp.Header.ContentLength()
-	if contentLength >= 0 {
+	switch {
+	case contentLength >= 0:
 		bodyBuf.B, err = readBody(r, contentLength, maxBodySize, bodyBuf.B)
 		if err == ErrBodyTooLarge && resp.StreamBody {
 			resp.bodyStream = acquireRequestStream(bodyBuf, r, &resp.Header)
 			err = nil
 		}
-	} else if contentLength == -1 {
+	case contentLength == -1:
 		if resp.StreamBody {
 			resp.bodyStream = acquireRequestStream(bodyBuf, r, &resp.Header)
 		} else {
 			bodyBuf.B, err = readBodyChunked(r, maxBodySize, bodyBuf.B)
 		}
-	} else {
+	default:
 		bodyBuf.B, err = readBodyIdentity(r, maxBodySize, bodyBuf.B)
 		resp.Header.SetContentLength(len(bodyBuf.B))
 	}

--- a/server.go
+++ b/server.go
@@ -549,11 +549,12 @@ func CompressHandlerLevel(h RequestHandler, level int) RequestHandler {
 func CompressHandlerBrotliLevel(h RequestHandler, brotliLevel, otherLevel int) RequestHandler {
 	return func(ctx *RequestCtx) {
 		h(ctx)
-		if ctx.Request.Header.HasAcceptEncodingBytes(strBr) {
+		switch {
+		case ctx.Request.Header.HasAcceptEncodingBytes(strBr):
 			ctx.Response.brotliBody(brotliLevel) //nolint:errcheck
-		} else if ctx.Request.Header.HasAcceptEncodingBytes(strGzip) {
+		case ctx.Request.Header.HasAcceptEncodingBytes(strGzip):
 			ctx.Response.gzipBody(otherLevel) //nolint:errcheck
-		} else if ctx.Request.Header.HasAcceptEncodingBytes(strDeflate) {
+		case ctx.Request.Header.HasAcceptEncodingBytes(strDeflate):
 			ctx.Response.deflateBody(otherLevel) //nolint:errcheck
 		}
 	}
@@ -2238,11 +2239,12 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 							panic(fmt.Sprintf("BUG: error in SetReadDeadline(%v): %v", deadline, err))
 						}
 					}
-					if reqConf.MaxRequestBodySize > 0 {
+					switch {
+					case reqConf.MaxRequestBodySize > 0:
 						maxRequestBodySize = reqConf.MaxRequestBodySize
-					} else if s.MaxRequestBodySize > 0 {
+					case s.MaxRequestBodySize > 0:
 						maxRequestBodySize = s.MaxRequestBodySize
-					} else {
+					default:
 						maxRequestBodySize = DefaultMaxRequestBodySize
 					}
 					if reqConf.WriteTimeout > 0 {

--- a/uri.go
+++ b/uri.go
@@ -688,7 +688,8 @@ func normalizePath(dst, src []byte) []byte {
 func (u *URI) RequestURI() []byte {
 	var dst []byte
 	if u.DisablePathNormalizing {
-		dst = append(u.requestURI[:0], u.PathOriginal()...)
+		dst = u.requestURI[:0]
+		dst = append(dst, u.PathOriginal()...)
 	} else {
 		dst = appendQuotedPath(u.requestURI[:0], u.Path())
 	}

--- a/userdata.go
+++ b/userdata.go
@@ -42,7 +42,8 @@ func (d *userData) Set(key interface{}, value interface{}) {
 	kv := userDataKV{}
 	kv.key = key
 	kv.value = value
-	*d = append(args, kv)
+	args = append(args, kv)
+	*d = args
 }
 
 func (d *userData) SetBytes(key []byte, value interface{}) {


### PR DESCRIPTION
This PR enables `gocritic` linter and fixes the following lint issues:
```
args.go:555:2: ifElseChain: rewrite if-else to switch statement (gocritic)
        if idxPercent == -1 {
        ^
args.go:570:3: ifElseChain: rewrite if-else to switch statement (gocritic)
                if c == '%' {
                ^
client.go:1346:34: unslice: could simplify req.Header.userAgent[:] to req.Header.userAgent (gocritic)
                        req.Header.userAgent = append(req.Header.userAgent[:], userAgent...)
                                                      ^
client.go:2306:34: unslice: could simplify req.Header.userAgent[:] to req.Header.userAgent (gocritic)
                        req.Header.userAgent = append(req.Header.userAgent[:], userAgent...)
                                                      ^
client.go:2413:34: unslice: could simplify req.Header.userAgent[:] to req.Header.userAgent (gocritic)
                        req.Header.userAgent = append(req.Header.userAgent[:], userAgent...)
                                                      ^
header.go:1301:3: ifElseChain: rewrite if-else to switch statement (gocritic)
                if caseInsensitiveCompare(strContentType, key) {
                ^
uri.go:691:9: appendAssign: append result not assigned to the same slice (gocritic)
                dst = append(u.requestURI[:0], u.PathOriginal()...)
                      ^
userdata.go:45:7: appendAssign: append result not assigned to the same slice (gocritic)
        *d = append(args, kv)
             ^
bytesconv_test.go:85:9: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
        } else {
               ^
header_test.go:1980:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
                switch string(key) {
                ^
header_test.go:2001:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
                switch string(key) {
                ^
header_test.go:2025:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
                switch string(key) {
                ^
```