### PR TITLE
test: remove redundant error check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,6 +80,11 @@ linters-settings:
       - sloppyReassign
       - unnamedResult
       - whyNoLint
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
 
 issues:
   # Show all issues from a linter.

--- a/server_test.go
+++ b/server_test.go
@@ -4146,7 +4146,7 @@ func TestMaxReadTimeoutPerRequest(t *testing.T) {
 
 	select {
 	case err := <-ch:
-		if err == nil || err != nil && !strings.EqualFold(err.Error(), "timeout") {
+		if err == nil || !strings.EqualFold(err.Error(), "timeout") {
 			t.Fatalf("Unexpected error from serveConn: %v", err)
 		}
 	case <-time.After(time.Second):
@@ -4206,7 +4206,7 @@ func TestMaxWriteTimeoutPerRequest(t *testing.T) {
 
 	select {
 	case err := <-ch:
-		if err == nil || err != nil && !strings.EqualFold(err.Error(), "timeout") {
+		if err == nil || !strings.EqualFold(err.Error(), "timeout") {
 			t.Fatalf("Unexpected error from serveConn: %v", err)
 		}
 	case <-time.After(time.Second):


### PR DESCRIPTION
This PR simplifies `err == nil || err != nil && !strings.EqualFold(err.Error(), "timeout")` statement. If the first `err` is non-`nil` then the second `err` is automatically `non-nil`.

The redundancy is found by `govet`'s `nilness` check:

```sh
❯ ./bin/golangci-lint run
server_test.go:4149:24: nilness: tautological condition: non-nil != nil (govet)
                if err == nil || err != nil && !strings.EqualFold(err.Error(), "timeout") {
                                     ^
server_test.go:4209:24: nilness: tautological condition: non-nil != nil (govet)
                if err == nil || err != nil && !strings.EqualFold(err.Error(), "timeout") {
                                     ^
```