### PR TITLE
Use FASTHTTP_PREFORK_CHILD env variable to detect child

### DIFF
--- a/prefork/prefork_test.go
+++ b/prefork/prefork_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func setUp() {
-	os.Args = append(os.Args, preforkChildFlag)
+	os.Setenv(preforkChildEnvVariable, "1")
 }
 
 func tearDown() {
-	os.Args = os.Args[:len(os.Args)-1]
+	os.Unsetenv(preforkChildEnvVariable)
 }
 
 func getAddr() string {


### PR DESCRIPTION
It's better to use an environment variable as they are more standard. They way flags are parsed isn't standardized within the Go ecosystem.

Fixes: https://github.com/valyala/fasthttp/issues/1782