### PR TITLE
Optimize struct field order to reduce memory usage

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -74,9 +74,9 @@ type Cookie struct {
 	domain []byte
 	path   []byte
 
+	sameSite    CookieSameSite
 	httpOnly    bool
 	secure      bool
-	sameSite    CookieSameSite
 	partitioned bool
 
 	bufKV argsKV

--- a/fs.go
+++ b/fs.go
@@ -259,12 +259,6 @@ type FS struct {
 	// Path to the root directory to serve files from.
 	Root string
 
-	// AllowEmptyRoot controls what happens when Root is empty. When false (default) it will default to the
-	// current working directory. An empty root is mostly useful when you want to use absolute paths
-	// on windows that are on different filesystems. On linux setting your Root to "/" already allows you to use
-	// absolute paths on any filesystem.
-	AllowEmptyRoot bool
-
 	// List of index file names to try opening during directory access.
 	//
 	// For example:
@@ -275,6 +269,36 @@ type FS struct {
 	//
 	// By default the list is empty.
 	IndexNames []string
+
+	// Path to the compressed root directory to serve files from. If this value
+	// is empty, Root is used.
+	CompressRoot string
+
+	// Path rewriting function.
+	//
+	// By default request path is not modified.
+	PathRewrite PathRewriteFunc
+
+	// PathNotFound fires when file is not found in filesystem
+	// this functions tries to replace "Cannot open requested path"
+	// server response giving to the programmer the control of server flow.
+	//
+	// By default PathNotFound returns
+	// "Cannot open requested path"
+	PathNotFound RequestHandler
+
+	// AllowEmptyRoot controls what happens when Root is empty. When false (default) it will default to the
+	// current working directory. An empty root is mostly useful when you want to use absolute paths
+	// on windows that are on different filesystems. On linux setting your Root to "/" already allows you to use
+	// absolute paths on any filesystem.
+	AllowEmptyRoot bool
+
+	// Uses brotli encoding and fallbacks to gzip in responses if set to true, uses gzip if set to false.
+	//
+	// This value has sense only if Compress is set.
+	//
+	// Brotli encoding is disabled by default.
+	CompressBrotli bool
 
 	// Index pages for directories without files matching IndexNames
 	// are automatically generated if set.
@@ -298,34 +322,10 @@ type FS struct {
 	// Transparent compression is disabled by default.
 	Compress bool
 
-	// Uses brotli encoding and fallbacks to gzip in responses if set to true, uses gzip if set to false.
-	//
-	// This value has sense only if Compress is set.
-	//
-	// Brotli encoding is disabled by default.
-	CompressBrotli bool
-
-	// Path to the compressed root directory to serve files from. If this value
-	// is empty, Root is used.
-	CompressRoot string
-
 	// Enables byte range requests if set to true.
 	//
 	// Byte range requests are disabled by default.
 	AcceptByteRange bool
-
-	// Path rewriting function.
-	//
-	// By default request path is not modified.
-	PathRewrite PathRewriteFunc
-
-	// PathNotFound fires when file is not found in filesystem
-	// this functions tries to replace "Cannot open requested path"
-	// server response giving to the programmer the control of server flow.
-	//
-	// By default PathNotFound returns
-	// "Cannot open requested path"
-	PathNotFound RequestHandler
 
 	// SkipCache if true, will cache no file handler.
 	//
@@ -510,8 +510,8 @@ type fsHandler struct {
 	generateIndexPages     bool
 	compress               bool
 	compressBrotli         bool
-	compressRoot           string
 	acceptByteRange        bool
+	compressRoot           string
 	compressedFileSuffixes map[string]string
 
 	cacheManager cacheManager

--- a/header.go
+++ b/header.go
@@ -26,18 +26,18 @@ const (
 type ResponseHeader struct {
 	noCopy noCopy
 
-	disableNormalizing   bool
-	noHTTP11             bool
-	connectionClose      bool
-	noDefaultContentType bool
-	noDefaultDate        bool
-
-	statusCode            int
-	statusMessage         []byte
-	protocol              []byte
-	contentLength         int
-	contentLengthBytes    []byte
+	disableNormalizing    bool
+	noHTTP11              bool
+	connectionClose       bool
+	noDefaultContentType  bool
+	noDefaultDate         bool
 	secureErrorLogMessage bool
+
+	statusCode         int
+	statusMessage      []byte
+	protocol           []byte
+	contentLength      int
+	contentLengthBytes []byte
 
 	contentType     []byte
 	contentEncoding []byte
@@ -71,9 +71,9 @@ type RequestHeader struct {
 	// for reducing RequestHeader object size.
 	cookiesCollected bool
 
+	secureErrorLogMessage bool
 	contentLength         int
 	contentLengthBytes    []byte
-	secureErrorLogMessage bool
 
 	method      []byte
 	requestURI  []byte
@@ -3239,8 +3239,6 @@ type headerScanner struct {
 	// hLen stores header subslice len
 	hLen int
 
-	disableNormalizing bool
-
 	// by checking whether the next line contains a colon or not to tell
 	// it's a header entry or a multi line value of current header entry.
 	// the side effect of this operation is that we know the index of the
@@ -3249,7 +3247,8 @@ type headerScanner struct {
 	nextColon   int
 	nextNewLine int
 
-	initialized bool
+	disableNormalizing bool
+	initialized        bool
 }
 
 func (s *headerScanner) next() bool {

--- a/http.go
+++ b/http.go
@@ -53,6 +53,11 @@ type Request struct {
 
 	multipartForm         *multipart.Form
 	multipartFormBoundary string
+
+	// Request timeout. Usually set by DoDeadline or DoTimeout
+	// if <= 0, means not set
+	timeout time.Duration
+
 	secureErrorLogMessage bool
 
 	// Group bool members in order to reduce Request object size.
@@ -64,10 +69,6 @@ type Request struct {
 	// Used by Server to indicate the request was received on a HTTPS endpoint.
 	// Client/HostClient shouldn't use this field but should depend on the uri.scheme instead.
 	isTLS bool
-
-	// Request timeout. Usually set by DoDeadline or DoTimeout
-	// if <= 0, means not set
-	timeout time.Duration
 
 	// Use Host header (request.Header.SetHost) instead of the host from SetRequestURI, SetHost, or URI().SetHost
 	UseHostHeader bool
@@ -101,11 +102,6 @@ type Response struct {
 	// Use SetBodyStream to set the body stream.
 	StreamBody bool
 
-	bodyStream io.Reader
-	w          responseBodyWriter
-	body       *bytebufferpool.ByteBuffer
-	bodyRaw    []byte
-
 	// Response.Read() skips reading body if set to true.
 	// Use it for reading HEAD responses.
 	//
@@ -115,6 +111,11 @@ type Response struct {
 
 	keepBodyBuffer        bool
 	secureErrorLogMessage bool
+
+	bodyStream io.Reader
+	w          responseBodyWriter
+	body       *bytebufferpool.ByteBuffer
+	bodyRaw    []byte
 
 	// Remote TCPAddr from concurrently net.Conn.
 	raddr net.Addr

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -152,14 +152,15 @@ type TCPDialer struct {
 	// }
 	Resolver Resolver
 
-	// DisableDNSResolution may be used to disable DNS resolution
-	DisableDNSResolution bool
 	// DNSCacheDuration may be used to override the default DNS cache duration (DefaultDNSCacheDuration)
 	DNSCacheDuration time.Duration
 
 	tcpAddrsMap sync.Map
 
 	concurrencyCh chan struct{}
+
+	// DisableDNSResolution may be used to disable DNS resolution
+	DisableDNSResolution bool
 
 	once sync.Once
 }

--- a/workerpool.go
+++ b/workerpool.go
@@ -22,6 +22,7 @@ type workerPool struct {
 	MaxWorkersCount int
 
 	LogAllErrors bool
+	mustStop     bool
 
 	MaxIdleWorkerDuration time.Duration
 
@@ -29,7 +30,6 @@ type workerPool struct {
 
 	lock         sync.Mutex
 	workersCount int
-	mustStop     bool
 
 	ready []*workerChan
 


### PR DESCRIPTION
1. Reduce RequestHeader from **368** bytes to **360** bytes
2. Reduce Request from **816** bytes to **800** bytes
3. Reduce Response from **432** bytes to **416** bytes
4. Reduce Client from **312** bytes to **288** bytes
5. Reduce HostClient from **416** bytes to **392** bytes
6. Reduce PipelineClient from **176** bytes to **168** bytes
7. Reduce pipelineConnClient from **216** bytes to **208** bytes
8. Reduce Cookie from **232** bytes to **224** bytes
9. Reduce FS from **184** bytes to **160** bytes
10. Reduce fsHandler from **168** bytes to **160** bytes
11. Reduce ResponseHeader from **328** bytes to **320** bytes
12. Reduce headerScanner from **128** bytes to **120** bytes
13. Reduce TCPDialer from **104** bytes to **96** bytes
14. Reduce workerPool from **152** btyes to **144** btyes