### PR TITLE
Add support for non buffered body server responses.

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -355,3 +355,23 @@ func appendQuotedPath(dst, src []byte) []byte {
 	}
 	return dst
 }
+
+// countHexDigits returns the number of hex digits required to represent n when using writeHexInt
+func countHexDigits(n int) int {
+	if n < 0 {
+		// developer sanity-check
+		panic("BUG: int must be positive")
+	}
+
+	if n == 0 {
+		return 1
+	}
+
+	count := 0
+	for n > 0 {
+		n = n >> 4
+		count++
+	}
+
+	return count
+}

--- a/http.go
+++ b/http.go
@@ -120,6 +120,8 @@ type Response struct {
 	raddr net.Addr
 	// Local TCPAddr from concurrently net.Conn
 	laddr net.Addr
+
+	headersWritten bool
 }
 
 // SetHost sets host for the request.
@@ -1122,6 +1124,7 @@ func (resp *Response) Reset() {
 	resp.laddr = nil
 	resp.ImmediateHeaderFlush = false
 	resp.StreamBody = false
+	resp.headersWritten = false
 }
 
 func (resp *Response) resetSkipHeader() {

--- a/server_test.go
+++ b/server_test.go
@@ -4252,6 +4252,9 @@ func TestServerDisableBuffering(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error when copying body: %v", err)
 			}
+			if len(ctx.Response.Body()) > 0 {
+				t.Fatalf("Body was populated when buffer was disabled")
+			}
 		},
 	}
 

--- a/unbuffered.go
+++ b/unbuffered.go
@@ -1,0 +1,116 @@
+package fasthttp
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+)
+
+type UnbufferedWriter interface {
+	Write(p []byte) (int, error)
+	WriteHeaders() (int, error)
+	Close() error
+}
+
+type UnbufferedWriterHttp1 struct {
+	writer            *bufio.Writer
+	ctx               *RequestCtx
+	bodyChunkStarted  bool
+	bodyLastChunkSent bool
+}
+
+var ErrNotUnbuffered = errors.New("not unbuffered")
+var ErrClosedUnbufferedWriter = errors.New("closed unbuffered writer")
+
+// Ensure UnbufferedWriterHttp1 implements UnbufferedWriter.
+var _ UnbufferedWriter = &UnbufferedWriterHttp1{}
+
+// NewUnbufferedWriter
+//
+// Object must be discarded when request is finished
+func NewUnbufferedWriter(ctx *RequestCtx) *UnbufferedWriterHttp1 {
+	writer := acquireWriter(ctx)
+	return &UnbufferedWriterHttp1{ctx: ctx, writer: writer}
+}
+
+func (uw *UnbufferedWriterHttp1) Write(p []byte) (int, error) {
+	if uw.writer == nil || uw.ctx == nil {
+		return 0, ErrClosedUnbufferedWriter
+	}
+
+	// Write headers if not already sent
+	if !uw.ctx.Response.headersWritten {
+		_, err := uw.WriteHeaders()
+		if err != nil {
+			return 0, fmt.Errorf("error writing headers: %w", err)
+		}
+	}
+
+	// Write body. In chunks if content length is not set.
+	if uw.ctx.Response.Header.contentLength == -1 && uw.ctx.Response.Header.IsHTTP11() {
+		uw.bodyChunkStarted = true
+		err := writeChunk(uw.writer, p)
+		if err != nil {
+			return 0, err
+		}
+		uw.ctx.bytesSent += len(p) + 4 + countHexDigits(len(p))
+		return len(p), nil
+	}
+
+	n, err := uw.writer.Write(p)
+	uw.ctx.bytesSent += n
+
+	return n, err
+}
+
+func (uw *UnbufferedWriterHttp1) WriteHeaders() (int, error) {
+	if uw.writer == nil || uw.ctx == nil {
+		return 0, ErrClosedUnbufferedWriter
+	}
+
+	if !uw.ctx.Response.headersWritten {
+		if uw.ctx.Response.Header.contentLength == 0 && uw.ctx.Response.Header.IsHTTP11() {
+			if uw.ctx.Response.SkipBody {
+				uw.ctx.Response.Header.SetContentLength(0)
+			} else {
+				uw.ctx.Response.Header.SetContentLength(-1) // means Transfer-Encoding = chunked
+			}
+		}
+		h := uw.ctx.Response.Header.Header()
+		n, err := uw.writer.Write(h)
+		if err != nil {
+			return 0, err
+		}
+		uw.ctx.bytesSent += n
+		uw.ctx.Response.headersWritten = true
+	}
+	return 0, nil
+}
+
+func (uw *UnbufferedWriterHttp1) Close() error {
+	if uw.writer == nil || uw.ctx == nil {
+		return ErrClosedUnbufferedWriter
+	}
+
+	// write headers if not already sent (e.g. if there is no body written)
+	if !uw.ctx.Response.headersWritten {
+		// skip body, as we are closing without writing body
+		uw.ctx.Response.SkipBody = true
+		_, err := uw.WriteHeaders()
+		if err != nil {
+			return fmt.Errorf("error writing headers: %w", err)
+		}
+	}
+
+	// finalize chunks
+	if uw.bodyChunkStarted && uw.ctx.Response.Header.IsHTTP11() && !uw.bodyLastChunkSent {
+		_, _ = uw.writer.Write([]byte("0\r\n\r\n"))
+		uw.ctx.bytesSent += 5
+	}
+	_ = uw.writer.Flush()
+	uw.bodyLastChunkSent = true
+	releaseWriter(uw.ctx.s, uw.writer)
+	uw.writer = nil
+	uw.ctx = nil
+	return nil
+}


### PR DESCRIPTION
Adds support for non-buffered responses.

Sometimes we want to respond by copying from a stream (files or remote network connections), but the current method RegisterStreamBody has 2 cons:

- Is executed after the handler function returns
- Create 2 go threads and 2 channels for each response

This feature allows us to stream directly from the handler context

**In server**

```
´func handle(ctx *fasthttp.RequestCtx) {
     // DisableBuffering modifies fasthttp to disable headers and body buffering for this request
     ctx.DisableBuffering()
     
     // Write headers
     ctx.Response.Header.Set(.....)
     ctx.Response.Header.Set(.....)
     ctx.Response.Header.Set(.....)
     ctx.SetStatusCode(StatusOK)
    
     // Write body. Headers will be sent and cannot be modified once the body begins to be dispatched.
     // src can be any io.Reader or io.ReaderFrom or any object implementing io.WriteTo
     // The process would be unbuffered, well, actually using at most a 32KB buffer 
     // according to the current io.Copy implementation.
     // Ideal for serving large files without storing them on RAM. 
     io.Copy(ctx, src)

     // Optionally we can call CLoseReponse() or it will be called automatically after handler returns
     ctx.CloseResponse()

     fmt.Printf("Total bytes sent including headers: %d",ctx.BytesSent())
}
```

It will automatically set the Transfer-Encoding header to "chunked" and chunk the content on the fly.

