### PR TITLE
fix benchmark panics on client_timing_test.go

### DIFF
--- a/client_timing_test.go
+++ b/client_timing_test.go
@@ -24,11 +24,11 @@ type fakeClientConn struct {
 }
 
 func (c *fakeClientConn) SetWriteDeadline(t time.Time) error {
-       return nil
+	return nil
 }
 
 func (c *fakeClientConn) SetReadDeadline(t time.Time) error {
-       return nil
+	return nil
 }
 
 func (c *fakeClientConn) Write(b []byte) (int, error) {

--- a/client_timing_test.go
+++ b/client_timing_test.go
@@ -23,6 +23,14 @@ type fakeClientConn struct {
 	ch chan struct{}
 }
 
+func (c *fakeClientConn) SetWriteDeadline(t time.Time) error {
+       return nil
+}
+
+func (c *fakeClientConn) SetReadDeadline(t time.Time) error {
+       return nil
+}
+
 func (c *fakeClientConn) Write(b []byte) (int, error) {
 	c.ch <- struct{}{}
 	return len(b), nil


### PR DESCRIPTION
this will prevent  panics on benchmarks at client_timing_test.go

fixes #1641 