### PR TITLE
Allow redirect URI path to not be normalized.

### DIFF
--- a/client.go
+++ b/client.go
@@ -1064,7 +1064,7 @@ func doRequestFollowRedirects(req *Request, resp *Response, url string, maxRedir
 			err = ErrMissingLocation
 			break
 		}
-		url = getRedirectURL(url, location, req.uri.DisablePathNormalizing)
+		url = getRedirectURL(url, location, req.DisableRedirectPathNormalizing)
 	}
 
 	return statusCode, body, err

--- a/client.go
+++ b/client.go
@@ -1064,16 +1064,17 @@ func doRequestFollowRedirects(req *Request, resp *Response, url string, maxRedir
 			err = ErrMissingLocation
 			break
 		}
-		url = getRedirectURL(url, location)
+		url = getRedirectURL(url, location, req.uri.DisablePathNormalizing)
 	}
 
 	return statusCode, body, err
 }
 
-func getRedirectURL(baseURL string, location []byte) string {
+func getRedirectURL(baseURL string, location []byte, disablePathNormalizing bool) string {
 	u := AcquireURI()
 	u.Update(baseURL)
 	u.UpdateBytes(location)
+	u.DisablePathNormalizing = disablePathNormalizing
 	redirectURL := u.String()
 	ReleaseURI(u)
 	return redirectURL

--- a/client_test.go
+++ b/client_test.go
@@ -1589,6 +1589,10 @@ func TestClientFollowRedirects(t *testing.T) {
 				u := ctx.URI()
 				u.Update("/bar")
 				ctx.Redirect(u.String(), StatusFound)
+			case "/abc/*/123":
+				u := ctx.URI()
+				u.Update("/xyz/*/456")
+				ctx.Redirect(u.String(), StatusFound)
 			default:
 				ctx.Success("text/plain", ctx.Path())
 			}
@@ -1704,6 +1708,30 @@ func TestClientFollowRedirects(t *testing.T) {
 		}
 		if err != ErrTimeout {
 			t.Errorf("unexpected error: %v. Expecting %v", err, ErrTimeout)
+		}
+
+		ReleaseRequest(req)
+		ReleaseResponse(resp)
+	}
+
+	for i := 0; i < 10; i++ {
+		req := AcquireRequest()
+		resp := AcquireResponse()
+
+		req.SetRequestURI("http://xxx/abc/*/123")
+		req.URI().DisablePathNormalizing = true
+
+		err := c.DoRedirects(req, resp, 16)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if statusCode := resp.StatusCode(); statusCode != StatusOK {
+			t.Fatalf("unexpected status code: %d", statusCode)
+		}
+
+		if body := string(resp.Body()); body != "/xyz/*/456" {
+			t.Fatalf("unexpected response %q. Expecting %q", body, "/xyz/*/456")
 		}
 
 		ReleaseRequest(req)
@@ -3304,5 +3332,62 @@ func TestClientTransportEx(t *testing.T) {
 	roundTripCount := loopCount * (getCount + postCount)
 	if count != roundTripCount {
 		t.Errorf("round trip count should be: %v", roundTripCount)
+	}
+}
+
+func Test_getRedirectURL(t *testing.T) {
+	type args struct {
+		baseURL                string
+		location               []byte
+		disablePathNormalizing bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Path normalizing enabled, no special characters in path",
+			args: args{
+				baseURL:                "http://foo.example.com/abc",
+				location:               []byte("http://bar.example.com/def"),
+				disablePathNormalizing: false,
+			},
+			want: "http://bar.example.com/def",
+		},
+		{
+			name: "Path normalizing enabled, special characters in path",
+			args: args{
+				baseURL:                "http://foo.example.com/abc/*/def",
+				location:               []byte("http://bar.example.com/123/*/456"),
+				disablePathNormalizing: false,
+			},
+			want: "http://bar.example.com/123/%2A/456",
+		},
+		{
+			name: "Path normalizing disabled, no special characters in path",
+			args: args{
+				baseURL:                "http://foo.example.com/abc",
+				location:               []byte("http://bar.example.com/def"),
+				disablePathNormalizing: true,
+			},
+			want: "http://bar.example.com/def",
+		},
+		{
+			name: "Path normalizing disabled, special characters in path",
+			args: args{
+				baseURL:                "http://foo.example.com/abc/*/def",
+				location:               []byte("http://bar.example.com/123/*/456"),
+				disablePathNormalizing: true,
+			},
+			want: "http://bar.example.com/123/*/456",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getRedirectURL(tt.args.baseURL, tt.args.location, tt.args.disablePathNormalizing); got != tt.want {
+				t.Errorf("getRedirectURL() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1720,6 +1720,7 @@ func TestClientFollowRedirects(t *testing.T) {
 
 		req.SetRequestURI("http://xxx/abc/*/123")
 		req.URI().DisablePathNormalizing = true
+		req.DisableRedirectPathNormalizing = true
 
 		err := c.DoRedirects(req, resp, 16)
 		if err != nil {

--- a/http.go
+++ b/http.go
@@ -71,6 +71,15 @@ type Request struct {
 
 	// Use Host header (request.Header.SetHost) instead of the host from SetRequestURI, SetHost, or URI().SetHost
 	UseHostHeader bool
+
+	// Redirect path values are sent as-is without normalization
+	//
+	// Disabled redirect path normalization may be useful for proxying incoming requests
+	// to servers that are expecting paths to be forwarded as-is.
+	//
+	// By default redirect path values are normalized, i.e.
+	// extra slashes are removed, special characters are encoded.
+	DisableRedirectPathNormalizing bool
 }
 
 // Response represents HTTP response.
@@ -1080,6 +1089,7 @@ func (req *Request) Reset() {
 	req.resetSkipHeader()
 	req.timeout = 0
 	req.UseHostHeader = false
+	req.DisableRedirectPathNormalizing = false
 }
 
 func (req *Request) resetSkipHeader() {

--- a/http.go
+++ b/http.go
@@ -72,10 +72,7 @@ type Request struct {
 	// Use Host header (request.Header.SetHost) instead of the host from SetRequestURI, SetHost, or URI().SetHost
 	UseHostHeader bool
 
-	// Redirect path values are sent as-is without normalization
-	//
-	// Disabled redirect path normalization may be useful for proxying incoming requests
-	// to servers that are expecting paths to be forwarded as-is.
+	// DisableRedirectPathNormalizing disables redirect path normalization when used with DoRedirects.
 	//
 	// By default redirect path values are normalized, i.e.
 	// extra slashes are removed, special characters are encoded.


### PR DESCRIPTION
Fix #1637 

Propagates the `DisablePathNormalizing` setting on a request URI to the redirect URI. This fixes an issue where redirect URIs were being normalized regardless of the setting on the request URI. This could effectively break the redirect URI, depending on the expectations of the server.

Preserves the current default behavior, which is for `DisablePathNormalizing` to be `false`.