### PR TITLE
test: remove `//nolint:govet` comments

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -336,8 +336,8 @@ func testCopyTo(t *testing.T, a *Args) {
 	var b Args
 	a.CopyTo(&b)
 
-	if !reflect.DeepEqual(*a, b) { //nolint:govet
-		t.Fatalf("ArgsCopyTo fail, a: \n%+v\nb: \n%+v\n", *a, b) //nolint:govet
+	if !reflect.DeepEqual(a, &b) {
+		t.Fatalf("ArgsCopyTo fail, a: \n%+v\nb: \n%+v\n", a, &b)
 	}
 
 	b.VisitAll(func(k, _ []byte) {

--- a/header_test.go
+++ b/header_test.go
@@ -1407,8 +1407,8 @@ func TestResponseHeaderCopyTo(t *testing.T) {
 	h.bufKV = argsKV{}
 	h1.bufKV = argsKV{}
 
-	if !reflect.DeepEqual(h, h1) { //nolint:govet
-		t.Fatalf("ResponseHeaderCopyTo fail, src: \n%+v\ndst: \n%+v\n", h, h1) //nolint:govet
+	if !reflect.DeepEqual(&h, &h1) {
+		t.Fatalf("ResponseHeaderCopyTo fail, src: \n%+v\ndst: \n%+v\n", &h, &h1)
 	}
 }
 
@@ -1450,8 +1450,8 @@ func TestRequestHeaderCopyTo(t *testing.T) {
 	h.bufKV = argsKV{}
 	h1.bufKV = argsKV{}
 
-	if !reflect.DeepEqual(h, h1) { //nolint:govet
-		t.Fatalf("RequestHeaderCopyTo fail, src: \n%+v\ndst: \n%+v\n", h, h1) //nolint:govet
+	if !reflect.DeepEqual(&h, &h1) {
+		t.Fatalf("RequestHeaderCopyTo fail, src: \n%+v\ndst: \n%+v\n", &h, &h1)
 	}
 }
 
@@ -1466,7 +1466,7 @@ func TestResponseContentTypeNoDefaultNotEmpty(t *testing.T) {
 	headers := h.String()
 
 	if strings.Contains(headers, "Content-Type: \r\n") {
-		t.Fatalf("ResponseContentTypeNoDefaultNotEmpty fail, response: \n%+v\noutcome: \n%q\n", h, headers) //nolint:govet
+		t.Fatalf("ResponseContentTypeNoDefaultNotEmpty fail, response: \n%+v\noutcome: \n%q\n", &h, headers)
 	}
 }
 
@@ -1534,7 +1534,7 @@ func TestResponseDateNoDefaultNotEmpty(t *testing.T) {
 	headers := h.String()
 
 	if strings.Contains(headers, "\r\nDate: ") {
-		t.Fatalf("ResponseDateNoDefaultNotEmpty fail, response: \n%+v\noutcome: \n%q\n", h, headers) //nolint:govet
+		t.Fatalf("ResponseDateNoDefaultNotEmpty fail, response: \n%+v\noutcome: \n%q\n", &h, headers)
 	}
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -155,8 +155,8 @@ func testRequestCopyTo(t *testing.T, src *Request) {
 	var dst Request
 	src.CopyTo(&dst)
 
-	if !reflect.DeepEqual(*src, dst) { //nolint:govet
-		t.Fatalf("RequestCopyTo fail, src: \n%+v\ndst: \n%+v\n", *src, dst) //nolint:govet
+	if !reflect.DeepEqual(src, &dst) {
+		t.Fatalf("RequestCopyTo fail, src: \n%+v\ndst: \n%+v\n", src, &dst)
 	}
 }
 
@@ -164,8 +164,8 @@ func testResponseCopyTo(t *testing.T, src *Response) {
 	var dst Response
 	src.CopyTo(&dst)
 
-	if !reflect.DeepEqual(*src, dst) { //nolint:govet
-		t.Fatalf("ResponseCopyTo fail, src: \n%+v\ndst: \n%+v\n", *src, dst) //nolint:govet
+	if !reflect.DeepEqual(src, &dst) {
+		t.Fatalf("ResponseCopyTo fail, src: \n%+v\ndst: \n%+v\n", src, &dst)
 	}
 }
 

--- a/uri_test.go
+++ b/uri_test.go
@@ -230,14 +230,14 @@ func TestURICopyTo(t *testing.T) {
 	var u URI
 	var copyU URI
 	u.CopyTo(&copyU)
-	if !reflect.DeepEqual(u, copyU) { //nolint:govet
-		t.Fatalf("URICopyTo fail, u: \n%+v\ncopyu: \n%+v\n", u, copyU) //nolint:govet
+	if !reflect.DeepEqual(&u, &copyU) {
+		t.Fatalf("URICopyTo fail, u: \n%+v\ncopyu: \n%+v\n", &u, &copyU)
 	}
 
 	u.UpdateBytes([]byte("https://example.com/foo?bar=baz&baraz#qqqq"))
 	u.CopyTo(&copyU)
-	if !reflect.DeepEqual(u, copyU) { //nolint:govet
-		t.Fatalf("URICopyTo fail, u: \n%+v\ncopyu: \n%+v\n", u, copyU) //nolint:govet
+	if !reflect.DeepEqual(&u, &copyU) {
+		t.Fatalf("URICopyTo fail, u: \n%+v\ncopyu: \n%+v\n", &u, &copyU)
 	}
 }
 


### PR DESCRIPTION
This PR refactors the tests for `noCopy` structs, eliminating the need for `//nolint:govet` comments.

`govet` raises lint issues in tests on the `reflect.DeepEqual(h1, h2)` line where `h1, h2` are of type `Header`. This is because `Header` contains the special field `noCopy`, which triggers `govet`. To appease `govet`, we can pass pointers to `reflect.DeepEqual(&h1, &h2)`. According to the [documentation](https://pkg.go.dev/reflect#DeepEqual), we can do this without breaking tests because "Pointer values are deeply equal if they are equal using Go's == operator or if they point to deeply equal values."