### PR TITLE
chore: Remove redundant and outdated build constraints

### DIFF
--- a/allocation_test.go
+++ b/allocation_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package fasthttp
 

--- a/b2s_new.go
+++ b/b2s_new.go
@@ -1,5 +1,4 @@
 //go:build go1.20
-// +build go1.20
 
 package fasthttp
 

--- a/b2s_old.go
+++ b/b2s_old.go
@@ -1,5 +1,4 @@
 //go:build !go1.20
-// +build !go1.20
 
 package fasthttp
 

--- a/bytesconv_32.go
+++ b/bytesconv_32.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x
-// +build !amd64,!arm64,!ppc64,!ppc64le,!s390x
 
 package fasthttp
 

--- a/bytesconv_32_test.go
+++ b/bytesconv_32_test.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x
-// +build !amd64,!arm64,!ppc64,!ppc64le,!s390x
 
 package fasthttp
 

--- a/bytesconv_64.go
+++ b/bytesconv_64.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64 || ppc64 || ppc64le || s390x
-// +build amd64 arm64 ppc64 ppc64le s390x
 
 package fasthttp
 

--- a/bytesconv_64_test.go
+++ b/bytesconv_64_test.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64 || ppc64 || ppc64le || s390x
-// +build amd64 arm64 ppc64 ppc64le s390x
 
 package fasthttp
 

--- a/bytesconv_table_gen.go
+++ b/bytesconv_table_gen.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fasthttp
 

--- a/fasthttpadaptor/b2s_new.go
+++ b/fasthttpadaptor/b2s_new.go
@@ -1,5 +1,4 @@
 //go:build go1.20
-// +build go1.20
 
 package fasthttpadaptor
 

--- a/fasthttpadaptor/b2s_old.go
+++ b/fasthttpadaptor/b2s_old.go
@@ -1,5 +1,4 @@
 //go:build !go1.20
-// +build !go1.20
 
 package fasthttpadaptor
 

--- a/fuzzit/cookie/cookie_fuzz.go
+++ b/fuzzit/cookie/cookie_fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package fuzz
 

--- a/fuzzit/request/request_fuzz.go
+++ b/fuzzit/request/request_fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package fuzz
 

--- a/fuzzit/response/response_fuzz.go
+++ b/fuzzit/response/response_fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package fuzz
 

--- a/fuzzit/url/url_fuzz.go
+++ b/fuzzit/url/url_fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package fuzz
 

--- a/reuseport/reuseport.go
+++ b/reuseport/reuseport.go
@@ -1,5 +1,4 @@
 //go:build !windows && !aix
-// +build !windows,!aix
 
 // Package reuseport provides TCP net.Listener with SO_REUSEPORT support.
 //

--- a/round2_32.go
+++ b/round2_32.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x
-// +build !amd64,!arm64,!ppc64,!ppc64le,!s390x
 
 package fasthttp
 

--- a/round2_32_test.go
+++ b/round2_32_test.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64 && !ppc64 && !ppc64le && !s390x
-// +build !amd64,!arm64,!ppc64,!ppc64le,!s390x
 
 package fasthttp
 

--- a/round2_64.go
+++ b/round2_64.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64 || ppc64 || ppc64le || s390x
-// +build amd64 arm64 ppc64 ppc64le s390x
 
 package fasthttp
 

--- a/round2_64_test.go
+++ b/round2_64_test.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64 || ppc64 || ppc64le || s390x
-// +build amd64 arm64 ppc64 ppc64le s390x
 
 package fasthttp
 

--- a/s2b_new.go
+++ b/s2b_new.go
@@ -1,5 +1,4 @@
 //go:build go1.20
-// +build go1.20
 
 package fasthttp
 

--- a/s2b_old.go
+++ b/s2b_old.go
@@ -1,5 +1,4 @@
 //go:build !go1.20
-// +build !go1.20
 
 package fasthttp
 

--- a/tcp.go
+++ b/tcp.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fasthttp
 

--- a/tcp_windows.go
+++ b/tcp_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package fasthttp
 
 import (

--- a/uri_unix.go
+++ b/uri_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fasthttp
 

--- a/uri_windows.go
+++ b/uri_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package fasthttp
 
 func addLeadingSlash(dst, src []byte) []byte {

--- a/uri_windows_test.go
+++ b/uri_windows_test.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 package fasthttp
 
 import "testing"


### PR DESCRIPTION
This PR removes outdated `// +build` constraints (it was replaced by `//go:build` in Go 16) by running `go fix ./...`.

We can remove OS-specific build constraints like `//go:build windows` if a file name ends with `_windows.go` (according to the [doc](https://pkg.go.dev/cmd/go#hdr-Build_constraints)).