### PR TITLE
test: fix typo

### DIFF
--- a/prefork/prefork_test.go
+++ b/prefork/prefork_test.go
@@ -48,7 +48,7 @@ func Test_New(t *testing.T) {
 	p := New(s)
 
 	if p.Network != defaultNetwork {
-		t.Errorf("Prefork.Netork == %q, want %q", p.Network, defaultNetwork)
+		t.Errorf("Prefork.Network == %q, want %q", p.Network, defaultNetwork)
 	}
 
 	if reflect.ValueOf(p.ServeFunc).Pointer() != reflect.ValueOf(s.Serve).Pointer() {


### PR DESCRIPTION
The PR corrects one spelling mistake inside `Test_New`.