### PR TITLE
Enable perfsprint linter; fix up lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,6 @@ linters:
     - noctx
     - nonamedreturns
     - paralleltest
-    - perfsprint
     - testableexamples
     - testpackage
     - thelper

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -3,10 +3,10 @@ package fasthttp
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"html"
 	"net"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -118,7 +118,7 @@ func testAppendIPv4(t *testing.T, ipStr string, isValid bool) {
 }
 
 func testAppendUint(t *testing.T, n int) {
-	expectedS := fmt.Sprintf("%d", n)
+	expectedS := strconv.Itoa(n)
 	s := AppendUint(nil, n)
 	if string(s) != expectedS {
 		t.Fatalf("unexpected uint %q. Expecting %q. n=%d", s, expectedS, n)

--- a/client_test.go
+++ b/client_test.go
@@ -2258,7 +2258,7 @@ type writeErrorConn struct {
 }
 
 func (w *writeErrorConn) Write(p []byte) (int, error) {
-	return 1, fmt.Errorf("error")
+	return 1, errors.New("error")
 }
 
 func (w *writeErrorConn) Close() error {
@@ -2286,7 +2286,7 @@ type readErrorConn struct {
 }
 
 func (r *readErrorConn) Read(p []byte) (int, error) {
-	return 0, fmt.Errorf("error")
+	return 0, errors.New("error")
 }
 
 func (r *readErrorConn) Write(p []byte) (int, error) {
@@ -2849,7 +2849,7 @@ func TestClientConfigureClientFailed(t *testing.T) {
 
 	c := &Client{
 		ConfigureClient: func(hc *HostClient) error {
-			return fmt.Errorf("failed to configure")
+			return errors.New("failed to configure")
 		},
 	}
 

--- a/compress_test.go
+++ b/compress_test.go
@@ -2,6 +2,7 @@ package fasthttp
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -225,7 +226,7 @@ func testConcurrent(concurrency int, f func() error) error {
 				return err
 			}
 		case <-time.After(time.Second):
-			return fmt.Errorf("timeout")
+			return errors.New("timeout")
 		}
 	}
 	return nil

--- a/header.go
+++ b/header.go
@@ -2118,7 +2118,7 @@ func (h *ResponseHeader) tryRead(r *bufio.Reader, n int) error {
 		if err == bufio.ErrBufferFull {
 			if h.secureErrorLogMessage {
 				return &ErrSmallBuffer{
-					error: fmt.Errorf("error when reading response headers"),
+					error: errors.New("error when reading response headers"),
 				}
 			}
 			return &ErrSmallBuffer{
@@ -2170,7 +2170,7 @@ func (h *ResponseHeader) tryReadTrailer(r *bufio.Reader, n int) error {
 		if err == bufio.ErrBufferFull {
 			if h.secureErrorLogMessage {
 				return &ErrSmallBuffer{
-					error: fmt.Errorf("error when reading response trailer"),
+					error: errors.New("error when reading response trailer"),
 				}
 			}
 			return &ErrSmallBuffer{
@@ -2279,7 +2279,7 @@ func (h *RequestHeader) tryReadTrailer(r *bufio.Reader, n int) error {
 		if err == bufio.ErrBufferFull {
 			if h.secureErrorLogMessage {
 				return &ErrSmallBuffer{
-					error: fmt.Errorf("error when reading request trailer"),
+					error: errors.New("error when reading request trailer"),
 				}
 			}
 			return &ErrSmallBuffer{
@@ -2821,7 +2821,7 @@ func (h *ResponseHeader) parseFirstLine(buf []byte) (int, error) {
 	n := bytes.IndexByte(b, ' ')
 	if n < 0 {
 		if h.secureErrorLogMessage {
-			return 0, fmt.Errorf("cannot find whitespace in the first line of response")
+			return 0, errors.New("cannot find whitespace in the first line of response")
 		}
 		return 0, fmt.Errorf("cannot find whitespace in the first line of response %q", buf)
 	}
@@ -2838,7 +2838,7 @@ func (h *ResponseHeader) parseFirstLine(buf []byte) (int, error) {
 	}
 	if len(b) > n && b[n] != ' ' {
 		if h.secureErrorLogMessage {
-			return 0, fmt.Errorf("unexpected char at the end of status code")
+			return 0, errors.New("unexpected char at the end of status code")
 		}
 		return 0, fmt.Errorf("unexpected char at the end of status code. Response %q", buf)
 	}
@@ -2863,7 +2863,7 @@ func (h *RequestHeader) parseFirstLine(buf []byte) (int, error) {
 	n := bytes.IndexByte(b, ' ')
 	if n <= 0 {
 		if h.secureErrorLogMessage {
-			return 0, fmt.Errorf("cannot find http request method")
+			return 0, errors.New("cannot find http request method")
 		}
 		return 0, fmt.Errorf("cannot find http request method in %q", buf)
 	}
@@ -2876,7 +2876,7 @@ func (h *RequestHeader) parseFirstLine(buf []byte) (int, error) {
 		return 0, fmt.Errorf("cannot find whitespace in the first line of request %q", buf)
 	} else if n == 0 {
 		if h.secureErrorLogMessage {
-			return 0, fmt.Errorf("requestURI cannot be empty")
+			return 0, errors.New("requestURI cannot be empty")
 		}
 		return 0, fmt.Errorf("requestURI cannot be empty in %q", buf)
 	}
@@ -3067,7 +3067,7 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 				}
 				if caseInsensitiveCompare(s.key, strContentLength) {
 					if contentLengthSeen {
-						return 0, fmt.Errorf("duplicate Content-Length header")
+						return 0, errors.New("duplicate Content-Length header")
 					}
 					contentLengthSeen = true
 
@@ -3100,7 +3100,7 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 
 					if !isIdentity && !isChunked {
 						if h.secureErrorLogMessage {
-							return 0, fmt.Errorf("unsupported Transfer-Encoding")
+							return 0, errors.New("unsupported Transfer-Encoding")
 						}
 						return 0, fmt.Errorf("unsupported Transfer-Encoding: %q", s.value)
 					}

--- a/header_test.go
+++ b/header_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -454,7 +455,7 @@ func TestResponseHeaderAdd(t *testing.T) {
 	m["bbb"] = struct{}{}
 	m["xxx"] = struct{}{}
 	for i := 0; i < 10; i++ {
-		v := fmt.Sprintf("%d", i)
+		v := strconv.Itoa(i)
 		h.Add("Foo-Bar", v)
 		m[v] = struct{}{}
 	}
@@ -507,7 +508,7 @@ func TestRequestHeaderAdd(t *testing.T) {
 	m["bbb"] = struct{}{}
 	m["xxx"] = struct{}{}
 	for i := 0; i < 10; i++ {
-		v := fmt.Sprintf("%d", i)
+		v := strconv.Itoa(i)
 		h.Add("Foo-Bar", v)
 		m[v] = struct{}{}
 	}
@@ -1294,7 +1295,7 @@ func TestResponseHeaderFirstByteReadEOF(t *testing.T) {
 
 	var h ResponseHeader
 
-	r := &errorReader{fmt.Errorf("non-eof error")}
+	r := &errorReader{errors.New("non-eof error")}
 	br := bufio.NewReader(r)
 	err := h.Read(br)
 	if err == nil {

--- a/http.go
+++ b/http.go
@@ -1633,7 +1633,7 @@ func (req *Request) Write(w *bufio.Writer) error {
 		_, err = w.Write(body)
 	} else if len(body) > 0 {
 		if req.secureErrorLogMessage {
-			return fmt.Errorf("non-zero body for non-POST request")
+			return errors.New("non-zero body for non-POST request")
 		}
 		return fmt.Errorf("non-zero body for non-POST request. body=%q", body)
 	}
@@ -2379,7 +2379,7 @@ func readBodyChunked(r *bufio.Reader, maxBodySize int, dst []byte) ([]byte, erro
 		}
 		if !bytes.Equal(dst[len(dst)-strCRLFLen:], strCRLF) {
 			return dst, ErrBrokenChunk{
-				error: fmt.Errorf("cannot find crlf at the end of chunk"),
+				error: errors.New("cannot find crlf at the end of chunk"),
 			}
 		}
 		dst = dst[:len(dst)-strCRLFLen]

--- a/stackless/func_test.go
+++ b/stackless/func_test.go
@@ -1,7 +1,7 @@
 package stackless
 
 import (
-	"fmt"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -44,7 +44,7 @@ func TestNewFuncMulti(t *testing.T) {
 		var err error
 		for i := 0; i < iterations; i++ {
 			if !f1(3) {
-				err = fmt.Errorf("f1 mustn't return false")
+				err = errors.New("f1 mustn't return false")
 				break
 			}
 		}
@@ -56,7 +56,7 @@ func TestNewFuncMulti(t *testing.T) {
 		var err error
 		for i := 0; i < iterations; i++ {
 			if !f2(5) {
-				err = fmt.Errorf("f2 mustn't return false")
+				err = errors.New("f2 mustn't return false")
 				break
 			}
 		}

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,6 +2,7 @@ package fasthttp
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -55,7 +56,7 @@ func TestStreamReaderClose(t *testing.T) {
 			w.Write(data) //nolint:errcheck
 		}
 		if err := w.Flush(); err == nil {
-			ch <- fmt.Errorf("expecting error on the second flush")
+			ch <- errors.New("expecting error on the second flush")
 		}
 		ch <- nil
 	})


### PR DESCRIPTION
The PR enables the [`perfsprint`](https://golangci-lint.run/usage/linters/#perfsprint) linter in the golangci-lint configuration file. The `fasthttp` library is  heavily focused on performance, making this linter a beneficial addition.

This PR fixes up the lint issues that arose from `persprint`. All of these were minor:

- replace `fmt.Errorf("msg")` with `errors.New("msg))`;
- replace `fmt.Sprintf("%d", n)` with `strconv.Itoa(n)` in tests.