### PR TITLE
Enable dupword, unconvert linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - cyclop
     - depguard
     - dupl
-    - dupword
     - errname
     - errorlint
     - exhaustive
@@ -43,7 +42,6 @@ linters:
     - testpackage
     - thelper
     - tparallel
-    - unconvert
     - unparam
     - usestdlibvars
     - varnamelen

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -37,7 +37,7 @@ func TestAppendHTMLEscape(t *testing.T) {
 		allcases[i] = byte(i)
 	}
 	res := string(AppendHTMLEscape(nil, string(allcases)))
-	expect := string(html.EscapeString(string(allcases)))
+	expect := html.EscapeString(string(allcases))
 	if res != expect {
 		t.Fatalf("unexpected string %q. Expecting %q.", res, expect)
 	}

--- a/client.go
+++ b/client.go
@@ -1474,6 +1474,7 @@ func (c *HostClient) acquireConn(reqTimeout time.Duration, connectionClose bool)
 			return nil, ErrNoFreeConns
 		}
 
+		//nolint:dupword
 		// reqTimeout    c.MaxConnWaitTimeout   wait duration
 		//     d1                 d2            min(d1, d2)
 		//  0(not set)            d2            d2

--- a/fs.go
+++ b/fs.go
@@ -870,7 +870,7 @@ func (cm *inMemoryCacheManager) GetFileFromCache(cacheKind CacheKind, path strin
 	fileCache := cm.getFsCache(cacheKind)
 
 	cm.cacheLock.Lock()
-	ff, ok := fileCache[string(path)]
+	ff, ok := fileCache[path]
 	if ok {
 		ff.readersCount++
 	}
@@ -1594,7 +1594,7 @@ func (h *fsHandler) newFSFile(f fs.File, fileInfo fs.FileInfo, compressed bool, 
 }
 
 func readFileHeader(f io.Reader, compressed bool, fileEncoding string) ([]byte, error) {
-	r := io.Reader(f)
+	r := f
 	var (
 		br *brotli.Reader
 		zr *gzip.Reader

--- a/http_test.go
+++ b/http_test.go
@@ -3022,7 +3022,7 @@ func TestResponseBodyStream(t *testing.T) {
 			}
 		})
 
-		t.Run("limit response body size size", func(t *testing.T) {
+		t.Run("limit response body size", func(t *testing.T) {
 			t.Parallel()
 
 			client := Client{StreamResponseBody: true, MaxResponseBodySize: 20}


### PR DESCRIPTION
```sh
❯ golangci-lint run
bytesconv_test.go:40:18: unnecessary conversion (unconvert)
        expect := string(html.EscapeString(string(allcases)))
                        ^
fs.go:873:28: unnecessary conversion (unconvert)
        ff, ok := fileCache[string(path)]
                                  ^
fs.go:1597:16: unnecessary conversion (unconvert)
        r := io.Reader(f)
                      ^
client.go:1479:3: Duplicate words (d2) found (dupword)
                //  0(not set)            d2            d2
                ^
client.go:1481:3: Duplicate words (d2) found (dupword)
                //  0(not set)            d2            d2
                ^
http_test.go:3025:9: Duplicate words (size) found (dupword)
                t.Run("limit response body size size", func(t *testing.T) {
                      ^
```