### PR TITLE
handle root properly in virtual file systems

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -989,10 +989,7 @@ func cleanCacheNolock(
 
 func (h *fsHandler) pathToFilePath(path string) string {
 	if _, ok := h.filesystem.(*osFS); !ok {
-		if len(path) < 1 {
-			return path
-		}
-		return path[1:]
+		return filepath.Join(h.root, path)
 	}
 	return filepath.FromSlash(h.root + path)
 }


### PR DESCRIPTION
ServeFS does not handle `root` properly, this is a fix. I did not understood why we have separate logic for `osFS` and other implementations anyway.