### PR TITLE
chore: Use 'any' instead of 'interface{}'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
     - nonamedreturns
     - paralleltest
     - perfsprint
-    - revive
     - stylecheck
     - testableexamples
     - testpackage
@@ -68,3 +67,8 @@ linters-settings:
 
   # Show all issues with the same text.
   max-same-issues: 0
+
+  revive:
+    # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+    rules:
+      - name: use-any

--- a/args.go
+++ b/args.go
@@ -32,7 +32,7 @@ func ReleaseArgs(a *Args) {
 }
 
 var argsPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Args{}
 	},
 }

--- a/brotli.go
+++ b/brotli.go
@@ -134,17 +134,17 @@ func WriteBrotliLevel(w io.Writer, p []byte, level int) (int, error) {
 
 var (
 	stacklessWriteBrotliOnce sync.Once
-	stacklessWriteBrotliFunc func(ctx interface{}) bool
+	stacklessWriteBrotliFunc func(ctx any) bool
 )
 
-func stacklessWriteBrotli(ctx interface{}) {
+func stacklessWriteBrotli(ctx any) {
 	stacklessWriteBrotliOnce.Do(func() {
 		stacklessWriteBrotliFunc = stackless.NewFunc(nonblockingWriteBrotli)
 	})
 	stacklessWriteBrotliFunc(ctx)
 }
 
-func nonblockingWriteBrotli(ctxv interface{}) {
+func nonblockingWriteBrotli(ctxv any) {
 	ctx := ctxv.(*compressCtx)
 	zw := acquireRealBrotliWriter(ctx.w, ctx.level)
 

--- a/client.go
+++ b/client.go
@@ -1714,7 +1714,7 @@ func (c *HostClient) releaseConn(cc *clientConn) {
 }
 
 func (c *HostClient) acquireWriter(conn net.Conn) *bufio.Writer {
-	var v interface{}
+	var v any
 	if c.clientWriterPool != nil {
 		v = c.clientWriterPool.Get()
 		if v == nil {
@@ -1749,7 +1749,7 @@ func (c *HostClient) releaseWriter(bw *bufio.Writer) {
 }
 
 func (c *HostClient) acquireReader(conn net.Conn) *bufio.Reader {
-	var v interface{}
+	var v any
 	if c.clientReaderPool != nil {
 		v = c.clientReaderPool.Get()
 		if v == nil {

--- a/compress.go
+++ b/compress.go
@@ -179,17 +179,17 @@ func WriteGzipLevel(w io.Writer, p []byte, level int) (int, error) {
 
 var (
 	stacklessWriteGzipOnce sync.Once
-	stacklessWriteGzipFunc func(ctx interface{}) bool
+	stacklessWriteGzipFunc func(ctx any) bool
 )
 
-func stacklessWriteGzip(ctx interface{}) {
+func stacklessWriteGzip(ctx any) {
 	stacklessWriteGzipOnce.Do(func() {
 		stacklessWriteGzipFunc = stackless.NewFunc(nonblockingWriteGzip)
 	})
 	stacklessWriteGzipFunc(ctx)
 }
 
-func nonblockingWriteGzip(ctxv interface{}) {
+func nonblockingWriteGzip(ctxv any) {
 	ctx := ctxv.(*compressCtx)
 	zw := acquireRealGzipWriter(ctx.w, ctx.level)
 
@@ -282,17 +282,17 @@ func WriteDeflateLevel(w io.Writer, p []byte, level int) (int, error) {
 
 var (
 	stacklessWriteDeflateOnce sync.Once
-	stacklessWriteDeflateFunc func(ctx interface{}) bool
+	stacklessWriteDeflateFunc func(ctx any) bool
 )
 
-func stacklessWriteDeflate(ctx interface{}) {
+func stacklessWriteDeflate(ctx any) {
 	stacklessWriteDeflateOnce.Do(func() {
 		stacklessWriteDeflateFunc = stackless.NewFunc(nonblockingWriteDeflate)
 	})
 	stacklessWriteDeflateFunc(ctx)
 }
 
-func nonblockingWriteDeflate(ctxv interface{}) {
+func nonblockingWriteDeflate(ctxv any) {
 	ctx := ctxv.(*compressCtx)
 	zw := acquireRealDeflateWriter(ctx.w, ctx.level)
 

--- a/cookie.go
+++ b/cookie.go
@@ -54,7 +54,7 @@ func ReleaseCookie(c *Cookie) {
 }
 
 var cookiePool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Cookie{}
 	},
 }

--- a/expvarhandler/expvar_test.go
+++ b/expvarhandler/expvar_test.go
@@ -12,7 +12,7 @@ import (
 func TestExpvarHandlerBasic(t *testing.T) {
 	t.Parallel()
 
-	expvar.Publish("customVar", expvar.Func(func() interface{} {
+	expvar.Publish("customVar", expvar.Func(func() any {
 		return "foobar"
 	}))
 
@@ -24,7 +24,7 @@ func TestExpvarHandlerBasic(t *testing.T) {
 
 	body := ctx.Response.Body()
 
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(body, &m); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -137,7 +137,7 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	}
 }
 
-func setContextValueMiddleware(next fasthttp.RequestHandler, key string, value interface{}) fasthttp.RequestHandler {
+func setContextValueMiddleware(next fasthttp.RequestHandler, key string, value any) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		ctx.SetUserValue(key, value)
 		next(ctx)

--- a/fasthttputil/pipeconns.go
+++ b/fasthttputil/pipeconns.go
@@ -335,7 +335,7 @@ func releaseByteBuffer(b *byteBuffer) {
 }
 
 var byteBufferPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &byteBuffer{
 			b: make([]byte, 1024),
 		}

--- a/fs_test.go
+++ b/fs_test.go
@@ -18,7 +18,7 @@ type TestLogger struct {
 	t *testing.T
 }
 
-func (t TestLogger) Printf(format string, args ...interface{}) {
+func (t TestLogger) Printf(format string, args ...any) {
 	t.t.Logf(format, args...)
 }
 

--- a/http.go
+++ b/http.go
@@ -2128,7 +2128,7 @@ func copyZeroAlloc(w io.Writer, r io.Reader) (int64, error) {
 }
 
 var copyBufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return make([]byte, 4096)
 	},
 }

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -31,7 +31,7 @@ var (
 // Logger is used for logging formatted messages.
 type Logger interface {
 	// Printf must have the same semantics as log.Printf.
-	Printf(format string, args ...interface{})
+	Printf(format string, args ...any)
 }
 
 // Prefork implements fasthttp server prefork

--- a/server.go
+++ b/server.go
@@ -674,7 +674,7 @@ func (ctx *RequestCtx) Hijacked() bool {
 // All the values are removed from ctx after returning from the top
 // RequestHandler. Additionally, Close method is called on each value
 // implementing io.Closer before removing the value from ctx.
-func (ctx *RequestCtx) SetUserValue(key interface{}, value interface{}) {
+func (ctx *RequestCtx) SetUserValue(key any, value any) {
 	ctx.userValues.Set(key, value)
 }
 
@@ -687,18 +687,18 @@ func (ctx *RequestCtx) SetUserValue(key interface{}, value interface{}) {
 // functions involved in request processing.
 //
 // All the values stored in ctx are deleted after returning from RequestHandler.
-func (ctx *RequestCtx) SetUserValueBytes(key []byte, value interface{}) {
+func (ctx *RequestCtx) SetUserValueBytes(key []byte, value any) {
 	ctx.userValues.SetBytes(key, value)
 }
 
 // UserValue returns the value stored via SetUserValue* under the given key.
-func (ctx *RequestCtx) UserValue(key interface{}) interface{} {
+func (ctx *RequestCtx) UserValue(key any) any {
 	return ctx.userValues.Get(key)
 }
 
 // UserValueBytes returns the value stored via SetUserValue*
 // under the given key.
-func (ctx *RequestCtx) UserValueBytes(key []byte) interface{} {
+func (ctx *RequestCtx) UserValueBytes(key []byte) any {
 	return ctx.userValues.GetBytes(key)
 }
 
@@ -706,7 +706,7 @@ func (ctx *RequestCtx) UserValueBytes(key []byte) interface{} {
 //
 // visitor must not retain references to key and value after returning.
 // Make key and/or value copies if you need storing them after returning.
-func (ctx *RequestCtx) VisitUserValues(visitor func([]byte, interface{})) {
+func (ctx *RequestCtx) VisitUserValues(visitor func([]byte, any)) {
 	for i, n := 0, len(ctx.userValues); i < n; i++ {
 		kv := &ctx.userValues[i]
 		if _, ok := kv.key.(string); ok {
@@ -719,7 +719,7 @@ func (ctx *RequestCtx) VisitUserValues(visitor func([]byte, interface{})) {
 //
 // visitor must not retain references to key and value after returning.
 // Make key and/or value copies if you need storing them after returning.
-func (ctx *RequestCtx) VisitUserValuesAll(visitor func(interface{}, interface{})) {
+func (ctx *RequestCtx) VisitUserValuesAll(visitor func(any, any)) {
 	for i, n := 0, len(ctx.userValues); i < n; i++ {
 		kv := &ctx.userValues[i]
 		visitor(kv.key, kv.value)
@@ -732,7 +732,7 @@ func (ctx *RequestCtx) ResetUserValues() {
 }
 
 // RemoveUserValue removes the given key and the value under it in ctx.
-func (ctx *RequestCtx) RemoveUserValue(key interface{}) {
+func (ctx *RequestCtx) RemoveUserValue(key any) {
 	ctx.userValues.Remove(key)
 }
 
@@ -854,7 +854,7 @@ func (r *firstByteReader) Read(b []byte) (int, error) {
 // Logger is used for logging formatted messages.
 type Logger interface {
 	// Printf must have the same semantics as log.Printf.
-	Printf(format string, args ...interface{})
+	Printf(format string, args ...any)
 }
 
 var ctxLoggerLock sync.Mutex
@@ -864,7 +864,7 @@ type ctxLogger struct {
 	logger Logger
 }
 
-func (cl *ctxLogger) Printf(format string, args ...interface{}) {
+func (cl *ctxLogger) Printf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	ctxLoggerLock.Lock()
 	cl.logger.Printf("%.3f %s - %s", time.Since(cl.ctx.ConnTime()).Seconds(), cl.ctx.String(), msg)
@@ -2750,7 +2750,7 @@ func (ctx *RequestCtx) Err() error {
 //
 // This method is present to make RequestCtx implement the context interface.
 // This method is the same as calling ctx.UserValue(key)
-func (ctx *RequestCtx) Value(key interface{}) interface{} {
+func (ctx *RequestCtx) Value(key any) any {
 	return ctx.UserValue(key)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -1751,7 +1751,7 @@ func TestRequestCtxUserValue(t *testing.T) {
 		}
 	}
 	vlen := 0
-	ctx.VisitUserValues(func(key []byte, value interface{}) {
+	ctx.VisitUserValues(func(key []byte, value any) {
 		vlen++
 		v := ctx.UserValue(key)
 		if v != value {
@@ -4293,7 +4293,7 @@ type testLogger struct {
 	out  string
 }
 
-func (cl *testLogger) Printf(format string, args ...interface{}) {
+func (cl *testLogger) Printf(format string, args ...any) {
 	cl.lock.Lock()
 	cl.out += fmt.Sprintf(format, args...)[6:] + "\n"
 	cl.lock.Unlock()

--- a/stackless/func.go
+++ b/stackless/func.go
@@ -18,7 +18,7 @@ import (
 //
 // The stackless wrapper returns false if the call cannot be processed
 // at the moment due to high load.
-func NewFunc(f func(ctx interface{})) func(ctx interface{}) bool {
+func NewFunc(f func(ctx any)) func(ctx any) bool {
 	if f == nil {
 		// developer sanity-check
 		panic("BUG: f cannot be nil")
@@ -33,7 +33,7 @@ func NewFunc(f func(ctx interface{})) func(ctx interface{}) bool {
 	}
 	var once sync.Once
 
-	return func(ctx interface{}) bool {
+	return func(ctx any) bool {
 		once.Do(onceInit)
 		fw := getFuncWork()
 		fw.ctx = ctx
@@ -50,7 +50,7 @@ func NewFunc(f func(ctx interface{})) func(ctx interface{}) bool {
 	}
 }
 
-func funcWorker(funcWorkCh <-chan *funcWork, f func(ctx interface{})) {
+func funcWorker(funcWorkCh <-chan *funcWork, f func(ctx any)) {
 	for fw := range funcWorkCh {
 		f(fw.ctx)
 		fw.done <- struct{}{}
@@ -75,6 +75,6 @@ func putFuncWork(fw *funcWork) {
 var funcWorkPool sync.Pool
 
 type funcWork struct {
-	ctx  interface{}
+	ctx  any
 	done chan struct{}
 }

--- a/stackless/func_test.go
+++ b/stackless/func_test.go
@@ -11,7 +11,7 @@ func TestNewFuncSimple(t *testing.T) {
 	t.Parallel()
 
 	var n uint64
-	f := NewFunc(func(ctx interface{}) {
+	f := NewFunc(func(ctx any) {
 		atomic.AddUint64(&n, uint64(ctx.(int)))
 	})
 
@@ -30,10 +30,10 @@ func TestNewFuncMulti(t *testing.T) {
 	t.Parallel()
 
 	var n1, n2 uint64
-	f1 := NewFunc(func(ctx interface{}) {
+	f1 := NewFunc(func(ctx any) {
 		atomic.AddUint64(&n1, uint64(ctx.(int)))
 	})
-	f2 := NewFunc(func(ctx interface{}) {
+	f2 := NewFunc(func(ctx any) {
 		atomic.AddUint64(&n2, uint64(ctx.(int)))
 	})
 

--- a/stackless/func_timing_test.go
+++ b/stackless/func_timing_test.go
@@ -7,7 +7,7 @@ import (
 
 func BenchmarkFuncOverhead(b *testing.B) {
 	var n uint64
-	f := NewFunc(func(ctx interface{}) {
+	f := NewFunc(func(ctx any) {
 		atomic.AddUint64(&n, *(ctx.(*uint64)))
 	})
 	b.RunParallel(func(pb *testing.PB) {

--- a/stackless/writer.go
+++ b/stackless/writer.go
@@ -101,17 +101,17 @@ var errHighLoad = errors.New("cannot compress data due to high load")
 
 var (
 	stacklessWriterFuncOnce sync.Once
-	stacklessWriterFuncFunc func(ctx interface{}) bool
+	stacklessWriterFuncFunc func(ctx any) bool
 )
 
-func stacklessWriterFunc(ctx interface{}) bool {
+func stacklessWriterFunc(ctx any) bool {
 	stacklessWriterFuncOnce.Do(func() {
 		stacklessWriterFuncFunc = NewFunc(writerFunc)
 	})
 	return stacklessWriterFuncFunc(ctx)
 }
 
-func writerFunc(ctx interface{}) {
+func writerFunc(ctx any) {
 	w := ctx.(*writer)
 	switch w.op {
 	case opWrite:

--- a/streaming.go
+++ b/streaming.go
@@ -107,7 +107,7 @@ func releaseRequestStream(rs *requestStream) {
 }
 
 var requestStreamPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &requestStream{}
 	},
 }

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -369,7 +369,7 @@ func (d *TCPDialer) tcpAddrsClean() {
 	for {
 		time.Sleep(time.Second)
 		t := time.Now()
-		d.tcpAddrsMap.Range(func(k, v interface{}) bool {
+		d.tcpAddrsMap.Range(func(k, v any) bool {
 			if e, ok := v.(*tcpAddrEntry); ok && t.Sub(e.resolveTime) > expireDuration {
 				d.tcpAddrsMap.Delete(k)
 			}

--- a/uri.go
+++ b/uri.go
@@ -28,7 +28,7 @@ func ReleaseURI(u *URI) {
 }
 
 var uriPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &URI{}
 	},
 }

--- a/userdata.go
+++ b/userdata.go
@@ -5,13 +5,13 @@ import (
 )
 
 type userDataKV struct {
-	key   interface{}
-	value interface{}
+	key   any
+	value any
 }
 
 type userData []userDataKV
 
-func (d *userData) Set(key interface{}, value interface{}) {
+func (d *userData) Set(key any, value any) {
 	if b, ok := key.([]byte); ok {
 		key = string(b)
 	}
@@ -46,11 +46,11 @@ func (d *userData) Set(key interface{}, value interface{}) {
 	*d = args
 }
 
-func (d *userData) SetBytes(key []byte, value interface{}) {
+func (d *userData) SetBytes(key []byte, value any) {
 	d.Set(key, value)
 }
 
-func (d *userData) Get(key interface{}) interface{} {
+func (d *userData) Get(key any) any {
 	if b, ok := key.([]byte); ok {
 		key = b2s(b)
 	}
@@ -65,7 +65,7 @@ func (d *userData) Get(key interface{}) interface{} {
 	return nil
 }
 
-func (d *userData) GetBytes(key []byte) interface{} {
+func (d *userData) GetBytes(key []byte) any {
 	return d.Get(key)
 }
 
@@ -81,7 +81,7 @@ func (d *userData) Reset() {
 	*d = (*d)[:0]
 }
 
-func (d *userData) Remove(key interface{}) {
+func (d *userData) Remove(key any) {
 	if b, ok := key.([]byte); ok {
 		key = b2s(b)
 	}

--- a/userdata_test.go
+++ b/userdata_test.go
@@ -32,7 +32,7 @@ func TestUserData(t *testing.T) {
 	}
 }
 
-func testUserDataGet(t *testing.T, u *userData, key []byte, value interface{}) {
+func testUserDataGet(t *testing.T, u *userData, key []byte, value any) {
 	v := u.GetBytes(key)
 	if v == nil && value != nil {
 		t.Fatalf("cannot obtain value for key=%q", key)

--- a/userdata_timing_test.go
+++ b/userdata_timing_test.go
@@ -8,7 +8,7 @@ func BenchmarkUserDataCustom(b *testing.B) {
 	keys := []string{"foobar", "baz", "aaa", "bsdfs"}
 	b.RunParallel(func(pb *testing.PB) {
 		var u userData
-		var v interface{} = u
+		var v any = u
 		for pb.Next() {
 			for _, key := range keys {
 				u.Set(key, v)
@@ -27,15 +27,15 @@ func BenchmarkUserDataCustom(b *testing.B) {
 func BenchmarkUserDataStdMap(b *testing.B) {
 	keys := []string{"foobar", "baz", "aaa", "bsdfs"}
 	b.RunParallel(func(pb *testing.PB) {
-		u := make(map[string]interface{})
-		var v interface{} = u
+		u := make(map[string]any)
+		var v any = u
 		for pb.Next() {
 			for _, key := range keys {
 				u[key] = v
 			}
 			for _, key := range keys {
 				vv := u[key]
-				if _, ok := vv.(map[string]interface{}); !ok {
+				if _, ok := vv.(map[string]any); !ok {
 					b.Fatalf("unexpected value %v for key %q", vv, key)
 				}
 			}

--- a/workerpool.go
+++ b/workerpool.go
@@ -51,7 +51,7 @@ func (wp *workerPool) Start() {
 	}
 	wp.stopCh = make(chan struct{})
 	stopCh := wp.stopCh
-	wp.workerChanPool.New = func() interface{} {
+	wp.workerChanPool.New = func() any {
 		return &workerChan{
 			ch: make(chan net.Conn, workerChanCap),
 		}


### PR DESCRIPTION
This PR replaces `interface{}` with `any` by running the command `gofmt -w -r "interface{} -> any" -l .`. Also, enables `revive` linter for checking `any` is always used.