### PR TITLE
Don't allow , in host when using Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package fasthttp
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -476,6 +477,10 @@ func (c *Client) Do(req *Request, resp *Response) error {
 	}
 
 	host := uri.Host()
+
+	if bytes.ContainsRune(host, ',') {
+		return fmt.Errorf("invalid host %q. Use HostClient for multiple hosts", host)
+	}
 
 	isTLS := false
 	if uri.isHTTPS() {


### PR DESCRIPTION
When using a url like http://example.com,/ URI will parse "example.com," as host. HostClient then splits this by "," into multiple addresses and will connect to example.com. HostClient splitting the address by "," is only for direct use, not for use with Client.