### PR TITLE
add support for CHIPS (Cookies Having Independent Partitioned State)

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -132,12 +132,13 @@ func (c *Cookie) SetSameSite(mode CookieSameSite) {
 	}
 }
 
+// Partitioned returns true if the cookie is partitioned.
 func (c *Cookie) Partitioned() bool {
 	return c.partitioned
 }
 
-// SetPartitioned sets the cookie's SameSite flag to the given value.
-// Set value Partitioned will set Secure to true and Path to / also to avoid browser rejection.
+// SetPartitioned sets the cookie's Partitioned flag to the given value.
+// Set value Partitioned to true will set Secure to true and Path to / also to avoid browser rejection.
 func (c *Cookie) SetPartitioned(partitioned bool) {
 	c.partitioned = partitioned
 	if partitioned == true {

--- a/cookie.go
+++ b/cookie.go
@@ -33,7 +33,7 @@ const (
 	CookieSameSiteStrictMode
 	// CookieSameSiteNoneMode sets the SameSite flag with the "None" parameter.
 	// See https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
-	CookieSameSiteNoneMode
+	CookieSameSiteNoneMode // third-party cookies are phasing out, use Partitioned cookies instead
 )
 
 // AcquireCookie returns an empty Cookie object from the pool.
@@ -74,9 +74,10 @@ type Cookie struct {
 	domain []byte
 	path   []byte
 
-	httpOnly bool
-	secure   bool
-	sameSite CookieSameSite
+	httpOnly    bool
+	secure      bool
+	sameSite    CookieSameSite
+	partitioned bool
 
 	bufKV argsKV
 	buf   []byte
@@ -94,6 +95,7 @@ func (c *Cookie) CopyTo(src *Cookie) {
 	c.httpOnly = src.httpOnly
 	c.secure = src.secure
 	c.sameSite = src.sameSite
+	c.partitioned = src.partitioned
 }
 
 // HTTPOnly returns true if the cookie is http only.
@@ -127,6 +129,20 @@ func (c *Cookie) SetSameSite(mode CookieSameSite) {
 	c.sameSite = mode
 	if mode == CookieSameSiteNoneMode {
 		c.SetSecure(true)
+	}
+}
+
+func (c *Cookie) Partitioned() bool {
+	return c.partitioned
+}
+
+// SetPartitioned sets the cookie's SameSite flag to the given value.
+// Set value Partitioned will set Secure to true and Path to / also to avoid browser rejection.
+func (c *Cookie) SetPartitioned(partitioned bool) {
+	c.partitioned = partitioned
+	if partitioned == true {
+		c.SetSecure(true)
+		c.SetPath("/")
 	}
 }
 
@@ -247,6 +263,7 @@ func (c *Cookie) Reset() {
 	c.httpOnly = false
 	c.secure = false
 	c.sameSite = CookieSameSiteDisabled
+	c.partitioned = false
 }
 
 // AppendBytes appends cookie representation to dst and returns
@@ -303,6 +320,10 @@ func (c *Cookie) AppendBytes(dst []byte) []byte {
 		dst = append(dst, strCookieSameSite...)
 		dst = append(dst, '=')
 		dst = append(dst, strCookieSameSiteNone...)
+	}
+	if c.partitioned {
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookiePartitioned...)
 	}
 	return dst
 }
@@ -424,6 +445,10 @@ func (c *Cookie) ParseBytes(src []byte) error {
 					c.secure = true
 				} else if caseInsensitiveCompare(strCookieSameSite, kv.value) {
 					c.sameSite = CookieSameSiteDefaultMode
+				}
+			case 'p': // "partitioned"
+				if caseInsensitiveCompare(strCookiePartitioned, kv.value) {
+					c.partitioned = true
 				}
 			}
 		} // else empty or no match

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -243,6 +243,35 @@ func TestCookieHttpOnly(t *testing.T) {
 	}
 }
 
+func TestCookiePartitioned(t *testing.T) {
+	t.Parallel()
+
+	var c Cookie
+
+	if err := c.Parse("foo=bar; PATH=/; secure; Partitioned"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !c.Partitioned() {
+		t.Fatalf("Partitioned must be set")
+	}
+	s := c.String()
+	if !strings.Contains(s, "; Partitioned") {
+		t.Fatalf("missing Partitioned flag in cookie %q", s)
+	}
+
+	if !c.Secure() {
+		t.Fatalf("secure must be set")
+	}
+	s = c.String()
+	if !strings.Contains(s, "; secure") {
+		t.Fatalf("missing secure flag in cookie %q", s)
+	}
+
+	if string(c.Path()) != "/" {
+		t.Fatalf("path must be set /")
+	}
+}
+
 func TestCookieAcquireReleaseSequential(t *testing.T) {
 	t.Parallel()
 

--- a/strings.go
+++ b/strings.go
@@ -63,6 +63,7 @@ var (
 	strCookiePath           = []byte("path")
 	strCookieHTTPOnly       = []byte("HttpOnly")
 	strCookieSecure         = []byte("secure")
+	strCookiePartitioned    = []byte("Partitioned")
 	strCookieMaxAge         = []byte("max-age")
 	strCookieSameSite       = []byte("SameSite")
 	strCookieSameSiteLax    = []byte("Lax")


### PR DESCRIPTION
The proposed changes enhance fasthttp to handle CHIPS cookies, which allow developers to opt a cookie into partitioned storage. With CHIPS, separate cookie jars are maintained per top-level site, improving privacy and mitigating cross-site tracking.

You can find additional information about CHIPS [here](https://developers.google.com/privacy-sandbox/3pcd/chips)