### PR TITLE
Enable wastedassign, whitespace linters; fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,8 +45,6 @@ linters:
     - unparam
     - usestdlibvars
     - varnamelen
-    - wastedassign
-    - whitespace
     - wrapcheck
     - wsl
 

--- a/args.go
+++ b/args.go
@@ -551,7 +551,7 @@ func decodeArgAppend(dst, src []byte) []byte {
 		return append(dst, src...)
 	}
 
-	idx := 0
+	var idx int
 	switch {
 	case idxPercent == -1:
 		idx = idxPlus

--- a/server_test.go
+++ b/server_test.go
@@ -1920,7 +1920,6 @@ func TestServerContinueHandler(t *testing.T) {
 	// Expect 100 continue denied
 	rw := &readWriter{}
 	for i := 0; i < 25; i++ {
-
 		// Regular requests without Expect 100 continue header
 		rw.r.Reset()
 		rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -31,7 +31,7 @@ aaaaaaaaaa`
 	s := &Server{
 		StreamRequestBody: true,
 		Handler: func(ctx *RequestCtx) {
-			body := ""
+			var body string
 			expected := "aaaaaaaaaa"
 			if string(ctx.Path()) == "/one" {
 				body = string(ctx.PostBody())

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -375,7 +375,6 @@ func (d *TCPDialer) tcpAddrsClean() {
 			}
 			return true
 		})
-
 	}
 }
 

--- a/workerpool.go
+++ b/workerpool.go
@@ -110,9 +110,9 @@ func (wp *workerPool) clean(scratch *[]*workerChan) {
 	n := len(ready)
 
 	// Use binary-search algorithm to find out the index of the least recently worker which can be cleaned up.
-	l, r, mid := 0, n-1, 0
+	l, r := 0, n-1
 	for l <= r {
-		mid = (l + r) / 2
+		mid := (l + r) / 2
 		if criticalTime.After(wp.ready[mid].lastUseTime) {
 			l = mid + 1
 		} else {
@@ -238,7 +238,6 @@ func (wp *workerPool) workerFunc(ch *workerChan) {
 			_ = c.Close()
 			wp.connState(c, StateClosed)
 		}
-		c = nil
 
 		if !wp.release(ch) {
 			break


### PR DESCRIPTION
This PR enables `wastedassign` and `whitespace` linters. And fixes the following issues:
```sh
❯ golangci-lint run
server.go:2294: unnecessary leading newline (whitespace)
                if ctx.Request.MayContinue() {

tcpdialer.go:378: unnecessary trailing newline (whitespace)

        }
server_test.go:1922: unnecessary leading newline (whitespace)
        for i := 0; i < 25; i++ {

args.go:554:2: assigned to idx, but reassigned without using the value (wastedassign)
        idx := 0
        ^
server.go:1849:3: assigned to c, but reassigned without using the value (wastedassign)
                c = nil
                ^
server.go:2587:2: assigned to ctx, but reassigned without using the value (wastedassign)
        ctx = nil
        ^
workerpool.go:113:8: assigned to mid, but reassigned without using the value (wastedassign)
        l, r, mid := 0, n-1, 0
              ^
workerpool.go:241:3: assigned to c, but reassigned without using the value (wastedassign)
                c = nil
                ^
streaming_test.go:34:4: assigned to body, but reassigned without using the value (wastedassign)
                        body := ""
                        ^
```