### PR TITLE
BUGFIX: HostClient.DialDualStack not work when using DoDeadline

### DIFF
--- a/client.go
+++ b/client.go
@@ -1840,6 +1840,9 @@ func (c *HostClient) dialHostHard(dialTimeout time.Duration) (conn net.Conn, err
 	dial := c.Dial
 	if dialTimeout != 0 && dial == nil {
 		dial = func(addr string) (net.Conn, error) {
+			if c.DialDualStack {
+				return DialDualStackTimeout(addr, dialTimeout)
+			}
 			return DialTimeout(addr, dialTimeout)
 		}
 	}


### PR DESCRIPTION
If `HostClient` has `DialDualStack=true` and there is no custom `Dial` method specified, the `DialDualStack` setting will not work when sending requests using `DoDeadline` or `DoTimeout`. 

This issue was introduced in [ this commit ](https://github.com/valyala/fasthttp/commit/87cb886157ae414e178fd5bc14a57d5e1c8fcadb)
