### PR TITLE
Remove unnecessary build tag go1.21

### DIFF
--- a/s2b_new.go
+++ b/s2b_new.go
@@ -1,4 +1,4 @@
-//go:build go1.20 || go1.21
+//go:build go1.20
 
 package fasthttp
 

--- a/s2b_old.go
+++ b/s2b_old.go
@@ -1,4 +1,4 @@
-//go:build !go1.20 && !go1.21
+//go:build !go1.20
 
 package fasthttp
 


### PR DESCRIPTION
This PR reverts changes from #1695 because they are unnecessary.

## Short Explanation

According to the [Go documentation on Build Constraints](https://pkg.go.dev/cmd/go#hdr-Build_constraints), the constraint `go1.20` applies to `go1.20`, `go1.21`, `go1.22`, and so on. Conversely, `!go1.20` applies to `go1.18` and `go1.19`.

Here's the relevant excerpt from the documentation:

> During a particular build, the following build tags are satisfied:
> ...
> - a term for each Go major release, through the current version: "go1.1" from Go version 1.1 onward, "go1.12" from Go 1.12, and so on.

## Long Explanation

Currently, `fasthttp` supports the following Go versions: `1.18`, `1.19`, `1.20`, `1.21`, `1.22`.
With build tags, we should ensure that:
-  `s2b_new.go` is included only when building with Go `1.20`, `1.21`, `1.22`;
- `s2b_old.go` is used for Go versions `1.18` and `1.19`.

Let's implement the changes in this PR and list the files used for building with different Go versions.

#### Go 1.18

This version compiles `s2b_old.go`:

```sh
go version go1.18 darwin/arm64
❯ go1.18 list -f '{{.GoFiles}}' ./...
[args.go b2s_old.go brotli.go bytesconv.go bytesconv_64.go bytesconv_table.go client.go coarsetime.go compress.go cookie.go doc.go fs.go header.go headers.go http.go lbclient.go methods.go nocopy.go peripconn.go round2_64.go s2b_old.go server.go status.go stream.go streaming.go strings.go tcp.go tcpdialer.go timer.go tls.go uri.go uri_unix.go userdata.go workerpool.go]
...
```

Right.

#### Go 1.19

This version compiles `s2b_old.go`:

```sh
❯ go1.19 version
go version go1.19 darwin/arm64
❯ go1.19 list -f '{{.GoFiles}}' ./...
[args.go b2s_old.go brotli.go bytesconv.go bytesconv_64.go bytesconv_table.go client.go coarsetime.go compress.go cookie.go doc.go fs.go header.go headers.go http.go lbclient.go methods.go nocopy.go peripconn.go round2_64.go s2b_old.go server.go status.go stream.go streaming.go strings.go tcp.go tcpdialer.go timer.go tls.go uri.go uri_unix.go userdata.go workerpool.go]
...
```

Right.

### Go 1.20

This version compiles `s2b_new.go`:

```
❯ go1.20 version
go version go1.20 darwin/arm64
❯ go1.20 list -f '{{.GoFiles}}' ./...
[args.go b2s_new.go brotli.go bytesconv.go bytesconv_64.go bytesconv_table.go client.go coarsetime.go compress.go cookie.go doc.go fs.go header.go headers.go http.go lbclient.go methods.go nocopy.go peripconn.go round2_64.go s2b_new.go server.go status.go stream.go streaming.go strings.go tcp.go tcpdialer.go timer.go tls.go uri.go uri_unix.go userdata.go workerpool.go]
...
```

Yeah, this is what we want.

### Go 1.21

This version compiles `s2b_new.go`:

```
❯ go1.21.7 version
go version go1.21.7 darwin/arm64
❯ go1.21.7 list -f '{{.GoFiles}}' ./...
[args.go b2s_new.go brotli.go bytesconv.go bytesconv_64.go bytesconv_table.go client.go coarsetime.go compress.go cookie.go doc.go fs.go header.go headers.go http.go lbclient.go methods.go nocopy.go peripconn.go round2_64.go s2b_new.go server.go status.go stream.go streaming.go strings.go tcp.go tcpdialer.go timer.go tls.go uri.go uri_unix.go userdata.go workerpool.go]
...
```

Right.

### Go 1.22

This version compiles `s2b_new.go`:

```
❯ go version
go version go1.22.0 darwin/arm64
❯ go list -f '{{.GoFiles}}' ./...
[args.go b2s_new.go brotli.go bytesconv.go bytesconv_64.go bytesconv_table.go client.go coarsetime.go compress.go cookie.go doc.go fs.go header.go headers.go http.go lbclient.go methods.go nocopy.go peripconn.go round2_64.go s2b_new.go server.go status.go stream.go streaming.go strings.go tcp.go tcpdialer.go timer.go tls.go uri.go uri_unix.go userdata.go workerpool.go]
...
```

Cool.