### PR TITLE
fs: simplify readFileHeader by using defer statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tags
 *.pprof
 *.fasthttp.gz
 *.fasthttp.br
+*.fasthttp.zst
 .idea
 .vscode
 .DS_Store

--- a/brotli_test.go
+++ b/brotli_test.go
@@ -91,6 +91,7 @@ func testBrotliCompressSingleCase(s string) error {
 	if err != nil {
 		return fmt.Errorf("unexpected error: %w. s=%q", err, s)
 	}
+	defer releaseBrotliReader(zr)
 	body, err := io.ReadAll(zr)
 	if err != nil {
 		return fmt.Errorf("unexpected error: %w. s=%q", err, s)
@@ -98,7 +99,6 @@ func testBrotliCompressSingleCase(s string) error {
 	if string(body) != s {
 		return fmt.Errorf("unexpected string after decompression: %q. Expecting %q", body, s)
 	}
-	releaseBrotliReader(zr)
 	return nil
 }
 

--- a/compress_test.go
+++ b/compress_test.go
@@ -173,6 +173,7 @@ func testGzipCompressSingleCase(s string) error {
 	if err != nil {
 		return fmt.Errorf("unexpected error: %w. s=%q", err, s)
 	}
+	defer releaseGzipReader(zr)
 	body, err := io.ReadAll(zr)
 	if err != nil {
 		return fmt.Errorf("unexpected error: %w. s=%q", err, s)
@@ -180,7 +181,6 @@ func testGzipCompressSingleCase(s string) error {
 	if string(body) != s {
 		return fmt.Errorf("unexpected string after decompression: %q. Expecting %q", body, s)
 	}
-	releaseGzipReader(zr)
 	return nil
 }
 

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -90,6 +90,7 @@ func testZstdCompressSingleCase(s string) error {
 	if err != nil {
 		return fmt.Errorf("unexpected error: %w. s=%q", err, s)
 	}
+	defer releaseZstdReader(zr)
 	body, err := io.ReadAll(zr)
 	if err != nil {
 		return fmt.Errorf("unexpected error: %w. s=%q", err, s)
@@ -97,6 +98,5 @@ func testZstdCompressSingleCase(s string) error {
 	if string(body) != s {
 		return fmt.Errorf("unexpected string after decompression: %q. Expecting %q", body, s)
 	}
-	releaseZstdReader(zr)
 	return nil
 }


### PR DESCRIPTION
The PR refactors `readFileHader` function by using `defer` for releasing compress readers; adds the missing test logic that covers `zstd` reader (follows https://github.com/valyala/fasthttp/pull/1701).