### PR TITLE
Lazy load stackless functions

### DIFF
--- a/brotli.go
+++ b/brotli.go
@@ -132,7 +132,17 @@ func WriteBrotliLevel(w io.Writer, p []byte, level int) (int, error) {
 	}
 }
 
-var stacklessWriteBrotli = stackless.NewFunc(nonblockingWriteBrotli)
+var (
+	stacklessWriteBrotliOnce sync.Once
+	stacklessWriteBrotliFunc func(ctx interface{}) bool
+)
+
+func stacklessWriteBrotli(ctx interface{}) {
+	stacklessWriteBrotliOnce.Do(func() {
+		stacklessWriteBrotliFunc = stackless.NewFunc(nonblockingWriteBrotli)
+	})
+	stacklessWriteBrotliFunc(ctx)
+}
 
 func nonblockingWriteBrotli(ctxv interface{}) {
 	ctx := ctxv.(*compressCtx)

--- a/compress.go
+++ b/compress.go
@@ -177,7 +177,17 @@ func WriteGzipLevel(w io.Writer, p []byte, level int) (int, error) {
 	}
 }
 
-var stacklessWriteGzip = stackless.NewFunc(nonblockingWriteGzip)
+var (
+	stacklessWriteGzipOnce sync.Once
+	stacklessWriteGzipFunc func(ctx interface{}) bool
+)
+
+func stacklessWriteGzip(ctx interface{}) {
+	stacklessWriteGzipOnce.Do(func() {
+		stacklessWriteGzipFunc = stackless.NewFunc(nonblockingWriteGzip)
+	})
+	stacklessWriteGzipFunc(ctx)
+}
 
 func nonblockingWriteGzip(ctxv interface{}) {
 	ctx := ctxv.(*compressCtx)
@@ -270,7 +280,17 @@ func WriteDeflateLevel(w io.Writer, p []byte, level int) (int, error) {
 	}
 }
 
-var stacklessWriteDeflate = stackless.NewFunc(nonblockingWriteDeflate)
+var (
+	stacklessWriteDeflateOnce sync.Once
+	stacklessWriteDeflateFunc func(ctx interface{}) bool
+)
+
+func stacklessWriteDeflate(ctx interface{}) {
+	stacklessWriteDeflateOnce.Do(func() {
+		stacklessWriteDeflateFunc = stackless.NewFunc(nonblockingWriteDeflate)
+	})
+	stacklessWriteDeflateFunc(ctx)
+}
 
 func nonblockingWriteDeflate(ctxv interface{}) {
 	ctx := ctxv.(*compressCtx)


### PR DESCRIPTION
- I noticed that fasthttp was taking up 1.8MB of heap memory, even though it wasn't being used. This turned out to be the stackless function: 1.80MB  github.com/valyala/fasthttp/stackless.NewFunc
- Lazy load the stackless functions with sync.Once, given this a simple atomic read, it shouldn't affect performance for the fast-path (I haven't seen benchmarks with compression enabled).