### PR TITLE
feat: add function to parse HTTP header parameters

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -1110,6 +1110,26 @@ func testVisitHeaderParams(t *testing.T, header string, expectedParams [][2]stri
 	}
 }
 
+func FuzzVisitHeaderParams(f *testing.F) {
+	inputs := []string{
+		`application/json; v=1; foo=bar; q=0.938; param=param; param="big fox"; q=0.43`,
+		`*/*`,
+		`\\`,
+		`text/plain; foo="\\\"\'\\''\'"`,
+	}
+	for _, input := range inputs {
+		f.Add([]byte(input))
+	}
+	f.Fuzz(func(t *testing.T, header []byte) {
+		VisitHeaderParams(header, func(key, value []byte) bool {
+			if len(key) == 0 {
+				t.Errorf("Unexpected length zero parameter, failed input was: %s", header)
+			}
+			return true
+		})
+	})
+}
+
 func TestRequestMultipartFormBoundary(t *testing.T) {
 	t.Parallel()
 

--- a/header_timing_test.go
+++ b/header_timing_test.go
@@ -180,6 +180,19 @@ func benchmarkNormalizeHeaderKey(b *testing.B, src []byte) {
 	})
 }
 
+func BenchmarkVisitHeaderParams(b *testing.B) {
+	var h RequestHeader
+	h.SetBytesKV(strContentType, []byte(`text/plain  ;  foo=bar  ;   param2="dquote is: [\"], ok?" ; version=1; q=0.324  `))
+
+	header := h.ContentType()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		VisitHeaderParams(header, func(key, value []byte) bool { return true })
+	}
+}
+
 func BenchmarkRemoveNewLines(b *testing.B) {
 	type testcase struct {
 		value         string


### PR DESCRIPTION
The implementation is based on RFC-9110 5.6.6.

https://www.rfc-editor.org/rfc/rfc9110#name-parameters

The primary use case for parsing header parameters is for content negotiation, including multipart type boundaries.

The functor passed to VisitHeaderParams has a bool return value to allow the user to stop processing parameters early.
Examples of this being useful are to find a specific parameter, stop parsing after the q value, or to put a hard limit on the number of parameters a client can include.

I had originally written this for a different project using fasthttp, but I figured it was generic enough that it may warrant being merged in for others to use as well.  If not, no feelings will be hurt.

The implementation of validHeaderFieldByte is a little silly looking, but it's as fast as I could get it.
The Go standard library has its own implementation here, which is a bit slower: https://github.com/golang/go/blob/master/src/net/textproto/reader.go#L663
If the table solution is too arcane, we can copy the standard library instead.

Side note: VisitHeaderParams could also be used in MultipartFormBoundary to make fewer assumptions about how the client formatted their Content-Type header, but it would slow the function down quite a bit.
On my machine, it's 20 ns/op today vs 40 ns/op using VisitHeaderParams.