### PR TITLE
Enable several gocritic checks; resolve identified issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,12 +77,8 @@ linters-settings:
       - style
     disabled-checks:
       - deferInLoop
-      - httpNoBody
       - importShadow
-      - initClause
-      - paramTypeCombine
       - sloppyReassign
-      - typeUnparen
       - unnamedResult
       - whyNoLint
 

--- a/client_timing_test.go
+++ b/client_timing_test.go
@@ -165,7 +165,7 @@ func BenchmarkNetHTTPClientDoFastServer(b *testing.B) {
 
 	nn := uint32(0)
 	b.RunParallel(func(pb *testing.PB) {
-		req, err := http.NewRequest(MethodGet, fmt.Sprintf("http://foobar%d.com/aaa/bbb", atomic.AddUint32(&nn, 1)), nil)
+		req, err := http.NewRequest(MethodGet, fmt.Sprintf("http://foobar%d.com/aaa/bbb", atomic.AddUint32(&nn, 1)), http.NoBody)
 		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}
@@ -550,7 +550,7 @@ func benchmarkNetHTTPClientEndToEndBigResponseInmemory(b *testing.B, parallelism
 	url := "http://unused.host" + requestURI
 	b.SetParallelism(parallelism)
 	b.RunParallel(func(pb *testing.PB) {
-		req, err := http.NewRequest(MethodGet, url, nil)
+		req, err := http.NewRequest(MethodGet, url, http.NoBody)
 		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}

--- a/fs.go
+++ b/fs.go
@@ -1350,7 +1350,7 @@ const (
 	fsMaxCompressibleFileSize = 8 * 1024 * 1024
 )
 
-func (h *fsHandler) compressAndOpenFSFile(filePath string, fileEncoding string) (*fsFile, error) {
+func (h *fsHandler) compressAndOpenFSFile(filePath, fileEncoding string) (*fsFile, error) {
 	f, err := h.filesystem.Open(filePath)
 	if err != nil {
 		return nil, err
@@ -1532,7 +1532,7 @@ func (h *fsHandler) newCompressedFSFileCache(f fs.File, fileInfo fs.FileInfo, fi
 	return ff, nil
 }
 
-func (h *fsHandler) newCompressedFSFile(filePath string, fileEncoding string) (*fsFile, error) {
+func (h *fsHandler) newCompressedFSFile(filePath, fileEncoding string) (*fsFile, error) {
 	f, err := h.filesystem.Open(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open compressed file %q: %w", filePath, err)

--- a/header.go
+++ b/header.go
@@ -1430,7 +1430,7 @@ func (h *ResponseHeader) setSpecialHeader(key, value []byte) bool {
 }
 
 // setNonSpecial directly put into map i.e. not a basic header.
-func (h *ResponseHeader) setNonSpecial(key []byte, value []byte) {
+func (h *ResponseHeader) setNonSpecial(key, value []byte) {
 	h.h = setArgBytes(h.h, key, value, argsHasValue)
 }
 
@@ -1489,7 +1489,7 @@ func (h *RequestHeader) setSpecialHeader(key, value []byte) bool {
 }
 
 // setNonSpecial directly put into map i.e. not a basic header.
-func (h *RequestHeader) setNonSpecial(key []byte, value []byte) {
+func (h *RequestHeader) setNonSpecial(key, value []byte) {
 	h.h = setArgBytes(h.h, key, value, argsHasValue)
 }
 

--- a/http.go
+++ b/http.go
@@ -1201,7 +1201,7 @@ func (req *Request) ReadLimitBody(r *bufio.Reader, maxBodySize int) error {
 	return req.readLimitBody(r, maxBodySize, false, true)
 }
 
-func (req *Request) readLimitBody(r *bufio.Reader, maxBodySize int, getOnly bool, preParseMultipartForm bool) error {
+func (req *Request) readLimitBody(r *bufio.Reader, maxBodySize int, getOnly, preParseMultipartForm bool) error {
 	// Do not reset the request here - the caller must reset it before
 	// calling this method.
 
@@ -1219,7 +1219,7 @@ func (req *Request) readLimitBody(r *bufio.Reader, maxBodySize int, getOnly bool
 	return req.ContinueReadBody(r, maxBodySize, preParseMultipartForm)
 }
 
-func (req *Request) readBodyStream(r *bufio.Reader, maxBodySize int, getOnly bool, preParseMultipartForm bool) error {
+func (req *Request) readBodyStream(r *bufio.Reader, maxBodySize int, getOnly, preParseMultipartForm bool) error {
 	// Do not reset the request here - the caller must reset it before
 	// calling this method.
 
@@ -1310,7 +1310,7 @@ func (req *Request) ContinueReadBody(r *bufio.Reader, maxBodySize int, preParseM
 //
 // If maxBodySize > 0 and the body size exceeds maxBodySize,
 // then ErrBodyTooLarge is returned.
-func (req *Request) ReadBody(r *bufio.Reader, contentLength int, maxBodySize int) (err error) {
+func (req *Request) ReadBody(r *bufio.Reader, contentLength, maxBodySize int) (err error) {
 	bodyBuf := req.bodyBuffer()
 	bodyBuf.Reset()
 
@@ -2242,7 +2242,7 @@ func writeChunk(w *bufio.Writer, b []byte) error {
 // the given limit.
 var ErrBodyTooLarge = errors.New("body size exceeds the given limit")
 
-func readBody(r *bufio.Reader, contentLength int, maxBodySize int, dst []byte) ([]byte, error) {
+func readBody(r *bufio.Reader, contentLength, maxBodySize int, dst []byte) ([]byte, error) {
 	if maxBodySize > 0 && contentLength > maxBodySize {
 		return dst, ErrBodyTooLarge
 	}
@@ -2251,7 +2251,7 @@ func readBody(r *bufio.Reader, contentLength int, maxBodySize int, dst []byte) (
 
 var errChunkedStream = errors.New("chunked stream")
 
-func readBodyWithStreaming(r *bufio.Reader, contentLength int, maxBodySize int, dst []byte) (b []byte, err error) {
+func readBodyWithStreaming(r *bufio.Reader, contentLength, maxBodySize int, dst []byte) (b []byte, err error) {
 	if contentLength == -1 {
 		// handled in requestStream.Read()
 		return b, errChunkedStream

--- a/http_test.go
+++ b/http_test.go
@@ -2658,8 +2658,8 @@ func TestRequestRawBodyCopyTo(t *testing.T) {
 }
 
 type testReader struct {
-	read    chan (int)
-	cb      chan (struct{})
+	read    chan int
+	cb      chan struct{}
 	onClose func() error
 }
 

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -210,7 +210,8 @@ func (p *Prefork) prefork(addr string) (err error) {
 		p.logger().Printf("one of the child prefork processes exited with "+
 			"error: %v", sig.err)
 
-		if exitedProcs++; exitedProcs > p.RecoverThreshold {
+		exitedProcs++
+		if exitedProcs > p.RecoverThreshold {
 			p.logger().Printf("child prefork processes exit too many times, "+
 				"which exceeds the value of RecoverThreshold(%d), "+
 				"exiting the master process.\n", exitedProcs)

--- a/server.go
+++ b/server.go
@@ -682,7 +682,7 @@ func (ctx *RequestCtx) Hijacked() bool {
 // All the values are removed from ctx after returning from the top
 // RequestHandler. Additionally, Close method is called on each value
 // implementing io.Closer before removing the value from ctx.
-func (ctx *RequestCtx) SetUserValue(key any, value any) {
+func (ctx *RequestCtx) SetUserValue(key, value any) {
 	ctx.userValues.Set(key, value)
 }
 

--- a/status.go
+++ b/status.go
@@ -163,7 +163,7 @@ func StatusMessage(statusCode int) string {
 	return unknownStatusCode
 }
 
-func formatStatusLine(dst []byte, protocol []byte, statusCode int, statusText []byte) []byte {
+func formatStatusLine(dst, protocol []byte, statusCode int, statusText []byte) []byte {
 	dst = append(dst, protocol...)
 	dst = append(dst, ' ')
 	dst = strconv.AppendInt(dst, int64(statusCode), 10)

--- a/userdata.go
+++ b/userdata.go
@@ -11,7 +11,7 @@ type userDataKV struct {
 
 type userData []userDataKV
 
-func (d *userData) Set(key any, value any) {
+func (d *userData) Set(key, value any) {
 	if b, ok := key.([]byte); ok {
 		key = string(b)
 	}


### PR DESCRIPTION
The PR enables temporarily disabled `httpNoBody`, `initClause`, `paramTypeCombine`, `typeUnparen` checks from [gocritic](https://go-critic.com/overview.html) linter and fixes up lint issues.

```
❯ golangci-lint run
fs.go:1353:1: paramTypeCombine: func(filePath string, fileEncoding string) (*fsFile, error) could be replaced with func(filePath, fileEncoding string) (*fsFile, error) (gocritic)
func (h *fsHandler) compressAndOpenFSFile(filePath string, fileEncoding string) (*fsFile, error) {
^
fs.go:1535:1: paramTypeCombine: func(filePath string, fileEncoding string) (*fsFile, error) could be replaced with func(filePath, fileEncoding string) (*fsFile, error) (gocritic)
func (h *fsHandler) newCompressedFSFile(filePath string, fileEncoding string) (*fsFile, error) {
^
header.go:1433:1: paramTypeCombine: func(key []byte, value []byte) could be replaced with func(key, value []byte) (gocritic)
func (h *ResponseHeader) setNonSpecial(key []byte, value []byte) {
^
header.go:1492:1: paramTypeCombine: func(key []byte, value []byte) could be replaced with func(key, value []byte) (gocritic)
func (h *RequestHeader) setNonSpecial(key []byte, value []byte) {
^
http.go:1204:1: paramTypeCombine: func(r *bufio.Reader, maxBodySize int, getOnly bool, preParseMultipartForm bool) error could be replaced with func(r *bufio.Reader, maxBodySize int, getOnly, preParseMultipartForm bool) error (gocritic)
func (req *Request) readLimitBody(r *bufio.Reader, maxBodySize int, getOnly bool, preParseMultipartForm bool) error {
^
http.go:1222:1: paramTypeCombine: func(r *bufio.Reader, maxBodySize int, getOnly bool, preParseMultipartForm bool) error could be replaced with func(r *bufio.Reader, maxBodySize int, getOnly, preParseMultipartForm bool) error (gocritic)
func (req *Request) readBodyStream(r *bufio.Reader, maxBodySize int, getOnly bool, preParseMultipartForm bool) error {
^
http.go:1313:1: paramTypeCombine: func(r *bufio.Reader, contentLength int, maxBodySize int) (err error) could be replaced with func(r *bufio.Reader, contentLength, maxBodySize int) (err error) (gocritic)
func (req *Request) ReadBody(r *bufio.Reader, contentLength int, maxBodySize int) (err error) {
^
http.go:2245:1: paramTypeCombine: func(r *bufio.Reader, contentLength int, maxBodySize int, dst []byte) ([]byte, error) could be replaced with func(r *bufio.Reader, contentLength, maxBodySize int, dst []byte) ([]byte, error) (gocritic)
func readBody(r *bufio.Reader, contentLength int, maxBodySize int, dst []byte) ([]byte, error) {
^
http.go:2254:1: paramTypeCombine: func(r *bufio.Reader, contentLength int, maxBodySize int, dst []byte) (b []byte, err error) could be replaced with func(r *bufio.Reader, contentLength, maxBodySize int, dst []byte) (b []byte, err error) (gocritic)
func readBodyWithStreaming(r *bufio.Reader, contentLength int, maxBodySize int, dst []byte) (b []byte, err error) {
^
server.go:685:1: paramTypeCombine: func(key any, value any) could be replaced with func(key, value any) (gocritic)
func (ctx *RequestCtx) SetUserValue(key any, value any) {
^
status.go:166:1: paramTypeCombine: func(dst []byte, protocol []byte, statusCode int, statusText []byte) []byte could be replaced with func(dst, protocol []byte, statusCode int, statusText []byte) []byte (gocritic)
func formatStatusLine(dst []byte, protocol []byte, statusCode int, statusText []byte) []byte {
^
userdata.go:14:1: paramTypeCombine: func(key any, value any) could be replaced with func(key, value any) (gocritic)
func (d *userData) Set(key any, value any) {
^
client_timing_test.go:168:15: httpNoBody: http.NoBody should be preferred to the nil request body (gocritic)
                req, err := http.NewRequest(MethodGet, fmt.Sprintf("http://foobar%d.com/aaa/bbb", atomic.AddUint32(&nn, 1)), nil)
                            ^
client_timing_test.go:553:15: httpNoBody: http.NoBody should be preferred to the nil request body (gocritic)
                req, err := http.NewRequest(MethodGet, url, nil)
                            ^
http_test.go:2661:10: typeUnparen: could simplify chan (int) to chan int (gocritic)
        read    chan (int)
                ^
http_test.go:2662:10: typeUnparen: could simplify chan (struct{}) to chan struct{} (gocritic)
        cb      chan (struct{})
                ^
prefork/prefork.go:213:3: initClause: consider to move `exitedProcs++` before if (gocritic)
                if exitedProcs++; exitedProcs > p.RecoverThreshold {
                ^
```