### PR TITLE
docs: Add missing dots at the end of comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
     - gocognit
     - goconst
     - gocyclo
-    - godot
     - goerr113
     - gomnd
     - gosec
@@ -35,7 +34,6 @@ linters:
     - nonamedreturns
     - paralleltest
     - perfsprint
-    - stylecheck
     - testableexamples
     - testpackage
     - thelper
@@ -59,20 +57,28 @@ linters:
     - varcheck
 
 linters-settings:
-  # Show all issues from a linter.
-  max-issues-per-linter: 0
-
-  # Show all issues with the same text.
-  max-same-issues: 0
-
   revive:
     # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
     rules:
       - name: use-any
   lll:
     line-length: 130
+  stylecheck:
+    checks: [
+      "all",
+      "-ST1000", # at least one file in a package should have a package comment
+    ]
 
 issues:
+  # Show all issues from a linter.
+  max-issues-per-linter: 0
+
+  # Show all issues with the same text.
+  max-same-issues: 0
+
+  include:
+    - EXC0011 # include issues about comments from `stylecheck`
+
   exclude-rules:
     # Exclude some linters from running on tests files.
     - path: _test\.go

--- a/args.go
+++ b/args.go
@@ -118,7 +118,7 @@ func (a *Args) QueryString() []byte {
 
 // Sort sorts Args by key and then value using 'f' as comparison function.
 //
-// For example args.Sort(bytes.Compare)
+// For example args.Sort(bytes.Compare).
 func (a *Args) Sort(f func(x, y []byte) int) {
 	sort.SliceStable(a.args, func(i, j int) bool {
 		n := f(a.args[i].key, a.args[j].key)
@@ -229,7 +229,7 @@ func (a *Args) SetBytesKV(key, value []byte) {
 
 // SetNoValue sets only 'key' as argument without the '='.
 //
-// Only key in argument, like key1&key2
+// Only key in argument, like key1&key2.
 func (a *Args) SetNoValue(key string) {
 	a.args = setArg(a.args, key, "", argsNoValue)
 }

--- a/client.go
+++ b/client.go
@@ -226,7 +226,7 @@ type Client struct {
 	// By default connection duration is unlimited.
 	MaxConnDuration time.Duration
 
-	// Maximum number of attempts for idempotent calls
+	// Maximum number of attempts for idempotent calls.
 	//
 	// DefaultMaxIdemponentCallAttempts is used if not set.
 	MaxIdemponentCallAttempts int
@@ -278,7 +278,7 @@ type Client struct {
 	//     * cONTENT-lenGTH -> Content-Length
 	DisableHeaderNamesNormalizing bool
 
-	// Path values are sent as-is without normalization
+	// Path values are sent as-is without normalization.
 	//
 	// Disabled path normalization may be useful for proxying incoming requests
 	// to servers that are expecting paths to be forwarded as-is.
@@ -289,18 +289,18 @@ type Client struct {
 
 	// Maximum duration for waiting for a free connection.
 	//
-	// By default will not waiting, return ErrNoFreeConns immediately
+	// By default will not waiting, return ErrNoFreeConns immediately.
 	MaxConnWaitTimeout time.Duration
 
 	// RetryIf controls whether a retry should be attempted after an error.
 	//
-	// By default will use isIdempotent function
+	// By default will use isIdempotent function.
 	RetryIf RetryIfFunc
 
 	// Connection pool strategy. Can be either LIFO or FIFO (default).
 	ConnPoolStrategy ConnPoolStrategyType
 
-	// StreamResponseBody enables response body streaming
+	// StreamResponseBody enables response body streaming.
 	StreamResponseBody bool
 
 	// ConfigureClient configures the fasthttp.HostClient.
@@ -648,7 +648,7 @@ type DialFunc func(addr string) (net.Conn, error)
 //   - foobar.com:8080
 type DialFuncWithTimeout func(addr string, timeout time.Duration) (net.Conn, error)
 
-// RetryIfFunc signature of retry if function
+// RetryIfFunc signature of retry if function.
 //
 // Request argument passed to RetryIfFunc, if there are any request errors.
 type RetryIfFunc func(request *Request) bool
@@ -658,7 +658,7 @@ type RoundTripper interface {
 	RoundTrip(hc *HostClient, req *Request, resp *Response) (retry bool, err error)
 }
 
-// ConnPoolStrategyType define strategy of connection pool enqueue/dequeue
+// ConnPoolStrategyType define strategy of connection pool enqueue/dequeue.
 type ConnPoolStrategyType int
 
 const (
@@ -746,7 +746,7 @@ type HostClient struct {
 	// after DefaultMaxIdleConnDuration.
 	MaxIdleConnDuration time.Duration
 
-	// Maximum number of attempts for idempotent calls
+	// Maximum number of attempts for idempotent calls.
 	//
 	// DefaultMaxIdemponentCallAttempts is used if not set.
 	MaxIdemponentCallAttempts int
@@ -798,7 +798,7 @@ type HostClient struct {
 	//     * cONTENT-lenGTH -> Content-Length
 	DisableHeaderNamesNormalizing bool
 
-	// Path values are sent as-is without normalization
+	// Path values are sent as-is without normalization.
 	//
 	// Disabled path normalization may be useful for proxying incoming requests
 	// to servers that are expecting paths to be forwarded as-is.
@@ -807,7 +807,7 @@ type HostClient struct {
 	// extra slashes are removed, special characters are encoded.
 	DisablePathNormalizing bool
 
-	// Will not log potentially sensitive content in error logs
+	// Will not log potentially sensitive content in error logs.
 	//
 	// This option is useful for servers that handle sensitive data
 	// in the request/response.
@@ -831,7 +831,7 @@ type HostClient struct {
 	// Connection pool strategy. Can be either LIFO or FIFO (default).
 	ConnPoolStrategy ConnPoolStrategyType
 
-	// StreamResponseBody enables response body streaming
+	// StreamResponseBody enables response body streaming.
 	StreamResponseBody bool
 
 	lastUseTime uint32
@@ -872,7 +872,7 @@ type clientConn struct {
 
 var startTimeUnix = time.Now().Unix()
 
-// LastUseTime returns time the client was last used
+// LastUseTime returns time the client was last used.
 func (c *HostClient) LastUseTime() time.Time {
 	n := atomic.LoadUint32(&c.lastUseTime)
 	return time.Unix(startTimeUnix+int64(n), 0)
@@ -1694,7 +1694,7 @@ func (c *HostClient) decConnsCount() {
 	}
 }
 
-// ConnsCount returns connection count of HostClient
+// ConnsCount returns connection count of HostClient.
 func (c *HostClient) ConnsCount() int {
 	c.connsLock.Lock()
 	defer c.connsLock.Unlock()
@@ -1952,7 +1952,7 @@ func dialAddr(
 		return nil, err
 	}
 	if conn == nil {
-		return nil, errors.New("dialling unsuccessful. Please report this bug!")
+		return nil, errors.New("dialling unsuccessful. Please report this bug")
 	}
 
 	// We assume that any conn that has the Handshake() method is a TLS conn already.
@@ -2026,7 +2026,7 @@ func AddMissingPort(addr string, isTLS bool) string {
 // These three options are racing against each other and use
 // wantConn to coordinate and agree about the winning outcome.
 //
-// inspired by net/http/transport.go
+// Inspired by net/http/transport.go.
 type wantConn struct {
 	ready chan struct{}
 	mu    sync.Mutex // protects conn, err, close(ready)
@@ -2081,7 +2081,7 @@ func (w *wantConn) cancel(c *HostClient, err error) {
 
 // A wantConnQueue is a queue of wantConns.
 //
-// inspired by net/http/transport.go
+// Inspired by net/http/transport.go.
 type wantConnQueue struct {
 	// This is a queue, not a dequeue.
 	// It is split into two stages - head[headPos:] and tail.

--- a/client_test.go
+++ b/client_test.go
@@ -2273,11 +2273,11 @@ func (w *writeErrorConn) RemoteAddr() net.Addr {
 	return nil
 }
 
-func (r *writeErrorConn) SetReadDeadline(_ time.Time) error {
+func (w *writeErrorConn) SetReadDeadline(_ time.Time) error {
 	return nil
 }
 
-func (r *writeErrorConn) SetWriteDeadline(_ time.Time) error {
+func (w *writeErrorConn) SetWriteDeadline(_ time.Time) error {
 	return nil
 }
 

--- a/client_unix_test.go
+++ b/client_unix_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// See issue #1232
+// See issue #1232.
 func TestRstConnResponseWhileSending(t *testing.T) {
 	const expectedStatus = http.StatusTeapot
 	const payload = "payload"
@@ -73,7 +73,7 @@ func TestRstConnResponseWhileSending(t *testing.T) {
 	}
 }
 
-// See issue #1232
+// See issue #1232.
 func TestRstConnClosedWithoutResponse(t *testing.T) {
 	const payload = "payload"
 

--- a/cookie.go
+++ b/cookie.go
@@ -23,16 +23,16 @@ var (
 type CookieSameSite int
 
 const (
-	// CookieSameSiteDisabled removes the SameSite flag
+	// CookieSameSiteDisabled removes the SameSite flag.
 	CookieSameSiteDisabled CookieSameSite = iota
-	// CookieSameSiteDefaultMode sets the SameSite flag
+	// CookieSameSiteDefaultMode sets the SameSite flag.
 	CookieSameSiteDefaultMode
-	// CookieSameSiteLaxMode sets the SameSite flag with the "Lax" parameter
+	// CookieSameSiteLaxMode sets the SameSite flag with the "Lax" parameter.
 	CookieSameSiteLaxMode
-	// CookieSameSiteStrictMode sets the SameSite flag with the "Strict" parameter
+	// CookieSameSiteStrictMode sets the SameSite flag with the "Strict" parameter.
 	CookieSameSiteStrictMode
-	// CookieSameSiteNoneMode sets the SameSite flag with the "None" parameter
-	// see https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
+	// CookieSameSiteNoneMode sets the SameSite flag with the "None" parameter.
+	// See https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
 	CookieSameSiteNoneMode
 )
 
@@ -122,7 +122,7 @@ func (c *Cookie) SameSite() CookieSameSite {
 }
 
 // SetSameSite sets the cookie's SameSite flag to the given value.
-// set value CookieSameSiteNoneMode will set Secure to true also to avoid browser rejection
+// Set value CookieSameSiteNoneMode will set Secure to true also to avoid browser rejection.
 func (c *Cookie) SetSameSite(mode CookieSameSite) {
 	c.sameSite = mode
 	if mode == CookieSameSiteNoneMode {
@@ -172,16 +172,16 @@ func (c *Cookie) MaxAge() int {
 }
 
 // SetMaxAge sets cookie expiration time based on seconds. This takes precedence
-// over any absolute expiry set on the cookie
+// over any absolute expiry set on the cookie.
 //
-// Set max age to 0 to unset
+// Set max age to 0 to unset.
 func (c *Cookie) SetMaxAge(seconds int) {
 	c.maxAge = seconds
 }
 
 // Expire returns cookie expiration time.
 //
-// CookieExpireUnlimited is returned if cookie doesn't expire
+// CookieExpireUnlimited is returned if cookie doesn't expire.
 func (c *Cookie) Expire() time.Time {
 	expire := c.expire
 	if expire.IsZero() {

--- a/fs.go
+++ b/fs.go
@@ -558,7 +558,7 @@ func (ff *fsFile) smallFileReader() (io.Reader, error) {
 	return r, nil
 }
 
-// files bigger than this size are sent with sendfile
+// Files bigger than this size are sent with sendfile.
 const maxSmallFileSize = 2 * 4096
 
 func (ff *fsFile) isBig() bool {
@@ -1436,7 +1436,7 @@ func (h *fsHandler) compressFileNolock(
 	return h.newCompressedFSFile(compressedFilePath, fileEncoding)
 }
 
-// newCompressedFSFileCache use memory cache compressed files
+// newCompressedFSFileCache use memory cache compressed files.
 func (h *fsHandler) newCompressedFSFileCache(f fs.File, fileInfo fs.FileInfo, filePath, fileEncoding string) (*fsFile, error) {
 	var (
 		w   = &bytebufferpool.ByteBuffer{}

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -364,8 +364,6 @@ func TestFSServeFileDirectoryRedirect(t *testing.T) {
 	}
 }
 
-// //*
-// *//
 var dirTestFilesystem = os.DirFS(".")
 
 func TestDirFSServeFileHead(t *testing.T) {

--- a/fs_handler_example_test.go
+++ b/fs_handler_example_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// Setup file handlers (aka 'file server config')
+// Setup file handlers (aka 'file server config').
 var (
 	// Handler for serving images from /img/ path,
 	// i.e. /img/foo/bar.jpg will be served from
@@ -27,7 +27,7 @@ var (
 	filesHandler = fasthttp.FSHandler("/var/www/files", 0)
 )
 
-// Main request handler
+// Main request handler.
 func requestHandler(ctx *fasthttp.RequestCtx) {
 	path := ctx.Path()
 	switch {

--- a/header.go
+++ b/header.go
@@ -344,7 +344,7 @@ func (h *ResponseHeader) SetContentEncodingBytes(contentEncoding []byte) {
 	h.contentEncoding = append(h.contentEncoding[:0], contentEncoding...)
 }
 
-// addVaryBytes add value to the 'Vary' header if it's not included
+// addVaryBytes add value to the 'Vary' header if it's not included.
 func (h *ResponseHeader) addVaryBytes(value []byte) {
 	v := h.peek(strVary)
 	if len(v) == 0 {
@@ -948,7 +948,7 @@ func (h *RequestHeader) DisableNormalizing() {
 //   - conteNT-tYPE -> Content-Type
 //   - foo-bar-baz -> Foo-Bar-Baz
 //
-// This is enabled by default unless disabled using DisableNormalizing()
+// This is enabled by default unless disabled using DisableNormalizing().
 func (h *RequestHeader) EnableNormalizing() {
 	h.disableNormalizing = false
 }
@@ -980,7 +980,7 @@ func (h *ResponseHeader) DisableNormalizing() {
 //   - conteNT-tYPE -> Content-Type
 //   - foo-bar-baz -> Foo-Bar-Baz
 //
-// This is enabled by default unless disabled using DisableNormalizing()
+// This is enabled by default unless disabled using DisableNormalizing().
 func (h *ResponseHeader) EnableNormalizing() {
 	h.disableNormalizing = false
 }
@@ -1350,7 +1350,7 @@ func (h *ResponseHeader) setSpecialHeader(key, value []byte) bool {
 	return false
 }
 
-// setNonSpecial directly put into map i.e. not a basic header
+// setNonSpecial directly put into map i.e. not a basic header.
 func (h *ResponseHeader) setNonSpecial(key []byte, value []byte) {
 	h.h = setArgBytes(h.h, key, value, argsHasValue)
 }
@@ -1409,7 +1409,7 @@ func (h *RequestHeader) setSpecialHeader(key, value []byte) bool {
 	return false
 }
 
-// setNonSpecial directly put into map i.e. not a basic header
+// setNonSpecial directly put into map i.e. not a basic header.
 func (h *RequestHeader) setNonSpecial(key []byte, value []byte) {
 	h.h = setArgBytes(h.h, key, value, argsHasValue)
 }
@@ -3332,7 +3332,7 @@ func normalizeHeaderKey(b []byte, disableNormalizing bool) {
 	}
 }
 
-// removeNewLines will replace `\r` and `\n` with an empty space
+// removeNewLines will replace `\r` and `\n` with an empty space.
 func removeNewLines(raw []byte) []byte {
 	// check if a `\r` is present and save the position.
 	// if no `\r` is found, check if a `\n` is present.

--- a/header_timing_test.go
+++ b/header_timing_test.go
@@ -12,7 +12,7 @@ import (
 
 var strFoobar = []byte("foobar.com")
 
-// it has the same length as Content-Type
+// it has the same length as Content-Type.
 var strNonSpecialHeader = []byte("Dontent-Type")
 
 type benchReadBuf struct {
@@ -99,7 +99,7 @@ func BenchmarkResponseHeaderWrite(b *testing.B) {
 	})
 }
 
-// Result: 2.2 ns/op
+// Result: 2.2 ns/op.
 func BenchmarkRequestHeaderPeekBytesSpecialHeader(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var h RequestHeader
@@ -113,7 +113,7 @@ func BenchmarkRequestHeaderPeekBytesSpecialHeader(b *testing.B) {
 	})
 }
 
-// Result: 2.9 ns/op
+// Result: 2.9 ns/op.
 func BenchmarkRequestHeaderPeekBytesNonSpecialHeader(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var h RequestHeader
@@ -127,7 +127,7 @@ func BenchmarkRequestHeaderPeekBytesNonSpecialHeader(b *testing.B) {
 	})
 }
 
-// Result: 2.3 ns/op
+// Result: 2.3 ns/op.
 func BenchmarkResponseHeaderPeekBytesSpecialHeader(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var h ResponseHeader
@@ -141,7 +141,7 @@ func BenchmarkResponseHeaderPeekBytesSpecialHeader(b *testing.B) {
 	})
 }
 
-// Result: 2.9 ns/op
+// Result: 2.9 ns/op.
 func BenchmarkResponseHeaderPeekBytesNonSpecialHeader(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var h ResponseHeader

--- a/headers.go
+++ b/headers.go
@@ -1,14 +1,14 @@
 package fasthttp
 
-// Headers
+// Headers.
 const (
-	// Authentication
+	// Authentication.
 	HeaderAuthorization      = "Authorization"
 	HeaderProxyAuthenticate  = "Proxy-Authenticate"
 	HeaderProxyAuthorization = "Proxy-Authorization"
 	HeaderWWWAuthenticate    = "WWW-Authenticate"
 
-	// Caching
+	// Caching.
 	HeaderAge           = "Age"
 	HeaderCacheControl  = "Cache-Control"
 	HeaderClearSiteData = "Clear-Site-Data"
@@ -16,7 +16,7 @@ const (
 	HeaderPragma        = "Pragma"
 	HeaderWarning       = "Warning"
 
-	// Client hints
+	// Client hints.
 	HeaderAcceptCH         = "Accept-CH"
 	HeaderAcceptCHLifetime = "Accept-CH-Lifetime"
 	HeaderContentDPR       = "Content-DPR"
@@ -26,7 +26,7 @@ const (
 	HeaderViewportWidth    = "Viewport-Width"
 	HeaderWidth            = "Width"
 
-	// Conditionals
+	// Conditionals.
 	HeaderETag              = "ETag"
 	HeaderIfMatch           = "If-Match"
 	HeaderIfModifiedSince   = "If-Modified-Since"
@@ -35,24 +35,24 @@ const (
 	HeaderLastModified      = "Last-Modified"
 	HeaderVary              = "Vary"
 
-	// Connection management
+	// Connection management.
 	HeaderConnection      = "Connection"
 	HeaderKeepAlive       = "Keep-Alive"
 	HeaderProxyConnection = "Proxy-Connection"
 
-	// Content negotiation
+	// Content negotiation.
 	HeaderAccept         = "Accept"
 	HeaderAcceptCharset  = "Accept-Charset"
 	HeaderAcceptEncoding = "Accept-Encoding"
 	HeaderAcceptLanguage = "Accept-Language"
 
-	// Controls
+	// Controls.
 	HeaderCookie      = "Cookie"
 	HeaderExpect      = "Expect"
 	HeaderMaxForwards = "Max-Forwards"
 	HeaderSetCookie   = "Set-Cookie"
 
-	// CORS
+	// CORS.
 	HeaderAccessControlAllowCredentials = "Access-Control-Allow-Credentials"
 	HeaderAccessControlAllowHeaders     = "Access-Control-Allow-Headers"
 	HeaderAccessControlAllowMethods     = "Access-Control-Allow-Methods"
@@ -65,48 +65,48 @@ const (
 	HeaderTimingAllowOrigin             = "Timing-Allow-Origin"
 	HeaderXPermittedCrossDomainPolicies = "X-Permitted-Cross-Domain-Policies"
 
-	// Do Not Track
+	// Do Not Track.
 	HeaderDNT = "DNT"
 	HeaderTk  = "Tk"
 
-	// Downloads
+	// Downloads.
 	HeaderContentDisposition = "Content-Disposition"
 
-	// Message body information
+	// Message body information.
 	HeaderContentEncoding = "Content-Encoding"
 	HeaderContentLanguage = "Content-Language"
 	HeaderContentLength   = "Content-Length"
 	HeaderContentLocation = "Content-Location"
 	HeaderContentType     = "Content-Type"
 
-	// Proxies
+	// Proxies.
 	HeaderForwarded       = "Forwarded"
 	HeaderVia             = "Via"
 	HeaderXForwardedFor   = "X-Forwarded-For"
 	HeaderXForwardedHost  = "X-Forwarded-Host"
 	HeaderXForwardedProto = "X-Forwarded-Proto"
 
-	// Redirects
+	// Redirects.
 	HeaderLocation = "Location"
 
-	// Request context
+	// Request context.
 	HeaderFrom           = "From"
 	HeaderHost           = "Host"
 	HeaderReferer        = "Referer"
 	HeaderReferrerPolicy = "Referrer-Policy"
 	HeaderUserAgent      = "User-Agent"
 
-	// Response context
+	// Response context.
 	HeaderAllow  = "Allow"
 	HeaderServer = "Server"
 
-	// Range requests
+	// Range requests.
 	HeaderAcceptRanges = "Accept-Ranges"
 	HeaderContentRange = "Content-Range"
 	HeaderIfRange      = "If-Range"
 	HeaderRange        = "Range"
 
-	// Security
+	// Security.
 	HeaderContentSecurityPolicy           = "Content-Security-Policy"
 	HeaderContentSecurityPolicyReportOnly = "Content-Security-Policy-Report-Only"
 	HeaderCrossOriginResourcePolicy       = "Cross-Origin-Resource-Policy"
@@ -122,26 +122,26 @@ const (
 	HeaderXPoweredBy                      = "X-Powered-By"
 	HeaderXXSSProtection                  = "X-XSS-Protection"
 
-	// Server-sent event
+	// Server-sent event.
 	HeaderLastEventID = "Last-Event-ID"
 	HeaderNEL         = "NEL"
 	HeaderPingFrom    = "Ping-From"
 	HeaderPingTo      = "Ping-To"
 	HeaderReportTo    = "Report-To"
 
-	// Transfer coding
+	// Transfer coding.
 	HeaderTE               = "TE"
 	HeaderTrailer          = "Trailer"
 	HeaderTransferEncoding = "Transfer-Encoding"
 
-	// WebSockets
+	// WebSockets.
 	HeaderSecWebSocketAccept     = "Sec-WebSocket-Accept"
 	HeaderSecWebSocketExtensions = "Sec-WebSocket-Extensions" /* #nosec G101 */
 	HeaderSecWebSocketKey        = "Sec-WebSocket-Key"
 	HeaderSecWebSocketProtocol   = "Sec-WebSocket-Protocol"
 	HeaderSecWebSocketVersion    = "Sec-WebSocket-Version"
 
-	// Other
+	// Other.
 	HeaderAcceptPatch         = "Accept-Patch"
 	HeaderAcceptPushPolicy    = "Accept-Push-Policy"
 	HeaderAcceptSignature     = "Accept-Signature"

--- a/http.go
+++ b/http.go
@@ -38,7 +38,7 @@ func SetBodySizePoolLimit(reqBodyLimit, respBodyLimit int) {
 type Request struct {
 	noCopy noCopy
 
-	// Request header
+	// Request header.
 	//
 	// Copying Header by value is forbidden. Use pointer to Header instead.
 	Header RequestHeader
@@ -88,7 +88,7 @@ type Request struct {
 type Response struct {
 	noCopy noCopy
 
-	// Response header
+	// Response header.
 	//
 	// Copying Header by value is forbidden. Use pointer to Header instead.
 	Header ResponseHeader
@@ -116,9 +116,9 @@ type Response struct {
 	keepBodyBuffer        bool
 	secureErrorLogMessage bool
 
-	// Remote TCPAddr from concurrently net.Conn
+	// Remote TCPAddr from concurrently net.Conn.
 	raddr net.Addr
-	// Local TCPAddr from concurrently net.Conn
+	// Local TCPAddr from concurrently net.Conn.
 	laddr net.Addr
 }
 
@@ -250,12 +250,12 @@ func (resp *Response) SetBodyStream(bodyStream io.Reader, bodySize int) {
 	resp.Header.SetContentLength(bodySize)
 }
 
-// IsBodyStream returns true if body is set via SetBodyStream*
+// IsBodyStream returns true if body is set via SetBodyStream*.
 func (req *Request) IsBodyStream() bool {
 	return req.bodyStream != nil
 }
 
-// IsBodyStream returns true if body is set via SetBodyStream*
+// IsBodyStream returns true if body is set via SetBodyStream*.
 func (resp *Response) IsBodyStream() bool {
 	return resp.bodyStream != nil
 }
@@ -302,7 +302,7 @@ func (resp *Response) BodyWriter() io.Writer {
 	return &resp.w
 }
 
-// BodyStream returns io.Reader
+// BodyStream returns io.Reader.
 //
 // You must CloseBodyStream or ReleaseRequest after you use it.
 func (req *Request) BodyStream() io.Reader {
@@ -313,7 +313,7 @@ func (req *Request) CloseBodyStream() error {
 	return req.closeBodyStream()
 }
 
-// BodyStream returns io.Reader
+// BodyStream returns io.Reader.
 //
 // You must CloseBodyStream or ReleaseResponse after you use it.
 func (resp *Response) BodyStream() io.Reader {
@@ -894,13 +894,13 @@ func swapResponseBody(a, b *Response) {
 	a.bodyStream, b.bodyStream = b.bodyStream, a.bodyStream
 }
 
-// URI returns request URI
+// URI returns request URI.
 func (req *Request) URI() *URI {
 	req.parseURI() //nolint:errcheck
 	return &req.uri
 }
 
-// SetURI initializes request URI
+// SetURI initializes request URI.
 // Use this method if a single URI may be reused across multiple requests.
 // Otherwise, you can just use SetRequestURI() and it will be parsed as new URI.
 // The URI is copied and can be safely modified later.
@@ -1849,7 +1849,7 @@ func (resp *Response) deflateBody(level int) error {
 	return nil
 }
 
-// Bodies with sizes smaller than minCompressLen aren't compressed at all
+// Bodies with sizes smaller than minCompressLen aren't compressed at all.
 const minCompressLen = 200
 
 type writeFlusher interface {
@@ -2366,8 +2366,14 @@ func readCrLf(r *bufio.Reader) error {
 
 // SetTimeout sets timeout for the request.
 //
-// req.SetTimeout(t); c.Do(&req, &resp) is equivalent to
-// c.DoTimeout(&req, &resp, t)
+// The following code:
+//
+//	req.SetTimeout(t)
+//	c.Do(&req, &resp)
+//
+// is equivalent to
+//
+//	c.DoTimeout(&req, &resp, t)
 func (req *Request) SetTimeout(t time.Duration) {
 	req.timeout = t
 }

--- a/lbclient.go
+++ b/lbclient.go
@@ -59,12 +59,12 @@ type LBClient struct {
 // The timeout may be overridden via LBClient.Timeout.
 const DefaultLBClientTimeout = time.Second
 
-// DoDeadline calls DoDeadline on the least loaded client
+// DoDeadline calls DoDeadline on the least loaded client.
 func (cc *LBClient) DoDeadline(req *Request, resp *Response, deadline time.Time) error {
 	return cc.get().DoDeadline(req, resp, deadline)
 }
 
-// DoTimeout calculates deadline and calls DoDeadline on the least loaded client
+// DoTimeout calculates deadline and calls DoDeadline on the least loaded client.
 func (cc *LBClient) DoTimeout(req *Request, resp *Response, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	return cc.get().DoDeadline(req, resp, deadline)
@@ -95,8 +95,8 @@ func (cc *LBClient) init() {
 	}
 }
 
-// AddClient adds a new client to the balanced clients
-// returns the new total number of clients
+// AddClient adds a new client to the balanced clients and
+// returns the new total number of clients.
 func (cc *LBClient) AddClient(c BalancingClient) int {
 	cc.mu.Lock()
 	cc.cs = append(cc.cs, &lbClient{
@@ -107,9 +107,9 @@ func (cc *LBClient) AddClient(c BalancingClient) int {
 	return len(cc.cs)
 }
 
-// RemoveClients removes clients using the provided callback
-// if rc returns true, the passed client will be removed
-// returns the new total number of clients
+// RemoveClients removes clients using the provided callback.
+// If rc returns true, the passed client will be removed.
+// Returns the new total number of clients.
 func (cc *LBClient) RemoveClients(rc func(BalancingClient) bool) int {
 	cc.mu.Lock()
 	n := 0

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -34,11 +34,11 @@ type Logger interface {
 	Printf(format string, args ...any)
 }
 
-// Prefork implements fasthttp server prefork
+// Prefork implements fasthttp server prefork.
 //
 // Preforks master process (with all cores) between several child processes
 // increases performance significantly, because Go doesn't have to share
-// and manage memory between cores
+// and manage memory between cores.
 //
 // WARNING: using prefork prevents the use of any global state!
 // Things like in-memory caches won't work.
@@ -75,7 +75,7 @@ func init() { //nolint:gochecknoinits
 	flag.Bool(preforkChildFlag[1:], false, "Is a child process")
 }
 
-// IsChild checks if the current thread/process is a child
+// IsChild checks if the current thread/process is a child.
 func IsChild() bool {
 	for _, arg := range os.Args[1:] {
 		if arg == preforkChildFlag {
@@ -86,7 +86,7 @@ func IsChild() bool {
 	return false
 }
 
-// New wraps the fasthttp server to run with preforked processes
+// New wraps the fasthttp server to run with preforked processes.
 func New(s *fasthttp.Server) *Prefork {
 	return &Prefork{
 		Network:           defaultNetwork,
@@ -230,7 +230,7 @@ func (p *Prefork) prefork(addr string) (err error) {
 	return
 }
 
-// ListenAndServe serves HTTP requests from the given TCP addr
+// ListenAndServe serves HTTP requests from the given TCP addr.
 func (p *Prefork) ListenAndServe(addr string) error {
 	if IsChild() {
 		ln, err := p.listen(addr)
@@ -246,7 +246,7 @@ func (p *Prefork) ListenAndServe(addr string) error {
 	return p.prefork(addr)
 }
 
-// ListenAndServeTLS serves HTTPS requests from the given TCP addr
+// ListenAndServeTLS serves HTTPS requests from the given TCP addr.
 //
 // certFile and keyFile are paths to TLS certificate and key files.
 func (p *Prefork) ListenAndServeTLS(addr, certKey, certFile string) error {
@@ -264,7 +264,7 @@ func (p *Prefork) ListenAndServeTLS(addr, certKey, certFile string) error {
 	return p.prefork(addr)
 }
 
-// ListenAndServeTLSEmbed serves HTTPS requests from the given TCP addr
+// ListenAndServeTLSEmbed serves HTTPS requests from the given TCP addr.
 //
 // certData and keyData must contain valid TLS certificate and key data.
 func (p *Prefork) ListenAndServeTLSEmbed(addr string, certData, keyData []byte) error {

--- a/server.go
+++ b/server.go
@@ -19,6 +19,7 @@ import (
 
 var errNoCertOrKeyProvided = errors.New("cert or key has not provided")
 
+// ErrAlreadyServing is deprecated.
 // Deprecated: ErrAlreadyServing is never returned from Serve. See issue #633.
 var ErrAlreadyServing = errors.New("Server is already serving connections")
 
@@ -164,20 +165,20 @@ type Server struct {
 	//   * ErrBrokenChunks
 	ErrorHandler func(ctx *RequestCtx, err error)
 
-	// HeaderReceived is called after receiving the header
+	// HeaderReceived is called after receiving the header.
 	//
-	// non zero RequestConfig field values will overwrite the default configs
+	// Non zero RequestConfig field values will overwrite the default configs
 	HeaderReceived func(header *RequestHeader) RequestConfig
 
-	// ContinueHandler is called after receiving the Expect 100 Continue Header
+	// ContinueHandler is called after receiving the Expect 100 Continue Header.
 	//
 	// https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html#sec8.2.3
 	// https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.1.1
 	// Using ContinueHandler a server can make decisioning on whether or not
-	// to read a potentially large request body based on the headers
+	// to read a potentially large request body based on the headers.
 	//
 	// The default is to automatically read request bodies of Expect 100 Continue requests
-	// like they are normal requests
+	// like they are normal requests.
 	ContinueHandler func(header *RequestHeader) bool
 
 	// Server name for sending in response headers.
@@ -484,18 +485,18 @@ func TimeoutWithCodeHandler(h RequestHandler, timeout time.Duration, msg string,
 	}
 }
 
-// RequestConfig configure the per request deadline and body limits
+// RequestConfig configure the per request deadline and body limits.
 type RequestConfig struct {
 	// ReadTimeout is the maximum duration for reading the entire
 	// request body.
-	// a zero value means that default values will be honored
+	// A zero value means that default values will be honored.
 	ReadTimeout time.Duration
 	// WriteTimeout is the maximum duration before timing out
 	// writes of the response.
-	// a zero value means that default values will be honored
+	// A zero value means that default values will be honored.
 	WriteTimeout time.Duration
 	// Maximum request body size.
-	// a zero value means that default values will be honored
+	// A zero value means that default values will be honored.
 	MaxRequestBodySize int
 }
 
@@ -726,7 +727,7 @@ func (ctx *RequestCtx) VisitUserValuesAll(visitor func(any, any)) {
 	}
 }
 
-// ResetUserValues allows to reset user values from Request Context
+// ResetUserValues allows to reset user values from Request Context.
 func (ctx *RequestCtx) ResetUserValues() {
 	ctx.userValues.Reset()
 }
@@ -1143,6 +1144,8 @@ var (
 
 	// NetHttpFormValueFunc gives consistent behavior with net/http.
 	// POST and PUT body parameters take precedence over URL query string values.
+	//
+	//nolint:stylecheck // backwards compatibility
 	NetHttpFormValueFunc = func(ctx *RequestCtx, key string) []byte {
 		v := ctx.PostArgs().Peek(key)
 		if len(v) > 0 {
@@ -1731,7 +1734,7 @@ func (s *Server) ServeTLSEmbed(ln net.Listener, certData, keyData []byte) error 
 // AppendCert appends certificate and keyfile to TLS Configuration.
 //
 // This function allows programmer to handle multiple domains
-// in one server structure. See examples/multidomain
+// in one server structure. See examples/multidomain.
 func (s *Server) AppendCert(certFile, keyFile string) error {
 	if len(certFile) == 0 && len(keyFile) == 0 {
 		return errNoCertOrKeyProvided
@@ -2050,14 +2053,14 @@ var errHijacked = errors.New("connection has been hijacked")
 // GetCurrentConcurrency returns a number of currently served
 // connections.
 //
-// This function is intended be used by monitoring systems
+// This function is intended be used by monitoring systems.
 func (s *Server) GetCurrentConcurrency() uint32 {
 	return atomic.LoadUint32(&s.concurrency)
 }
 
 // GetOpenConnectionsCount returns a number of opened connections.
 //
-// This function is intended be used by monitoring systems
+// This function is intended be used by monitoring systems.
 func (s *Server) GetOpenConnectionsCount() int32 {
 	if atomic.LoadInt32(&s.stop) == 0 {
 		// Decrement by one to avoid reporting the extra open value that gets
@@ -2723,7 +2726,7 @@ func (ctx *RequestCtx) Deadline() (deadline time.Time, ok bool) {
 // never be canceled. Successive calls to Done return the same value.
 //
 // Note: Because creating a new channel for every request is just too expensive, so
-// RequestCtx.s.done is only closed when the server is shutting down
+// RequestCtx.s.done is only closed when the server is shutting down.
 func (ctx *RequestCtx) Done() <-chan struct{} {
 	return ctx.s.done
 }
@@ -2736,7 +2739,7 @@ func (ctx *RequestCtx) Done() <-chan struct{} {
 // or DeadlineExceeded if the context's deadline passed.
 //
 // Note: Because creating a new channel for every request is just too expensive, so
-// RequestCtx.s.done is only closed when the server is shutting down
+// RequestCtx.s.done is only closed when the server is shutting down.
 func (ctx *RequestCtx) Err() error {
 	select {
 	case <-ctx.s.done:
@@ -2751,7 +2754,7 @@ func (ctx *RequestCtx) Err() error {
 // the same key returns the same result.
 //
 // This method is present to make RequestCtx implement the context interface.
-// This method is the same as calling ctx.UserValue(key)
+// This method is the same as calling ctx.UserValue(key).
 func (ctx *RequestCtx) Value(key any) any {
 	return ctx.UserValue(key)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/valyala/fasthttp/fasthttputil"
 )
 
-// Make sure RequestCtx implements context.Context
+// Make sure RequestCtx implements context.Context.
 var _ context.Context = &RequestCtx{}
 
 type closerWithRequestCtx struct {

--- a/uri.go
+++ b/uri.go
@@ -52,7 +52,7 @@ type URI struct {
 	queryArgs       Args
 	parsedQueryArgs bool
 
-	// Path values are sent as-is without normalization
+	// Path values are sent as-is without normalization.
 	//
 	// Disabled path normalization may be useful for proxying incoming requests
 	// to servers that are expecting paths to be forwarded as-is.
@@ -122,7 +122,7 @@ func (u *URI) SetUsernameBytes(username []byte) {
 	u.username = append(u.username[:0], username...)
 }
 
-// Password returns URI password
+// Password returns URI password.
 //
 // The returned bytes are valid until the next URI method call.
 func (u *URI) Password() []byte {
@@ -554,7 +554,7 @@ func unhex(c byte) byte {
 }
 
 // validOptionalPort reports whether port is either an empty string
-// or matches /^:\d*$/
+// or matches /^:\d*$/.
 func validOptionalPort(port []byte) bool {
 	if len(port) == 0 {
 		return true


### PR DESCRIPTION
This PR adds missing dots at the end of comments. Also, enables `godot` linter to ensure comments always end with a full stop. Additionally, enables `stylecheck` issue to ensure comments always start with a function name.

The full log of running `golangci-lint`:
```sh
❯ golangci-lint run
prefork/prefork.go:78:59: Comment should end in a period (godot)
// IsChild checks if the current thread/process is a child
                                                          ^
prefork/prefork.go:89:65: Comment should end in a period (godot)
// New wraps the fasthttp server to run with preforked processes
                                                                ^
prefork/prefork.go:233:63: Comment should end in a period (godot)
// ListenAndServe serves HTTP requests from the given TCP addr
                                                              ^
args.go:121:40: Comment should end in a period (godot)
// For example args.Sort(bytes.Compare)
                                       ^
args.go:232:40: Comment should end in a period (godot)
// Only key in argument, like key1&key2
                                       ^
client.go:661:75: Comment should end in a period (godot)
// ConnPoolStrategyType define strategy of connection pool enqueue/dequeue
                                                                          ^
client.go:875:53: Comment should end in a period (godot)
// LastUseTime returns time the client was last used
                                                    ^
client.go:1697:53: Comment should end in a period (godot)
// ConnsCount returns connection count of HostClient
                                                    ^
client.go:2029:37: Comment should end in a period (godot)
// inspired by net/http/transport.go
                                    ^
client.go:2084:37: Comment should end in a period (godot)
// inspired by net/http/transport.go
                                    ^
cookie.go:26:53: Comment should end in a period (godot)
        // CookieSameSiteDisabled removes the SameSite flag
                                                           ^
cookie.go:28:53: Comment should end in a period (godot)
        // CookieSameSiteDefaultMode sets the SameSite flag
                                                           ^
cookie.go:30:74: Comment should end in a period (godot)
        // CookieSameSiteLaxMode sets the SameSite flag with the "Lax" parameter
                                                                                ^
cookie.go:32:80: Comment should end in a period (godot)
        // CookieSameSiteStrictMode sets the SameSite flag with the "Strict" parameter
                                                                                      ^
cookie.go:125:92: Comment should end in a period (godot)
// set value CookieSameSiteNoneMode will set Secure to true also to avoid browser rejection
                                                                                           ^
cookie.go:177:29: Comment should end in a period (godot)
// Set max age to 0 to unset
                            ^
cookie.go:184:62: Comment should end in a period (godot)
// CookieExpireUnlimited is returned if cookie doesn't expire
                                                             ^
fs.go:561:54: Comment should end in a period (godot)
// files bigger than this size are sent with sendfile
                                                     ^
fs.go:1439:62: Comment should end in a period (godot)
// newCompressedFSFileCache use memory cache compressed files
                                                             ^
header.go:347:68: Comment should end in a period (godot)
// addVaryBytes add value to the 'Vary' header if it's not included
                                                                   ^
header.go:951:73: Comment should end in a period (godot)
// This is enabled by default unless disabled using DisableNormalizing()
                                                                        ^
header.go:983:73: Comment should end in a period (godot)
// This is enabled by default unless disabled using DisableNormalizing()
                                                                        ^
header.go:1353:63: Comment should end in a period (godot)
// setNonSpecial directly put into map i.e. not a basic header
                                                              ^
header.go:1412:63: Comment should end in a period (godot)
// setNonSpecial directly put into map i.e. not a basic header
                                                              ^
header.go:3335:65: Comment should end in a period (godot)
// removeNewLines will replace `\r` and `\n` with an empty space
                                                                ^
headers.go:3:11: Comment should end in a period (godot)
// Headers
          ^
headers.go:5:19: Comment should end in a period (godot)
        // Authentication
                         ^
headers.go:11:12: Comment should end in a period (godot)
        // Caching
                  ^
headers.go:19:17: Comment should end in a period (godot)
        // Client hints
                       ^
headers.go:29:17: Comment should end in a period (godot)
        // Conditionals
                       ^
headers.go:38:26: Comment should end in a period (godot)
        // Connection management
                                ^
headers.go:43:24: Comment should end in a period (godot)
        // Content negotiation
                              ^
headers.go:49:13: Comment should end in a period (godot)
        // Controls
                   ^
headers.go:55:9: Comment should end in a period (godot)
        // CORS
               ^
headers.go:68:17: Comment should end in a period (godot)
        // Do Not Track
                       ^
headers.go:72:14: Comment should end in a period (godot)
        // Downloads
                    ^
headers.go:75:29: Comment should end in a period (godot)
        // Message body information
                                   ^
headers.go:82:12: Comment should end in a period (godot)
        // Proxies
                  ^
headers.go:89:14: Comment should end in a period (godot)
        // Redirects
                    ^
headers.go:92:20: Comment should end in a period (godot)
        // Request context
                          ^
headers.go:99:21: Comment should end in a period (godot)
        // Response context
                           ^
headers.go:103:19: Comment should end in a period (godot)
        // Range requests
                         ^
headers.go:109:13: Comment should end in a period (godot)
        // Security
                   ^
headers.go:125:22: Comment should end in a period (godot)
        // Server-sent event
                            ^
headers.go:132:20: Comment should end in a period (godot)
        // Transfer coding
                          ^
headers.go:137:15: Comment should end in a period (godot)
        // WebSockets
                     ^
headers.go:144:10: Comment should end in a period (godot)
        // Other
                ^
http.go:253:63: Comment should end in a period (godot)
// IsBodyStream returns true if body is set via SetBodyStream*
                                                              ^
http.go:258:63: Comment should end in a period (godot)
// IsBodyStream returns true if body is set via SetBodyStream*
                                                              ^
http.go:897:27: Comment should end in a period (godot)
// URI returns request URI
                          ^
http.go:1852:74: Comment should end in a period (godot)
// Bodies with sizes smaller than minCompressLen aren't compressed at all
                                                                         ^
http.go:2370:31: Comment should end in a period (godot)
// c.DoTimeout(&req, &resp, t)
                              ^
lbclient.go:62:58: Comment should end in a period (godot)
// DoDeadline calls DoDeadline on the least loaded client
                                                         ^
lbclient.go:67:81: Comment should end in a period (godot)
// DoTimeout calculates deadline and calls DoDeadline on the least loaded client
                                                                                ^
lbclient.go:99:43: Comment should end in a period (godot)
// returns the new total number of clients
                                          ^
lbclient.go:112:43: Comment should end in a period (godot)
// returns the new total number of clients
                                          ^
server.go:487:68: Comment should end in a period (godot)
// RequestConfig configure the per request deadline and body limits
                                                                   ^
server.go:729:68: Comment should end in a period (godot)
// ResetUserValues allows to reset user values from Request Context
                                                                   ^
server.go:1734:53: Comment should end in a period (godot)
// in one server structure. See examples/multidomain
                                                    ^
server.go:2053:59: Comment should end in a period (godot)
// This function is intended be used by monitoring systems
                                                          ^
server.go:2060:59: Comment should end in a period (godot)
// This function is intended be used by monitoring systems
                                                          ^
server.go:2726:69: Comment should end in a period (godot)
// RequestCtx.s.done is only closed when the server is shutting down
                                                                    ^
server.go:2739:69: Comment should end in a period (godot)
// RequestCtx.s.done is only closed when the server is shutting down
                                                                    ^
server.go:2754:57: Comment should end in a period (godot)
// This method is the same as calling ctx.UserValue(key)
                                                        ^
uri.go:557:23: Comment should end in a period (godot)
// or matches /^:\d*$/
                      ^
client_unix_test.go:13:19: Comment should end in a period (godot)
// See issue #1232
                  ^
client_unix_test.go:76:19: Comment should end in a period (godot)
// See issue #1232
                  ^
fs_fs_test.go:368:7: Comment should end in a period (godot)
// *//
      ^
header_timing_test.go:15:42: Comment should end in a period (godot)
// it has the same length as Content-Type
                                         ^
header_timing_test.go:102:21: Comment should end in a period (godot)
// Result: 2.2 ns/op
                    ^
header_timing_test.go:116:21: Comment should end in a period (godot)
// Result: 2.9 ns/op
                    ^
header_timing_test.go:130:21: Comment should end in a period (godot)
// Result: 2.3 ns/op
                    ^
header_timing_test.go:144:21: Comment should end in a period (godot)
// Result: 2.9 ns/op
                    ^
server_test.go:26:51: Comment should end in a period (godot)
// Make sure RequestCtx implements context.Context
                                                  ^
fs_handler_example_test.go:10:50: Comment should end in a period (godot)
// Setup file handlers (aka 'file server config')
                                                 ^
fs_handler_example_test.go:30:24: Comment should end in a period (godot)
// Main request handler
                       ^
server.go:1146:2: ST1003: var NetHttpFormValueFunc should be NetHTTPFormValueFunc (stylecheck)
        NetHttpFormValueFunc = func(ctx *RequestCtx, key string) []byte {
        ^
client.go:1955:15: ST1005: error strings should not end with punctuation or newlines (stylecheck)
                return nil, errors.New("dialling unsuccessful. Please report this bug!")
                            ^
server.go:22:1: ST1022: comment on exported var ErrAlreadyServing should be of the form "ErrAlreadyServing ..." (stylecheck)
// Deprecated: ErrAlreadyServing is never returned from Serve. See issue #633.
^
client_test.go:2264:26: ST1016: methods on the same type should have the same receiver name (seen 2x "r", 4x "w") (stylecheck)
func (w *writeErrorConn) Close() error {
                         ^
```