### PR TITLE
add two export func to get gzip writer object from pool

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -177,6 +177,16 @@ func WriteGzipLevel(w io.Writer, p []byte, level int) (int, error) {
 	}
 }
 
+// GetGzipWriter Get a Gzip Writer object from pool. Need to call ReleaseGzipWriter after use
+func GetGzipWriter(w io.Writer, level int) stackless.Writer {
+	return acquireStacklessGzipWriter(w, level)
+}
+
+// ReleaseGzipWriter put a Gzip Writer object to pool
+func ReleaseGzipWriter(w stackless.Writer, level int) {
+	releaseStacklessGzipWriter(w, level)
+}
+
 var stacklessWriteGzip = stackless.NewFunc(nonblockingWriteGzip)
 
 func nonblockingWriteGzip(ctxv interface{}) {


### PR DESCRIPTION
Add two export func to get gzip writer object from pool(so we can gzip data streamly).

When I want to output gzip data to response, I wrote code like this:
```go
buf := bytebufferpool.Get()
WriteHTML(buf, myParams)  // write all html to a buffer
ctx.Response.Header.Add("Content-Encoding", "gzip")
_, _ = fasthttp.WriteGzipLevel(ctx.Response.BodyWriter(), buf.Bytes(), fasthttp.CompressBestSpeed)
bytebufferpool.Put(buf)
```

But up way will copy data from bytebuffer to gzip object.
I can not use API like this:
```go
_, _ = fasthttp.WriteGzipLevel(ctx.Response.BodyWriter(), []byte("first time"), fasthttp.CompressBestSpeed)
_, _ = fasthttp.WriteGzipLevel(ctx.Response.BodyWriter(), []byte("second time"), fasthttp.CompressBestSpeed)
```

Browser can't read response.

So, I export those two func: `GetGzipWriter` and `ReleaseGzipWriter`.
Then I can write data many times:
```go
gzipWriter := fasthttp.GetGzipWriter(ctx.Response.BodyWriter(), fasthttp.CompressBestSpeed)
_,_ = gzipWriter.Write([]byte("first time"))
_,_ = gzipWriter.Write([]byte("second time"))
fasthttp.ReleaseGzipWriter(gzipWriter, fasthttp.CompressBestSpeed)
```

Thanks.