### PR TITLE
fs: fix GenerateIndexPages when DirFS or embed.FS is used

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -1068,7 +1068,8 @@ func (h *fsHandler) handleRequest(ctx *RequestCtx) {
 			mustCompress = false
 			ff, err = h.openFSFile(filePath, mustCompress, fileEncoding)
 		}
-		if err == errDirIndexRequired {
+
+		if errors.Is(err, errDirIndexRequired) {
 			if !hasTrailingSlash {
 				ctx.RedirectBytes(append(path, '/'), StatusFound)
 				return
@@ -1260,6 +1261,11 @@ func (h *fsHandler) createDirIndex(ctx *RequestCtx, dirPath string, mustCompress
 	w := &bytebufferpool.ByteBuffer{}
 
 	base := ctx.URI()
+
+	// io/fs doesn't support ReadDir with empty path.
+	if dirPath == "" {
+		dirPath = "."
+	}
 
 	basePathEscaped := html.EscapeString(string(base.Path()))
 	_, _ = fmt.Fprintf(w, "<html><head><title>%s</title><style>.dir { font-weight: bold }</style></head><body>", basePathEscaped)
@@ -1556,12 +1562,17 @@ func (h *fsHandler) openFSFile(filePath string, mustCompress bool, fileEncoding 
 	if mustCompress {
 		filePath += h.compressedFileSuffixes[fileEncoding]
 	}
-
 	f, err := h.filesystem.Open(filePath)
 	if err != nil {
 		if mustCompress && errors.Is(err, fs.ErrNotExist) {
 			return h.compressAndOpenFSFile(filePathOriginal, fileEncoding)
 		}
+
+		// If the file is not found and the path is empty, let's return errDirIndexRequired error.
+		if filePath == "" && (errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrInvalid)) {
+			return nil, errDirIndexRequired
+		}
+
 		return nil, err
 	}
 

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -636,3 +636,85 @@ func TestDirFSServeFileDirectoryRedirect(t *testing.T) {
 		t.Fatalf("Unexpected status code %d for file '/fs.go'. Expecting %d.", ctx.Response.StatusCode(), StatusOK)
 	}
 }
+
+func TestFSFSGenerateIndexOsDirFS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dirFS", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &FS{
+			FS:                 dirTestFilesystem,
+			Root:               ".",
+			GenerateIndexPages: true,
+		}
+		h := fs.NewRequestHandler()
+
+		var ctx RequestCtx
+		var req Request
+		ctx.Init(&req, nil, nil)
+
+		h(&ctx)
+
+		cases := []string{"/", "//", ""}
+		for _, c := range cases {
+			ctx.Request.Reset()
+			ctx.Response.Reset()
+
+			req.Header.SetMethod(MethodGet)
+			req.SetRequestURI("http://foobar.com" + c)
+			h(&ctx)
+
+			if ctx.Response.StatusCode() != StatusOK {
+				t.Fatalf("unexpected status code %d for path %q. Expecting %d", ctx.Response.StatusCode(), ctx.Response.StatusCode(), StatusOK)
+			}
+
+			if !bytes.Contains(ctx.Response.Body(), []byte("fasthttputil")) {
+				t.Fatalf("unexpected body %q. Expecting to contain %q", ctx.Response.Body(), "fasthttputil")
+			}
+
+			if !bytes.Contains(ctx.Response.Body(), []byte("fs.go")) {
+				t.Fatalf("unexpected body %q. Expecting to contain %q", ctx.Response.Body(), "fs.go")
+			}
+		}
+	})
+
+	t.Run("embedFS", func(t *testing.T) {
+		t.Parallel()
+
+		fs := &FS{
+			FS:                 fsTestFilesystem,
+			Root:               ".",
+			GenerateIndexPages: true,
+		}
+		h := fs.NewRequestHandler()
+
+		var ctx RequestCtx
+		var req Request
+		ctx.Init(&req, nil, nil)
+
+		h(&ctx)
+
+		cases := []string{"/", "//", ""}
+		for _, c := range cases {
+			ctx.Request.Reset()
+			ctx.Response.Reset()
+
+			req.Header.SetMethod(MethodGet)
+			req.SetRequestURI("http://foobar.com" + c)
+			h(&ctx)
+
+			if ctx.Response.StatusCode() != StatusOK {
+				t.Fatalf("unexpected status code %d for path %q. Expecting %d", ctx.Response.StatusCode(), ctx.Response.StatusCode(), StatusOK)
+			}
+
+			if !bytes.Contains(ctx.Response.Body(), []byte("fasthttputil")) {
+				t.Fatalf("unexpected body %q. Expecting to contain %q", ctx.Response.Body(), "fasthttputil")
+			}
+
+			if !bytes.Contains(ctx.Response.Body(), []byte("fs.go")) {
+				t.Fatalf("unexpected body %q. Expecting to contain %q", ctx.Response.Body(), "fs.go")
+			}
+		}
+	})
+}


### PR DESCRIPTION
In current implementation of Fasthttp FS, GenerateIndexPages doesn't work properly with DirFS or embed.FS because of `fs.ValidPath` function. 

When you open `""` path using with DirFS it returns `invalid path error`. When using embed.FS, it returns `file does not exist` error. 

So, if the path is `""` both cases need to covered properly. 

**Note:** I ain't also sure this is a good solution.  Perhaps need smarter solution to cover more edge cases.