### PR TITLE
chore: add golangci-lint config file for flexibility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,5 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.54.2
-        args: --enable=nolintlint,gochecknoinits,bodyclose,gofumpt,gocritic --verbose
+        version: v1.55.2
+        args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+# This file contains configuration options for golangci-lint.
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+
+run:
+  # Timeout for analysis.
+  timeout: 5m
+
+linters:
+  # Disable all linters to prevent appearing new issues on golangci-lint update.
+  disable-all: true
+  enable:
+    - bodyclose
+    - errcheck
+    - gochecknoinits
+    - gocritic
+    - gofumpt
+    - gosimple
+    - govet
+    - ineffassign
+    - nolintlint
+    - staticcheck
+    - unused
+
+linters-settings:
+  # Show all issues from a linter.
+  max-issues-per-linter: 0
+
+  # Show all issues with the same text.
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,20 +6,63 @@ run:
   timeout: 5m
 
 linters:
-  # Disable all linters to prevent appearing new issues on golangci-lint update.
-  disable-all: true
-  enable:
-    - bodyclose
-    - errcheck
-    - gochecknoinits
-    - gocritic
-    - gofumpt
-    - gosimple
-    - govet
-    - ineffassign
-    - nolintlint
-    - staticcheck
-    - unused
+  enable-all: true
+  disable:
+    - cyclop
+    - depguard
+    - dupl
+    - dupword
+    - errname
+    - errorlint
+    - exhaustive
+    - exhaustruct
+    - forcetypeassert
+    - funlen
+    - gochecknoglobals
+    - gocognit
+    - goconst
+    - gocyclo
+    - godot
+    - goerr113
+    - gomnd
+    - gosec
+    - inamedparam
+    - ireturn
+    - lll
+    - maintidx
+    - nakedret
+    - nestif
+    - nlreturn
+    - noctx
+    - nonamedreturns
+    - paralleltest
+    - perfsprint
+    - revive
+    - stylecheck
+    - testableexamples
+    - testpackage
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - varnamelen
+    - wastedassign
+    - whitespace
+    - wrapcheck
+    - wsl
+
+    # Deprecated linters
+    - deadcode
+    - exhaustivestruct
+    - golint
+    - ifshort
+    - interfacer
+    - maligned
+    - nosnakecase
+    - scopelint
+    - structcheck
+    - varcheck
 
 linters-settings:
   # Show all issues from a linter.


### PR DESCRIPTION
This PR adds [.golangci.yml](https://golangci-lint.run/usage/configuration/#config-file) with configuration for `golangci-lint`. The config file allows better flexibility in configuration in comparison with command-line parameters. E.g., in future, we might add additional helpful linters, disable some linter rules only for tests, etc.

Also, in the PR updated the version of golangci-lint to the latest currently [released](https://github.com/golangci/golangci-lint/releases/tag/v1.55.2).