### PR TITLE
Upgrade golangci-lint to v1.56.2; fix gocritic issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,5 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v4
       with:
-        version: v1.55.2
+        version: v1.56.2
         args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,8 +69,22 @@ linters-settings:
       "-ST1000", # at least one file in a package should have a package comment
     ]
   gocritic:
-    enabled-checks:
-      - emptyStringTest
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - deferInLoop
+      - httpNoBody
+      - importShadow
+      - initClause
+      - paramTypeCombine
+      - sloppyReassign
+      - typeUnparen
+      - unnamedResult
+      - whyNoLint
 
 issues:
   # Show all issues from a linter.

--- a/args_test.go
+++ b/args_test.go
@@ -443,13 +443,13 @@ func TestArgsSetGetDel(t *testing.T) {
 			t.Fatalf("Unexpected value: %q. Expected %q", a.Peek(k), v)
 		}
 		a.Del(k)
-		if string(a.Peek(k)) != "" {
+		if len(a.Peek(k)) != 0 {
 			t.Fatalf("Unexpected value: %q. Expected %q", a.Peek(k), "")
 		}
 	}
 
 	a.Parse("aaa=xxx&bb=aa")
-	if string(a.Peek("foo0")) != "" {
+	if len(a.Peek("foo0")) != 0 {
 		t.Fatalf("Unexpected value %q", a.Peek("foo0"))
 	}
 	if string(a.Peek("aaa")) != "xxx" {
@@ -474,7 +474,7 @@ func TestArgsSetGetDel(t *testing.T) {
 			t.Fatalf("Unexpected value: %q. Expected %q", a.Peek(k), v)
 		}
 		a.Del(k)
-		if string(a.Peek(k)) != "" {
+		if len(a.Peek(k)) != 0 {
 			t.Fatalf("Unexpected value: %q. Expected %q", a.Peek(k), "")
 		}
 	}

--- a/brotli_test.go
+++ b/brotli_test.go
@@ -105,9 +105,9 @@ func testBrotliCompressSingleCase(s string) error {
 func TestCompressHandlerBrotliLevel(t *testing.T) {
 	t.Parallel()
 
-	expectedBody := string(createFixedBody(2e4))
+	expectedBody := createFixedBody(2e4)
 	h := CompressHandlerBrotliLevel(func(ctx *RequestCtx) {
-		ctx.WriteString(expectedBody) //nolint:errcheck
+		ctx.Write(expectedBody) //nolint:errcheck
 	}, CompressBrotliDefaultCompression, CompressDefaultCompression)
 
 	var ctx RequestCtx
@@ -121,11 +121,11 @@ func TestCompressHandlerBrotliLevel(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	ce := resp.Header.ContentEncoding()
-	if string(ce) != "" {
+	if len(ce) != 0 {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "")
 	}
 	body := resp.Body()
-	if string(body) != expectedBody {
+	if !bytes.Equal(body, expectedBody) {
 		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
 	}
 
@@ -148,7 +148,7 @@ func TestCompressHandlerBrotliLevel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(body) != expectedBody {
+	if !bytes.Equal(body, expectedBody) {
 		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
 	}
 
@@ -171,7 +171,7 @@ func TestCompressHandlerBrotliLevel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(body) != expectedBody {
+	if !bytes.Equal(body, expectedBody) {
 		t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
 	}
 }

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -35,7 +35,7 @@ func AppendHTMLEscape(dst []byte, s string) []byte {
 		case '\'':
 			sub = "&#39;" // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
 		}
-		if len(sub) > 0 {
+		if sub != "" {
 			dst = append(dst, s[prev:i]...)
 			dst = append(dst, sub...)
 			prev = i + 1

--- a/client_test.go
+++ b/client_test.go
@@ -456,7 +456,7 @@ func TestClientParseConn(t *testing.T) {
 		t.Fatalf("req RemoteAddr parse addr fail: %q, hope: %q", res.RemoteAddr().String(), host)
 	}
 
-	if !regexp.MustCompile(`^127\.0\.0\.1:[0-9]{4,5}$`).MatchString(res.LocalAddr().String()) {
+	if !regexp.MustCompile(`^127\.0\.0\.1:\d{4,5}$`).MatchString(res.LocalAddr().String()) {
 		t.Fatalf("res LocalAddr addr match fail: %q, hope match: %q", res.LocalAddr().String(), "^127.0.0.1:[0-9]{4,5}$")
 	}
 }
@@ -2323,7 +2323,7 @@ func (r *singleReadConn) Read(p []byte) (int, error) {
 	if len(r.s) == r.n {
 		return 0, io.EOF
 	}
-	n := copy(p, []byte(r.s[r.n:]))
+	n := copy(p, r.s[r.n:])
 	r.n += n
 	return n, nil
 }

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -160,7 +160,7 @@ func TestHijack(t *testing.T) {
 			if c, rw, err := f.Hijack(); err != nil {
 				t.Error(err)
 			} else {
-				if _, err := rw.Write([]byte("bar")); err != nil {
+				if _, err := rw.WriteString("bar"); err != nil {
 					t.Error(err)
 				}
 

--- a/fs.go
+++ b/fs.go
@@ -102,7 +102,7 @@ func ServeFile(ctx *RequestCtx, path string) {
 
 	if path == "" || !filepath.IsAbs(path) {
 		// extend relative path to absolute path
-		hasTrailingSlash := len(path) > 0 && (path[len(path)-1] == '/' || path[len(path)-1] == '\\')
+		hasTrailingSlash := path != "" && (path[len(path)-1] == '/' || path[len(path)-1] == '\\')
 
 		var err error
 		path = filepath.FromSlash(path)
@@ -442,7 +442,7 @@ func (fs *FS) normalizeRoot(root string) string {
 	}
 
 	// strip trailing slashes from the root path
-	for len(root) > 0 && root[len(root)-1] == os.PathSeparator {
+	for root != "" && root[len(root)-1] == os.PathSeparator {
 		root = root[:len(root)-1]
 	}
 	return root
@@ -468,7 +468,7 @@ func (fs *FS) initRequestHandler() {
 		}
 	}
 
-	if len(fs.CompressedFileSuffix) > 0 {
+	if fs.CompressedFileSuffix != "" {
 		compressedFileSuffixes["gzip"] = fs.CompressedFileSuffix
 		compressedFileSuffixes["br"] = FSCompressedFileSuffixes["br"]
 	}

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -254,7 +254,7 @@ func testFSFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Errorf("unexpected status code: %d. Expecting %d. filePath=%q", resp.StatusCode(), StatusOK, filePath)
 	}
 	ce := resp.Header.ContentEncoding()
-	if string(ce) != "" {
+	if len(ce) != 0 {
 		t.Errorf("unexpected content-encoding %q. Expecting empty string. filePath=%q", ce, filePath)
 	}
 	body := string(resp.Body())

--- a/fs_test.go
+++ b/fs_test.go
@@ -652,7 +652,7 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Errorf("unexpected status code: %d. Expecting %d. filePath=%q", resp.StatusCode(), StatusOK, filePath)
 	}
 	ce := resp.Header.ContentEncoding()
-	if string(ce) != "" {
+	if len(ce) != 0 {
 		t.Errorf("unexpected content-encoding %q. Expecting empty string. filePath=%q", ce, filePath)
 	}
 	body := string(resp.Body())

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -44,7 +44,7 @@ func FuzzResponseReadLimitBody(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, body []byte, max int) {
 		// Don't do bodies bigger than 10kb.
-		max = max % (10 * 1024)
+		max %= (10 * 1024)
 
 		var res Response
 
@@ -59,7 +59,7 @@ func FuzzRequestReadLimitBody(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, body []byte, max int) {
 		// Don't do bodies bigger than 10kb.
-		max = max % (10 * 1024)
+		max %= (10 * 1024)
 
 		var req Request
 

--- a/header_test.go
+++ b/header_test.go
@@ -167,7 +167,7 @@ func TestResponseHeaderEmptyValueFromHeader(t *testing.T) {
 	if err := h.Read(br); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(h.ContentType()) != string(h1.ContentType()) {
+	if !bytes.Equal(h.ContentType(), h1.ContentType()) {
 		t.Fatalf("unexpected content-type: %q. Expecting %q", h.ContentType(), h1.ContentType())
 	}
 	v1 := h.Peek("EmptyValue1")
@@ -222,7 +222,7 @@ func TestRequestHeaderEmptyValueFromHeader(t *testing.T) {
 	if err := h.Read(br); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(h.Host()) != string(h1.Host()) {
+	if !bytes.Equal(h.Host(), h1.Host()) {
 		t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), h1.Host())
 	}
 	v1 := h.Peek("EmptyValue1")
@@ -341,7 +341,7 @@ func TestRequestRawHeaders(t *testing.T) {
 		if err := h.Read(br); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if string(h.Host()) != "" {
+		if len(h.Host()) != 0 {
 			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "")
 		}
 		v1 := h.Peek("NoKey")
@@ -687,11 +687,11 @@ func TestResponseHeaderDel(t *testing.T) {
 		t.Fatalf("non-zero value: %q", hv)
 	}
 	hv = h.Peek(HeaderContentType)
-	if string(hv) != string(defaultContentType) {
+	if !bytes.Equal(hv, defaultContentType) {
 		t.Fatalf("unexpected content-type: %q. Expecting %q", hv, defaultContentType)
 	}
 	hv = h.Peek(HeaderContentEncoding)
-	if string(hv) != ("gzip") {
+	if string(hv) != "gzip" {
 		t.Fatalf("unexpected content-encoding: %q. Expecting %q", hv, "gzip")
 	}
 	hv = h.Peek(HeaderServer)
@@ -1519,7 +1519,7 @@ func TestRequestContentTypeNoDefault(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if string(h1.contentType) != "" {
+	if len(h1.contentType) != 0 {
 		t.Fatalf("unexpected Content-Type %q. Expecting %q", h1.contentType, "")
 	}
 }
@@ -2121,7 +2121,7 @@ func testRequestHeaderMethod(t *testing.T, expectedMethod string) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	m1 := h1.Method()
-	if string(m) != string(m1) {
+	if !bytes.Equal(m, m1) {
 		t.Fatalf("unexpected method: %q. Expecting %q", m, m1)
 	}
 }

--- a/http.go
+++ b/http.go
@@ -1250,7 +1250,7 @@ func (req *Request) ContinueReadBody(r *bufio.Reader, maxBodySize int, preParseM
 			// This way we limit memory usage for large file uploads, since their contents
 			// is streamed into temporary files if file size exceeds defaultMaxInMemoryFileSize.
 			req.multipartFormBoundary = string(req.Header.MultipartFormBoundary())
-			if len(req.multipartFormBoundary) > 0 && len(req.Header.peek(strContentEncoding)) == 0 {
+			if req.multipartFormBoundary != "" && len(req.Header.peek(strContentEncoding)) == 0 {
 				req.multipartForm, err = readMultipartForm(r, req.multipartFormBoundary, contentLength, defaultMaxInMemoryFileSize)
 				if err != nil {
 					req.Reset()
@@ -1329,7 +1329,7 @@ func (req *Request) ContinueReadBodyStream(r *bufio.Reader, maxBodySize int, pre
 			// This way we limit memory usage for large file uploads, since their contents
 			// is streamed into temporary files if file size exceeds defaultMaxInMemoryFileSize.
 			req.multipartFormBoundary = b2s(req.Header.MultipartFormBoundary())
-			if len(req.multipartFormBoundary) > 0 && len(req.Header.peek(strContentEncoding)) == 0 {
+			if req.multipartFormBoundary != "" && len(req.Header.peek(strContentEncoding)) == 0 {
 				req.multipartForm, err = readMultipartForm(r, req.multipartFormBoundary, contentLength, defaultMaxInMemoryFileSize)
 				if err != nil {
 					req.Reset()

--- a/http_test.go
+++ b/http_test.go
@@ -1210,7 +1210,7 @@ func TestRequestReadGzippedBody(t *testing.T) {
 	if r.Header.ContentLength() != len(body) {
 		t.Fatalf("unexpected content-length: %d. Expecting %d", r.Header.ContentLength(), len(body))
 	}
-	if string(r.Body()) != string(body) {
+	if !bytes.Equal(r.Body(), body) {
 		t.Fatalf("unexpected body: %q. Expecting %q", r.Body(), body)
 	}
 
@@ -1323,7 +1323,7 @@ func TestRequestContinueReadBodyDisablePrereadMultipartForm(t *testing.T) {
 		t.Fatalf("The multipartForm of the Request must be nil")
 	}
 
-	if string(formData) != string(r.Body()) {
+	if !bytes.Equal(formData, r.Body()) {
 		t.Fatalf("The body given must equal the body in the Request")
 	}
 }

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -152,7 +152,8 @@ func (p *Prefork) doCommand() (*exec.Cmd, error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.ExtraFiles = p.files
-	return cmd, cmd.Start()
+	err := cmd.Start()
+	return cmd, err
 }
 
 func (p *Prefork) prefork(addr string) (err error) {

--- a/server_test.go
+++ b/server_test.go
@@ -2012,7 +2012,7 @@ func TestCompressHandler(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	ce := resp.Header.ContentEncoding()
-	if string(ce) != "" {
+	if len(ce) != 0 {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "")
 	}
 	body := resp.Body()
@@ -2110,11 +2110,11 @@ func TestCompressHandlerVary(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	ce := resp.Header.ContentEncoding()
-	if string(ce) != "" {
+	if len(ce) != 0 {
 		t.Fatalf("unexpected Content-Encoding: %q. Expecting %q", ce, "")
 	}
 	vary := resp.Header.Peek("Vary")
-	if string(vary) != "" {
+	if len(vary) != 0 {
 		t.Fatalf("unexpected Vary: %q. Expecting %q", vary, "")
 	}
 	body := resp.Body()


### PR DESCRIPTION
The PR upgrades golangci-lint version to the latest [v1.56.2](https://github.com/golangci/golangci-lint/compare/v1.55.2...v1.56.2)), enables a lot of gocritic's checks and fixes up issues.

### Explanation of some gocritic's fixes

- in idiomatic Go, we should use `len(v) =! 0` instead of `string(v) != ""` when `v` is `[]byte`. See https://dmitri.shuralyov.com/idiomatic-go#empty-string-check;
- we should use `v != ""` instead of `len(v) != ` when `v` is string;
- we can compare byte slices with `bytes.Equal` instead of converting them to string;
- `rw.Write([]byte(str),...` can be rewritten to `rw.WriteString(str,...`.

### The full log of running `golangci-lint`

```sh
❯ golangci-lint run
prefork/prefork.go:155:14: evalOrder: may want to evaluate cmd.Start() before the return statement (gocritic)
        return cmd, cmd.Start()
                    ^
bytesconv.go:38:6: emptyStringTest: replace `len(sub) > 0` with `sub != ""` (gocritic)
                if len(sub) > 0 {
                   ^
fs.go:471:5: emptyStringTest: replace `len(fs.CompressedFileSuffix) > 0` with `fs.CompressedFileSuffix != ""` (gocritic)
        if len(fs.CompressedFileSuffix) > 0 {
           ^
fs.go:105:23: emptyStringTest: replace `len(path) > 0` with `path != ""` (gocritic)
                hasTrailingSlash := len(path) > 0 && (path[len(path)-1] == '/' || path[len(path)-1] == '\\')
                                    ^
fs.go:445:6: emptyStringTest: replace `len(root) > 0` with `root != ""` (gocritic)
        for len(root) > 0 && root[len(root)-1] == os.PathSeparator {
            ^
http.go:1253:7: emptyStringTest: replace `len(req.multipartFormBoundary) > 0` with `req.multipartFormBoundary != ""` (gocritic)
                        if len(req.multipartFormBoundary) > 0 && len(req.Header.peek(strContentEncoding)) == 0 {
                           ^
http.go:1332:7: emptyStringTest: replace `len(req.multipartFormBoundary) > 0` with `req.multipartFormBoundary != ""` (gocritic)
                        if len(req.multipartFormBoundary) > 0 && len(req.Header.peek(strContentEncoding)) == 0 {
                           ^
args_test.go:452:5: stringXbytes: suggestion: len(a.Peek("foo0")) != 0 (gocritic)
        if string(a.Peek("foo0")) != "" {
           ^
args_test.go:446:6: stringXbytes: suggestion: len(a.Peek(k)) != 0 (gocritic)
                if string(a.Peek(k)) != "" {
                   ^
args_test.go:477:6: stringXbytes: suggestion: len(a.Peek(k)) != 0 (gocritic)
                if string(a.Peek(k)) != "" {
                   ^
brotli_test.go:124:5: stringXbytes: suggestion: len(ce) != 0 (gocritic)
        if string(ce) != "" {
           ^
client_test.go:459:25: regexpSimplify: can re-write `^127\.0\.0\.1:[0-9]{4,5}$` as `^127\.0\.0\.1:\d{4,5}$` (gocritic)
        if !regexp.MustCompile(`^127\.0\.0\.1:[0-9]{4,5}$`).MatchString(res.LocalAddr().String()) {
                               ^
client_test.go:2326:7: stringXbytes: can simplify `[]byte(r.s[r.n:])` to `r.s[r.n:]` (gocritic)
        n := copy(p, []byte(r.s[r.n:]))
             ^
fs_fs_test.go:257:5: stringXbytes: suggestion: len(ce) != 0 (gocritic)
        if string(ce) != "" {
           ^
fs_test.go:655:5: stringXbytes: suggestion: len(ce) != 0 (gocritic)
        if string(ce) != "" {
           ^
fuzz_test.go:47:3: assignOp: replace `max = max % (10 * 1024)` with `max %= (10 * 1024)` (gocritic)
                max = max % (10 * 1024)
                ^
fuzz_test.go:62:3: assignOp: replace `max = max % (10 * 1024)` with `max %= (10 * 1024)` (gocritic)
                max = max % (10 * 1024)
                ^
header_test.go:170:5: stringXbytes: suggestion: !bytes.Equal(h.ContentType(), h1.ContentType()) (gocritic)
        if string(h.ContentType()) != string(h1.ContentType()) {
           ^
header_test.go:225:5: stringXbytes: suggestion: !bytes.Equal(h.Host(), h1.Host()) (gocritic)
        if string(h.Host()) != string(h1.Host()) {
           ^
header_test.go:690:5: stringXbytes: suggestion: !bytes.Equal(hv, defaultContentType) (gocritic)
        if string(hv) != string(defaultContentType) {
           ^
header_test.go:2124:5: stringXbytes: suggestion: !bytes.Equal(m, m1) (gocritic)
        if string(m) != string(m1) {
           ^
header_test.go:344:6: stringXbytes: suggestion: len(h.Host()) != 0 (gocritic)
                if string(h.Host()) != "" {
                   ^
header_test.go:1522:5: stringXbytes: suggestion: len(h1.contentType) != 0 (gocritic)
        if string(h1.contentType) != "" {
           ^
http_test.go:1326:5: stringXbytes: suggestion: !bytes.Equal(formData, r.Body()) (gocritic)
        if string(formData) != string(r.Body()) {
           ^
http_test.go:1213:5: stringXbytes: suggestion: !bytes.Equal(r.Body(), body) (gocritic)
        if string(r.Body()) != string(body) {
           ^
server_test.go:2015:5: stringXbytes: suggestion: len(ce) != 0 (gocritic)
        if string(ce) != "" {
           ^
server_test.go:2113:5: stringXbytes: suggestion: len(ce) != 0 (gocritic)
        if string(ce) != "" {
           ^
server_test.go:2117:5: stringXbytes: suggestion: len(vary) != 0 (gocritic)
        if string(vary) != "" {
           ^
fasthttpadaptor/adaptor_test.go:163:18: preferStringWriter: rw.WriteString("bar") should be preferred to the rw.Write([]byte("bar")) (gocritic)
                                if _, err := rw.Write([]byte("bar")); err != nil {
                                             ^
```