### PR TITLE
docs: fix typos in comments and tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -2013,7 +2013,7 @@ func (w *wantConn) cancel(c *HostClient, err error) {
 //
 // inspired by net/http/transport.go
 type wantConnQueue struct {
-	// This is a queue, not a deque.
+	// This is a queue, not a dequeue.
 	// It is split into two stages - head[headPos:] and tail.
 	// popFront is trivial (headPos++) on the first stage, and
 	// pushBack is trivial (append) on the second stage.

--- a/fs_test.go
+++ b/fs_test.go
@@ -436,7 +436,7 @@ func testParseByteRangeSuccess(t *testing.T, v string, contentLength, startPos, 
 		t.Fatalf("unexpected startPos=%d. Expecting %d. v=%q, contentLength=%d", startPos1, startPos, v, contentLength)
 	}
 	if endPos1 != endPos {
-		t.Fatalf("unexpected endPos=%d. Expectind %d. v=%q, contentLenght=%d", endPos1, endPos, v, contentLength)
+		t.Fatalf("unexpected endPos=%d. Expecting %d. v=%q, contentLength=%d", endPos1, endPos, v, contentLength)
 	}
 }
 

--- a/header_test.go
+++ b/header_test.go
@@ -1227,7 +1227,7 @@ func TestRequestHeaderProxyWithCookie(t *testing.T) {
 		t.Fatalf("unexpected Foo: %q. Expecting %q", h1.Peek("Foo"), "bar")
 	}
 	if string(h1.Cookie("foo")) != "bar" {
-		t.Fatalf("unexpected coookie foo=%q. Expecting %q", h1.Cookie("foo"), "bar")
+		t.Fatalf("unexpected cookie foo=%q. Expecting %q", h1.Cookie("foo"), "bar")
 	}
 	if string(h1.Cookie("bazzz")) != "aaaaaaa" {
 		t.Fatalf("unexpected cookie bazzz=%q. Expecting %q", h1.Cookie("bazzz"), "aaaaaaa")
@@ -2356,14 +2356,14 @@ func TestResponseHeaderReadSuccess(t *testing.T) {
 		t.Fatalf("expecting connection: close")
 	}
 
-	// tranfer-encoding: chunked
+	// transfer-encoding: chunked
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 505 Internal error\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n",
 		505, -1, "text/html")
 	if h.ConnectionClose() {
 		t.Fatalf("unexpected connection: close")
 	}
 
-	// reverse order of content-type and tranfer-encoding
+	// reverse order of content-type and transfer-encoding
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 343 foobar\r\nTransfer-Encoding: chunked\r\nContent-Type: text/json\r\n\r\n",
 		343, -1, "text/json")
 

--- a/http_test.go
+++ b/http_test.go
@@ -1556,7 +1556,7 @@ func TestRequestMultipartForm(t *testing.T) {
 		formData = testRequestMultipartForm(t, boundary, formData, 10)
 	}
 
-	// verify request unmarshalling / marshalling
+	// verify request unmarshaling / marshaling
 	s := "POST / HTTP/1.1\r\nHost: aaa\r\nContent-Type: multipart/form-data; boundary=foobar\r\nContent-Length: 213\r\n\r\n--foobar\r\nContent-Disposition: form-data; name=\"key_0\"\r\n\r\nvalue_0\r\n--foobar\r\nContent-Disposition: form-data; name=\"key_1\"\r\n\r\nvalue_1\r\n--foobar\r\nContent-Disposition: form-data; name=\"key_2\"\r\n\r\nvalue_2\r\n--foobar--\r\n"
 
 	var req Request

--- a/server.go
+++ b/server.go
@@ -403,7 +403,7 @@ type Server struct {
 	// instead.
 	TLSConfig *tls.Config
 
-	// FormValueFunc, which is used by RequestCtx.FormValue and support for customising
+	// FormValueFunc, which is used by RequestCtx.FormValue and support for customizing
 	// the behaviour of the RequestCtx.FormValue function.
 	//
 	// NetHttpFormValueFunc gives a FormValueFunc func implementation that is consistent with net/http.

--- a/server_example_test.go
+++ b/server_example_test.go
@@ -133,7 +133,7 @@ func ExampleRequestCtx_TimeoutError() {
 			time.Sleep(workDuration)
 
 			fmt.Fprintf(ctx, "ctx has been accessed by long-running task\n")
-			fmt.Fprintf(ctx, "The reuqestHandler may be finished by this time.\n")
+			fmt.Fprintf(ctx, "The requestHandler may be finished by this time.\n")
 
 			close(doneCh)
 		}()

--- a/server_test.go
+++ b/server_test.go
@@ -1830,7 +1830,7 @@ func TestServerExpect100Continue(t *testing.T) {
 			}
 			ct := ctx.Request.Header.ContentType()
 			if string(ct) != "a/b" {
-				t.Errorf("unexpectected content-type: %q. Expecting %q", ct, "a/b")
+				t.Errorf("unexpected content-type: %q. Expecting %q", ct, "a/b")
 			}
 			if string(ctx.PostBody()) != "12345" {
 				t.Errorf("unexpected body: %q. Expecting %q", ctx.PostBody(), "12345")
@@ -1870,7 +1870,7 @@ func TestServerContinueHandler(t *testing.T) {
 
 			ct := headers.ContentType()
 			if string(ct) != "a/b" {
-				t.Errorf("unexpectected content-type: %q. Expecting %q", ct, "a/b")
+				t.Errorf("unexpected content-type: %q. Expecting %q", ct, "a/b")
 			}
 
 			// Pass on any request that isn't the accepted content length
@@ -1888,7 +1888,7 @@ func TestServerContinueHandler(t *testing.T) {
 			}
 			ct := ctx.Request.Header.ContentType()
 			if string(ct) != "a/b" {
-				t.Errorf("unexpectected content-type: %q. Expecting %q", ct, "a/b")
+				t.Errorf("unexpected content-type: %q. Expecting %q", ct, "a/b")
 			}
 			if string(ctx.PostBody()) != "12345" {
 				t.Errorf("unexpected body: %q. Expecting %q", ctx.PostBody(), "12345")


### PR DESCRIPTION
This PR fixes spelling mistakes.