### PR TITLE
fs: fix openIndexFile when dirPath is empty string

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -1229,7 +1229,11 @@ func ParseByteRange(byteRange []byte, contentLength int) (startPos, endPos int, 
 
 func (h *fsHandler) openIndexFile(ctx *RequestCtx, dirPath string, mustCompress bool, fileEncoding string) (*fsFile, error) {
 	for _, indexName := range h.indexNames {
-		indexFilePath := dirPath + "/" + indexName
+		indexFilePath := indexName
+		if dirPath != "" {
+			indexFilePath = dirPath + "/" + indexName
+		}
+
 		ff, err := h.openFSFile(indexFilePath, mustCompress, fileEncoding)
 		if err == nil {
 			return ff, nil


### PR DESCRIPTION
openIndexFile overrides the index path to make it usable with subdirs. This causes wrong index path like `/index.html` when the dirPath is empty string. 