### PR TITLE
copyZeroAlloc: Try WriteTo and ReadFrom before acquiring a buffer

### DIFF
--- a/http.go
+++ b/http.go
@@ -2120,6 +2120,12 @@ func writeBodyFixedSize(w *bufio.Writer, r io.Reader, size int64) error {
 }
 
 func copyZeroAlloc(w io.Writer, r io.Reader) (int64, error) {
+	if wt, ok := r.(io.WriterTo); ok {
+		return wt.WriteTo(w)
+	}
+	if rt, ok := w.(io.ReaderFrom); ok {
+		return rt.ReadFrom(r)
+	}
 	vbuf := copyBufPool.Get()
 	buf := vbuf.([]byte)
 	n, err := io.CopyBuffer(w, r, buf)


### PR DESCRIPTION
These are the same statements at the beginning of io.CopyBuffer, but by doing them ourselves first we trade off a little cpu for not holding the 4kb buffer during the write.