### PR TITLE
Add macos-14 platform, enable shuffle of unit-tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -19,5 +19,5 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - run: go version
-      - run: go test ./...
-      - run: go test -race ./...
+      - run: go test -shuffle=on ./...
+      - run: go test -race -shuffle=on ./...


### PR DESCRIPTION
- Add `macos-14` platform which uses Apple M1 cpu's (ARM64).
- Add `-shuffle=on` to enable shuffling the unit-tests order. Each run will run tests in different order to catch tests depending on others or using data from other tests.

We recently enabled both of these options in gofiber with great success. https://github.com/gofiber/fiber/blob/main/.github/workflows/test.yml#L37