### PR TITLE
Use Named Fields and Align Structures to Reduce Memory Usage

### DIFF
--- a/brotli.go
+++ b/brotli.go
@@ -97,7 +97,7 @@ var (
 //   - CompressBrotliBestCompression
 //   - CompressBrotliDefaultCompression
 func AppendBrotliBytesLevel(dst, src []byte, level int) []byte {
-	w := &byteSliceWriter{dst}
+	w := &byteSliceWriter{b: dst}
 	WriteBrotliLevel(w, src, level) //nolint:errcheck
 	return w.b
 }
@@ -167,7 +167,7 @@ func AppendBrotliBytes(dst, src []byte) []byte {
 // WriteUnbrotli writes unbrotlied p to w and returns the number of uncompressed
 // bytes written to w.
 func WriteUnbrotli(w io.Writer, p []byte) (int, error) {
-	r := &byteSliceReader{p}
+	r := &byteSliceReader{b: p}
 	zr, err := acquireBrotliReader(r)
 	if err != nil {
 		return 0, err
@@ -183,7 +183,7 @@ func WriteUnbrotli(w io.Writer, p []byte) (int, error) {
 
 // AppendUnbrotliBytes appends unbrotlied src to dst and returns the resulting dst.
 func AppendUnbrotliBytes(dst, src []byte) ([]byte, error) {
-	w := &byteSliceWriter{dst}
+	w := &byteSliceWriter{b: dst}
 	_, err := WriteUnbrotli(w, src)
 	return w.b, err
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1947,9 +1947,9 @@ func testClientRequestSetTimeoutError(t *testing.T, c *Client, n int) {
 
 type readTimeoutConn struct {
 	net.Conn
-	t  time.Duration
 	wc chan struct{}
 	rc chan struct{}
+	t  time.Duration
 }
 
 func (r *readTimeoutConn) Read(p []byte) (int, error) {
@@ -3212,47 +3212,47 @@ func Test_AddMissingPort(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		args args
 		want string
+		args args
 	}{
 		{
-			args: args{"127.1", false}, // 127.1 is a short form of 127.0.0.1
+			args: args{addr: "127.1", isTLS: false}, // 127.1 is a short form of 127.0.0.1
 			want: "127.1:80",
 		},
 		{
-			args: args{"127.0.0.1", false},
+			args: args{addr: "127.0.0.1", isTLS: false},
 			want: "127.0.0.1:80",
 		},
 		{
-			args: args{"127.0.0.1", true},
+			args: args{addr: "127.0.0.1", isTLS: true},
 			want: "127.0.0.1:443",
 		},
 		{
-			args: args{"[::1]", false},
+			args: args{addr: "[::1]", isTLS: false},
 			want: "[::1]:80",
 		},
 		{
-			args: args{"::1", false},
+			args: args{addr: "::1", isTLS: false},
 			want: "::1", // keep as is
 		},
 		{
-			args: args{"[::1]", true},
+			args: args{addr: "[::1]", isTLS: true},
 			want: "[::1]:443",
 		},
 		{
-			args: args{"127.0.0.1:8080", false},
+			args: args{addr: "127.0.0.1:8080", isTLS: false},
 			want: "127.0.0.1:8080",
 		},
 		{
-			args: args{"127.0.0.1:8443", true},
+			args: args{addr: "127.0.0.1:8443", isTLS: true},
 			want: "127.0.0.1:8443",
 		},
 		{
-			args: args{"[::1]:8080", false},
+			args: args{addr: "[::1]:8080", isTLS: false},
 			want: "[::1]:8080",
 		},
 		{
-			args: args{"[::1]:8443", true},
+			args: args{addr: "[::1]:8443", isTLS: true},
 			want: "[::1]:8443",
 		},
 	}
@@ -3345,8 +3345,8 @@ func Test_getRedirectURL(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		args args
 		want string
+		args args
 	}{
 		{
 			name: "Path normalizing enabled, no special characters in path",
@@ -3402,8 +3402,8 @@ func TestDialTimeout(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
 		client         clientDoTimeOuter
+		name           string
 		requestTimeout time.Duration
 		shouldFailFast bool
 	}{

--- a/client_timing_test.go
+++ b/client_timing_test.go
@@ -18,9 +18,9 @@ import (
 
 type fakeClientConn struct {
 	net.Conn
+	ch chan struct{}
 	s  []byte
 	n  int
-	ch chan struct{}
 }
 
 func (c *fakeClientConn) SetWriteDeadline(t time.Time) error {

--- a/compress.go
+++ b/compress.go
@@ -141,7 +141,7 @@ var (
 //   - CompressDefaultCompression
 //   - CompressHuffmanOnly
 func AppendGzipBytesLevel(dst, src []byte, level int) []byte {
-	w := &byteSliceWriter{dst}
+	w := &byteSliceWriter{b: dst}
 	WriteGzipLevel(w, src, level) //nolint:errcheck
 	return w.b
 }
@@ -212,7 +212,7 @@ func AppendGzipBytes(dst, src []byte) []byte {
 // WriteGunzip writes ungzipped p to w and returns the number of uncompressed
 // bytes written to w.
 func WriteGunzip(w io.Writer, p []byte) (int, error) {
-	r := &byteSliceReader{p}
+	r := &byteSliceReader{b: p}
 	zr, err := acquireGzipReader(r)
 	if err != nil {
 		return 0, err
@@ -228,7 +228,7 @@ func WriteGunzip(w io.Writer, p []byte) (int, error) {
 
 // AppendGunzipBytes appends gunzipped src to dst and returns the resulting dst.
 func AppendGunzipBytes(dst, src []byte) ([]byte, error) {
-	w := &byteSliceWriter{dst}
+	w := &byteSliceWriter{b: dst}
 	_, err := WriteGunzip(w, src)
 	return w.b, err
 }
@@ -244,7 +244,7 @@ func AppendGunzipBytes(dst, src []byte) ([]byte, error) {
 //   - CompressDefaultCompression
 //   - CompressHuffmanOnly
 func AppendDeflateBytesLevel(dst, src []byte, level int) []byte {
-	w := &byteSliceWriter{dst}
+	w := &byteSliceWriter{b: dst}
 	WriteDeflateLevel(w, src, level) //nolint:errcheck
 	return w.b
 }
@@ -321,7 +321,7 @@ func AppendDeflateBytes(dst, src []byte) []byte {
 // WriteInflate writes inflated p to w and returns the number of uncompressed
 // bytes written to w.
 func WriteInflate(w io.Writer, p []byte) (int, error) {
-	r := &byteSliceReader{p}
+	r := &byteSliceReader{b: p}
 	zr, err := acquireFlateReader(r)
 	if err != nil {
 		return 0, err
@@ -337,7 +337,7 @@ func WriteInflate(w io.Writer, p []byte) (int, error) {
 
 // AppendInflateBytes appends inflated src to dst and returns the resulting dst.
 func AppendInflateBytes(dst, src []byte) ([]byte, error) {
-	w := &byteSliceWriter{dst}
+	w := &byteSliceWriter{b: dst}
 	_, err := WriteInflate(w, src)
 	return w.b, err
 }

--- a/cookie.go
+++ b/cookie.go
@@ -67,20 +67,22 @@ var cookiePool = &sync.Pool{
 type Cookie struct {
 	noCopy noCopy
 
+	expire time.Time
+
 	key    []byte
 	value  []byte
-	expire time.Time
-	maxAge int
 	domain []byte
 	path   []byte
+
+	buf []byte
+
+	bufKV  argsKV
+	maxAge int
 
 	sameSite    CookieSameSite
 	httpOnly    bool
 	secure      bool
 	partitioned bool
-
-	bufKV argsKV
-	buf   []byte
 }
 
 // CopyTo copies src cookie to c.

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -18,8 +18,8 @@ var headerContentTypeJson = []byte("application/json")
 var client *fasthttp.Client
 
 type Entity struct {
-	Id   int
 	Name string
+	Id   int
 }
 
 func main() {

--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -88,10 +88,10 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 }
 
 type netHTTPResponseWriter struct {
-	statusCode int
-	h          http.Header
 	w          io.Writer
+	h          http.Header
 	ctx        *fasthttp.RequestCtx
+	statusCode int
 }
 
 func (w *netHTTPResponseWriter) StatusCode() int {

--- a/fasthttputil/inmemory_listener_test.go
+++ b/fasthttputil/inmemory_listener_test.go
@@ -123,7 +123,7 @@ func testInmemoryListenerHTTP(t *testing.T, f func(t *testing.T, client *http.Cl
 	}
 
 	server := &http.Server{
-		Handler: &echoServerHandler{t},
+		Handler: &echoServerHandler{t: t},
 	}
 
 	go func() {

--- a/fasthttputil/pipeconns.go
+++ b/fasthttputil/pipeconns.go
@@ -42,9 +42,9 @@ func NewPipeConns() *PipeConns {
 //
 // PipeConns is NOT safe for concurrent use by multiple goroutines!
 type PipeConns struct {
+	stopCh     chan struct{}
 	c1         pipeConn
 	c2         pipeConn
-	stopCh     chan struct{}
 	stopChLock sync.Mutex
 }
 
@@ -93,8 +93,9 @@ func (pc *PipeConns) Close() error {
 }
 
 type pipeConn struct {
-	b  *byteBuffer
-	bb []byte
+	localAddr  net.Addr
+	remoteAddr net.Addr
+	b          *byteBuffer
 
 	rCh chan *byteBuffer
 	wCh chan *byteBuffer
@@ -106,11 +107,11 @@ type pipeConn struct {
 	readDeadlineCh  <-chan time.Time
 	writeDeadlineCh <-chan time.Time
 
-	readDeadlineChLock sync.Mutex
+	bb []byte
 
-	localAddr  net.Addr
-	remoteAddr net.Addr
-	addrLock   sync.RWMutex
+	addrLock sync.RWMutex
+
+	readDeadlineChLock sync.Mutex
 }
 
 func (c *pipeConn) Write(p []byte) (int, error) {

--- a/fs_test.go
+++ b/fs_test.go
@@ -71,7 +71,7 @@ func testPathNotFound(t *testing.T, pathNotFoundFunc RequestHandler) {
 	var ctx RequestCtx
 	var req Request
 	req.SetRequestURI("http//some.url/file")
-	ctx.Init(&req, nil, TestLogger{t})
+	ctx.Init(&req, nil, TestLogger{t: t})
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -176,7 +176,7 @@ func TestServeFileSmallNoReadFrom(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 
-	n, err := reader.WriteTo(pureWriter{buf})
+	n, err := reader.WriteTo(pureWriter{w: buf})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -1355,7 +1355,7 @@ func TestResponseHeaderFirstByteReadEOF(t *testing.T) {
 
 	var h ResponseHeader
 
-	r := &errorReader{errors.New("non-eof error")}
+	r := &errorReader{err: errors.New("non-eof error")}
 	br := bufio.NewReader(r)
 	err := h.Read(br)
 	if err == nil {

--- a/http.go
+++ b/http.go
@@ -38,21 +38,23 @@ func SetBodySizePoolLimit(reqBodyLimit, respBodyLimit int) {
 type Request struct {
 	noCopy noCopy
 
+	bodyStream io.Reader
+	w          requestBodyWriter
+	body       *bytebufferpool.ByteBuffer
+
+	multipartForm         *multipart.Form
+	multipartFormBoundary string
+
+	postArgs Args
+
+	bodyRaw []byte
+
+	uri URI
+
 	// Request header.
 	//
 	// Copying Header by value is forbidden. Use pointer to Header instead.
 	Header RequestHeader
-
-	uri      URI
-	postArgs Args
-
-	bodyStream io.Reader
-	w          requestBodyWriter
-	body       *bytebufferpool.ByteBuffer
-	bodyRaw    []byte
-
-	multipartForm         *multipart.Form
-	multipartFormBoundary string
 
 	// Request timeout. Usually set by DoDeadline or DoTimeout
 	// if <= 0, means not set
@@ -89,6 +91,17 @@ type Request struct {
 type Response struct {
 	noCopy noCopy
 
+	bodyStream io.Reader
+
+	// Remote TCPAddr from concurrently net.Conn.
+	raddr net.Addr
+	// Local TCPAddr from concurrently net.Conn.
+	laddr net.Addr
+	w     responseBodyWriter
+	body  *bytebufferpool.ByteBuffer
+
+	bodyRaw []byte
+
 	// Response header.
 	//
 	// Copying Header by value is forbidden. Use pointer to Header instead.
@@ -111,16 +124,6 @@ type Response struct {
 
 	keepBodyBuffer        bool
 	secureErrorLogMessage bool
-
-	bodyStream io.Reader
-	w          responseBodyWriter
-	body       *bytebufferpool.ByteBuffer
-	bodyRaw    []byte
-
-	// Remote TCPAddr from concurrently net.Conn.
-	raddr net.Addr
-	// Local TCPAddr from concurrently net.Conn.
-	laddr net.Addr
 }
 
 // SetHost sets host for the request.

--- a/lbclient.go
+++ b/lbclient.go
@@ -27,10 +27,6 @@ type BalancingClient interface {
 type LBClient struct {
 	noCopy noCopy
 
-	// Clients must contain non-zero clients list.
-	// Incoming requests are balanced among these clients.
-	Clients []BalancingClient
-
 	// HealthCheck is a callback called after each request.
 	//
 	// The request, response and the error returned by the client
@@ -42,15 +38,20 @@ type LBClient struct {
 	// By default HealthCheck returns false if err != nil.
 	HealthCheck func(req *Request, resp *Response, err error) bool
 
+	// Clients must contain non-zero clients list.
+	// Incoming requests are balanced among these clients.
+	Clients []BalancingClient
+
+	cs []*lbClient
+
 	// Timeout is the request timeout used when calling LBClient.Do.
 	//
 	// DefaultLBClientTimeout is used by default.
 	Timeout time.Duration
 
-	cs []*lbClient
+	mu sync.RWMutex
 
 	once sync.Once
-	mu   sync.RWMutex
 }
 
 // DefaultLBClientTimeout is the default request timeout used by LBClient

--- a/peripconn.go
+++ b/peripconn.go
@@ -9,8 +9,8 @@ import (
 type perIPConnCounter struct {
 	perIPConnPool    sync.Pool
 	perIPTLSConnPool sync.Pool
-	lock             sync.Mutex
 	m                map[uint32]int
+	lock             sync.Mutex
 }
 
 func (cc *perIPConnCounter) Register(ip uint32) int {
@@ -41,15 +41,17 @@ func (cc *perIPConnCounter) Unregister(ip uint32) {
 type perIPConn struct {
 	net.Conn
 
-	ip               uint32
 	perIPConnCounter *perIPConnCounter
+
+	ip uint32
 }
 
 type perIPTLSConn struct {
 	*tls.Conn
 
-	ip               uint32
 	perIPConnCounter *perIPConnCounter
+
+	ip uint32
 }
 
 func acquirePerIPConn(conn net.Conn, ip uint32, counter *perIPConnCounter) net.Conn {

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -42,30 +42,32 @@ type Logger interface {
 // WARNING: using prefork prevents the use of any global state!
 // Things like in-memory caches won't work.
 type Prefork struct {
+
+	// By default standard logger from log package is used.
+	Logger Logger
+
+	ln net.Listener
+
+	ServeFunc         func(ln net.Listener) error
+	ServeTLSFunc      func(ln net.Listener, certFile, keyFile string) error
+	ServeTLSEmbedFunc func(ln net.Listener, certData, keyData []byte) error
+
 	// The network must be "tcp", "tcp4" or "tcp6".
 	//
 	// By default is "tcp4"
 	Network string
+
+	files []*os.File
+
+	// Child prefork processes may exit with failure and will be started over until the times reach
+	// the value of RecoverThreshold, then it will return and terminate the server.
+	RecoverThreshold int
 
 	// Flag to use a listener with reuseport, if not a file Listener will be used
 	// See: https://www.nginx.com/blog/socket-sharding-nginx-release-1-9-1/
 	//
 	// It's disabled by default
 	Reuseport bool
-
-	// Child prefork processes may exit with failure and will be started over until the times reach
-	// the value of RecoverThreshold, then it will return and terminate the server.
-	RecoverThreshold int
-
-	// By default standard logger from log package is used.
-	Logger Logger
-
-	ServeFunc         func(ln net.Listener) error
-	ServeTLSFunc      func(ln net.Listener, certFile, keyFile string) error
-	ServeTLSEmbedFunc func(ln net.Listener, certData, keyData []byte) error
-
-	ln    net.Listener
-	files []*os.File
 }
 
 // IsChild checks if the current thread/process is a child.
@@ -164,8 +166,8 @@ func (p *Prefork) prefork(addr string) (err error) {
 	}
 
 	type procSig struct {
-		pid int
 		err error
+		pid int
 	}
 
 	goMaxProcs := runtime.GOMAXPROCS(0)
@@ -187,7 +189,7 @@ func (p *Prefork) prefork(addr string) (err error) {
 
 		childProcs[cmd.Process.Pid] = cmd
 		go func() {
-			sigCh <- procSig{cmd.Process.Pid, cmd.Wait()}
+			sigCh <- procSig{pid: cmd.Process.Pid, err: cmd.Wait()}
 		}()
 	}
 
@@ -213,7 +215,7 @@ func (p *Prefork) prefork(addr string) (err error) {
 		}
 		childProcs[cmd.Process.Pid] = cmd
 		go func() {
-			sigCh <- procSig{cmd.Process.Pid, cmd.Wait()}
+			sigCh <- procSig{pid: cmd.Process.Pid, err: cmd.Wait()}
 		}()
 	}
 

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -42,7 +42,6 @@ type Logger interface {
 // WARNING: using prefork prevents the use of any global state!
 // Things like in-memory caches won't work.
 type Prefork struct {
-
 	// By default standard logger from log package is used.
 	Logger Logger
 

--- a/reuseport/reuseport.go
+++ b/reuseport/reuseport.go
@@ -34,7 +34,7 @@ import (
 func Listen(network, addr string) (net.Listener, error) {
 	ln, err := cfg.NewListener(network, addr)
 	if err != nil && strings.Contains(err.Error(), "SO_REUSEPORT") {
-		return nil, &ErrNoReusePort{err}
+		return nil, &ErrNoReusePort{err: err}
 	}
 	return ln, err
 }

--- a/server.go
+++ b/server.go
@@ -148,6 +148,18 @@ type ServeHandler func(c net.Conn) error
 type Server struct {
 	noCopy noCopy
 
+	perIPConnCounter perIPConnCounter
+
+	ctxPool        sync.Pool
+	readerPool     sync.Pool
+	writerPool     sync.Pool
+	hijackConnPool sync.Pool
+
+	// Logger, which is used by RequestCtx.Logger().
+	//
+	// By default standard logger from log package is used.
+	Logger Logger
+
 	// Handler for processing incoming requests.
 	//
 	// Take into account that no `panic` recovery is done by `fasthttp` (thus any `panic` will take down the entire server).
@@ -181,10 +193,42 @@ type Server struct {
 	// like they are normal requests.
 	ContinueHandler func(header *RequestHeader) bool
 
+	// ConnState specifies an optional callback function that is
+	// called when a client connection changes state. See the
+	// ConnState type and associated constants for details.
+	ConnState func(net.Conn, ConnState)
+
+	// TLSConfig optionally provides a TLS configuration for use
+	// by ServeTLS, ServeTLSEmbed, ListenAndServeTLS, ListenAndServeTLSEmbed,
+	// AppendCert, AppendCertEmbed and NextProto.
+	//
+	// Note that this value is cloned by ServeTLS, ServeTLSEmbed, ListenAndServeTLS
+	// and ListenAndServeTLSEmbed, so it's not possible to modify the configuration
+	// with methods like tls.Config.SetSessionTicketKeys.
+	// To use SetSessionTicketKeys, use Server.Serve with a TLS Listener
+	// instead.
+	TLSConfig *tls.Config
+
+	// FormValueFunc, which is used by RequestCtx.FormValue and support for customizing
+	// the behaviour of the RequestCtx.FormValue function.
+	//
+	// NetHttpFormValueFunc gives a FormValueFunc func implementation that is consistent with net/http.
+	FormValueFunc FormValueFunc
+
+	nextProtos map[string]ServeHandler
+
+	concurrencyCh chan struct{}
+
+	idleConns map[net.Conn]time.Time
+	done      chan struct{}
+
 	// Server name for sending in response headers.
 	//
 	// Default server name is used if left blank.
 	Name string
+
+	// We need to know our listeners and idle connections so we can close them in Shutdown().
+	ln []net.Listener
 
 	// The maximum number of concurrent connections the server may serve.
 	//
@@ -261,6 +305,21 @@ type Server struct {
 	//
 	// Request body size is limited by DefaultMaxRequestBodySize by default.
 	MaxRequestBodySize int
+
+	// SleepWhenConcurrencyLimitsExceeded is a duration to be slept of if
+	// the concurrency limit in exceeded (default [when is 0]: don't sleep
+	// and accept new connections immediately).
+	SleepWhenConcurrencyLimitsExceeded time.Duration
+
+	idleConnsMu sync.Mutex
+
+	mu sync.Mutex
+
+	concurrency uint32
+	open        int32
+	stop        int32
+
+	rejectedRequestsCount uint32
 
 	// Whether to disable keep-alive connections.
 	//
@@ -340,11 +399,6 @@ type Server struct {
 	//     * cONTENT-lenGTH -> Content-Length
 	DisableHeaderNamesNormalizing bool
 
-	// SleepWhenConcurrencyLimitsExceeded is a duration to be slept of if
-	// the concurrency limit in exceeded (default [when is 0]: don't sleep
-	// and accept new connections immediately).
-	SleepWhenConcurrencyLimitsExceeded time.Duration
-
 	// NoDefaultServerHeader, when set to true, causes the default Server header
 	// to be excluded from the Response.
 	//
@@ -382,57 +436,6 @@ type Server struct {
 	// and calls the handler sooner when given body is
 	// larger than the current limit.
 	StreamRequestBody bool
-
-	// ConnState specifies an optional callback function that is
-	// called when a client connection changes state. See the
-	// ConnState type and associated constants for details.
-	ConnState func(net.Conn, ConnState)
-
-	// Logger, which is used by RequestCtx.Logger().
-	//
-	// By default standard logger from log package is used.
-	Logger Logger
-
-	// TLSConfig optionally provides a TLS configuration for use
-	// by ServeTLS, ServeTLSEmbed, ListenAndServeTLS, ListenAndServeTLSEmbed,
-	// AppendCert, AppendCertEmbed and NextProto.
-	//
-	// Note that this value is cloned by ServeTLS, ServeTLSEmbed, ListenAndServeTLS
-	// and ListenAndServeTLSEmbed, so it's not possible to modify the configuration
-	// with methods like tls.Config.SetSessionTicketKeys.
-	// To use SetSessionTicketKeys, use Server.Serve with a TLS Listener
-	// instead.
-	TLSConfig *tls.Config
-
-	// FormValueFunc, which is used by RequestCtx.FormValue and support for customizing
-	// the behaviour of the RequestCtx.FormValue function.
-	//
-	// NetHttpFormValueFunc gives a FormValueFunc func implementation that is consistent with net/http.
-	FormValueFunc FormValueFunc
-
-	nextProtos map[string]ServeHandler
-
-	concurrency      uint32
-	concurrencyCh    chan struct{}
-	perIPConnCounter perIPConnCounter
-
-	ctxPool        sync.Pool
-	readerPool     sync.Pool
-	writerPool     sync.Pool
-	hijackConnPool sync.Pool
-
-	// We need to know our listeners and idle connections so we can close them in Shutdown().
-	ln []net.Listener
-
-	idleConns   map[net.Conn]time.Time
-	idleConnsMu sync.Mutex
-
-	mu   sync.Mutex
-	open int32
-	stop int32
-	done chan struct{}
-
-	rejectedRequestsCount uint32
 }
 
 // TimeoutHandler creates RequestHandler, which returns StatusRequestTimeout
@@ -585,37 +588,39 @@ func CompressHandlerBrotliLevel(h RequestHandler, brotliLevel, otherLevel int) R
 type RequestCtx struct {
 	noCopy noCopy
 
-	// Incoming request.
-	//
-	// Copying Request by value is forbidden. Use pointer to Request instead.
-	Request Request
-
 	// Outgoing response.
 	//
 	// Copying Response by value is forbidden. Use pointer to Response instead.
 	Response Response
 
-	userValues userData
-
-	connID         uint64
-	connRequestNum uint64
-	connTime       time.Time
-	remoteAddr     net.Addr
+	connTime time.Time
 
 	time time.Time
 
-	logger ctxLogger
-	s      *Server
-	c      net.Conn
-	fbr    firstByteReader
+	logger     ctxLogger
+	remoteAddr net.Addr
+
+	c net.Conn
+	s *Server
 
 	timeoutResponse *Response
 	timeoutCh       chan struct{}
 	timeoutTimer    *time.Timer
 
-	hijackHandler    HijackHandler
+	hijackHandler HijackHandler
+	formValueFunc FormValueFunc
+	fbr           firstByteReader
+
+	userValues userData
+
+	// Incoming request.
+	//
+	// Copying Request by value is forbidden. Use pointer to Request instead.
+	Request Request
+
+	connID           uint64
+	connRequestNum   uint64
 	hijackNoResponse bool
-	formValueFunc    FormValueFunc
 }
 
 // HijackHandler must process the hijacked connection c.
@@ -2192,7 +2197,7 @@ func (s *Server) serveConn(c net.Conn) (err error) {
 					// If reading from a keep-alive connection returns nothing it means
 					// the connection was closed (either timeout or from the other side).
 					if err != io.EOF {
-						err = ErrNothingRead{err}
+						err = ErrNothingRead{error: err}
 					}
 				}
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -1296,10 +1296,10 @@ func TestServerMultipartFormDataRequest(t *testing.T) {
 		StreamRequestBody            bool
 		DisablePreParseMultipartForm bool
 	}{
-		{false, false},
-		{false, true},
-		{true, false},
-		{true, true},
+		{StreamRequestBody: false, DisablePreParseMultipartForm: false},
+		{StreamRequestBody: false, DisablePreParseMultipartForm: true},
+		{StreamRequestBody: true, DisablePreParseMultipartForm: false},
+		{StreamRequestBody: true, DisablePreParseMultipartForm: true},
 	} {
 		reqS := `POST /upload HTTP/1.1
 Host: qwerty.com
@@ -2651,8 +2651,8 @@ func testRequestCtxHijack(t *testing.T, s *Server) {
 	t.Helper()
 
 	type hijackSignal struct {
-		id int
 		rw *readWriter
+		id int
 	}
 
 	wg := sync.WaitGroup{}
@@ -2719,7 +2719,7 @@ func testRequestCtxHijack(t *testing.T, s *Server) {
 				t.Errorf("[iter: %d] Unexpected error from serveConn: %v", id, err)
 			}
 
-			hijackStartCh <- &hijackSignal{id, rw}
+			hijackStartCh <- &hijackSignal{id: id, rw: rw}
 		}(t, i)
 	}
 
@@ -4349,8 +4349,8 @@ func (rw *readWriter) SetWriteDeadline(t time.Time) error {
 }
 
 type testLogger struct {
-	lock sync.Mutex
 	out  string
+	lock sync.Mutex
 }
 
 func (cl *testLogger) Printf(format string, args ...any) {

--- a/server_timing_test.go
+++ b/server_timing_test.go
@@ -250,12 +250,12 @@ func (c *fakeServerConn) SetWriteDeadline(t time.Time) error {
 }
 
 type fakeListener struct {
-	lock            sync.Mutex
-	requestsCount   int
-	requestsPerConn int
-	request         []byte
 	ch              chan *fakeServerConn
 	done            chan struct{}
+	request         []byte
+	requestsCount   int
+	requestsPerConn int
+	lock            sync.Mutex
 	closed          bool
 }
 

--- a/stackless/writer.go
+++ b/stackless/writer.go
@@ -41,12 +41,13 @@ func NewWriter(dstW io.Writer, newWriter NewWriterFunc) Writer {
 type writer struct {
 	dstW io.Writer
 	zw   Writer
-	xw   xWriter
 
 	err error
-	n   int
+	xw  xWriter
 
-	p  []byte
+	p []byte
+	n int
+
 	op op
 }
 

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -126,7 +126,6 @@ type Resolver interface {
 
 // TCPDialer contains options to control a group of Dial calls.
 type TCPDialer struct {
-
 	// This may be used to override DNS resolving policy, like this:
 	// var dialer = &fasthttp.TCPDialer{
 	// 	Resolver: &net.Resolver{

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -126,18 +126,6 @@ type Resolver interface {
 
 // TCPDialer contains options to control a group of Dial calls.
 type TCPDialer struct {
-	// Concurrency controls the maximum number of concurrent Dials
-	// that can be performed using this object.
-	// Setting this to 0 means unlimited.
-	//
-	// WARNING: This can only be changed before the first Dial.
-	// Changes made after the first Dial will not affect anything.
-	Concurrency int
-
-	// LocalAddr is the local address to use when dialing an
-	// address.
-	// If nil, a local address is automatically chosen.
-	LocalAddr *net.TCPAddr
 
 	// This may be used to override DNS resolving policy, like this:
 	// var dialer = &fasthttp.TCPDialer{
@@ -152,17 +140,30 @@ type TCPDialer struct {
 	// }
 	Resolver Resolver
 
-	// DNSCacheDuration may be used to override the default DNS cache duration (DefaultDNSCacheDuration)
-	DNSCacheDuration time.Duration
-
-	tcpAddrsMap sync.Map
+	// LocalAddr is the local address to use when dialing an
+	// address.
+	// If nil, a local address is automatically chosen.
+	LocalAddr *net.TCPAddr
 
 	concurrencyCh chan struct{}
 
-	// DisableDNSResolution may be used to disable DNS resolution
-	DisableDNSResolution bool
+	tcpAddrsMap sync.Map
+
+	// Concurrency controls the maximum number of concurrent Dials
+	// that can be performed using this object.
+	// Setting this to 0 means unlimited.
+	//
+	// WARNING: This can only be changed before the first Dial.
+	// Changes made after the first Dial will not affect anything.
+	Concurrency int
+
+	// DNSCacheDuration may be used to override the default DNS cache duration (DefaultDNSCacheDuration)
+	DNSCacheDuration time.Duration
 
 	once sync.Once
+
+	// DisableDNSResolution may be used to disable DNS resolution
+	DisableDNSResolution bool
 }
 
 // Dial dials the given TCP addr using tcp4.
@@ -372,8 +373,8 @@ var ErrDialTimeout = errors.New("dialing to the given TCP address timed out")
 //		upstream = dialErr.Upstream // 34.206.39.153:80
 //	}
 type ErrDialWithUpstream struct {
-	Upstream string
 	wrapErr  error
+	Upstream string
 }
 
 func (e *ErrDialWithUpstream) Error() string {
@@ -396,11 +397,11 @@ func wrapDialWithUpstream(err error, upstream string) error {
 const DefaultDialTimeout = 3 * time.Second
 
 type tcpAddrEntry struct {
-	addrs    []net.TCPAddr
-	addrsIdx uint32
-
-	pending     int32
 	resolveTime time.Time
+	addrs       []net.TCPAddr
+	addrsIdx    uint32
+
+	pending int32
 }
 
 // DefaultDNSCacheDuration is the duration for caching resolved TCP addresses

--- a/uri.go
+++ b/uri.go
@@ -42,6 +42,8 @@ var uriPool = &sync.Pool{
 type URI struct {
 	noCopy noCopy
 
+	queryArgs Args
+
 	pathOriginal []byte
 	scheme       []byte
 	path         []byte
@@ -49,7 +51,11 @@ type URI struct {
 	hash         []byte
 	host         []byte
 
-	queryArgs       Args
+	fullURI    []byte
+	requestURI []byte
+
+	username        []byte
+	password        []byte
 	parsedQueryArgs bool
 
 	// Path values are sent as-is without normalization.
@@ -60,12 +66,6 @@ type URI struct {
 	// By default path values are normalized, i.e.
 	// extra slashes are removed, special characters are encoded.
 	DisablePathNormalizing bool
-
-	fullURI    []byte
-	requestURI []byte
-
-	username []byte
-	password []byte
 }
 
 // CopyTo copies uri contents to dst.

--- a/userdata_test.go
+++ b/userdata_test.go
@@ -54,7 +54,7 @@ func TestUserDataValueClose(t *testing.T) {
 	// store values implementing io.Closer
 	for i := 0; i < 5; i++ {
 		key := fmt.Sprintf("key_%d", i)
-		u.Set(key, &closerValue{&closeCalls})
+		u.Set(key, &closerValue{closeCalls: &closeCalls})
 	}
 
 	// store values without io.Closer

--- a/workerpool.go
+++ b/workerpool.go
@@ -15,29 +15,30 @@ import (
 //
 // Such a scheme keeps CPU caches hot (in theory).
 type workerPool struct {
+	workerChanPool sync.Pool
+
+	Logger Logger
+
 	// Function for serving server connections.
 	// It must leave c unclosed.
 	WorkerFunc ServeHandler
 
-	MaxWorkersCount int
+	stopCh chan struct{}
 
-	LogAllErrors bool
-	mustStop     bool
-
-	MaxIdleWorkerDuration time.Duration
-
-	Logger Logger
-
-	lock         sync.Mutex
-	workersCount int
+	connState func(net.Conn, ConnState)
 
 	ready []*workerChan
 
-	stopCh chan struct{}
+	MaxWorkersCount int
 
-	workerChanPool sync.Pool
+	MaxIdleWorkerDuration time.Duration
 
-	connState func(net.Conn, ConnState)
+	workersCount int
+
+	lock sync.Mutex
+
+	LogAllErrors bool
+	mustStop     bool
 }
 
 type workerChan struct {

--- a/zstd.go
+++ b/zstd.go
@@ -102,7 +102,7 @@ func releaseRealZstdWrter(zw *zstd.Encoder, level int) {
 }
 
 func AppendZstdBytesLevel(dst, src []byte, level int) []byte {
-	w := &byteSliceWriter{dst}
+	w := &byteSliceWriter{b: dst}
 	WriteZstdLevel(w, src, level) //nolint:errcheck
 	return w.b
 }
@@ -155,7 +155,7 @@ func AppendZstdBytes(dst, src []byte) []byte {
 // WriteUnzstd writes unzstd p to w and returns the number of uncompressed
 // bytes written to w.
 func WriteUnzstd(w io.Writer, p []byte) (int, error) {
-	r := &byteSliceReader{p}
+	r := &byteSliceReader{b: p}
 	zr, err := acquireZstdReader(r)
 	if err != nil {
 		return 0, err
@@ -171,7 +171,7 @@ func WriteUnzstd(w io.Writer, p []byte) (int, error) {
 
 // AppendUnzstdBytes appends unzstd src to dst and returns the resulting dst.
 func AppendUnzstdBytes(dst, src []byte) ([]byte, error) {
-	w := &byteSliceWriter{dst}
+	w := &byteSliceWriter{b: dst}
 	_, err := WriteUnzstd(w, src)
 	return w.b, err
 }


### PR DESCRIPTION
@erikdubbelboer Not sure your thoughts on this since it changes the order of fields in some of the public structs.

Affected Public Structs:
- Client
- HostClient
- Cookie
- URI
- ErrDialWithUpstream
- TCPDialer
- RequestCtx
- Response
- Request
- Server
- Prefork
- LBClient 

This is something we ran into in Fiber https://github.com/gofiber/fiber/pull/3079, we had a lot of places in the code base using `positional` instead of `named` fields. This can cause major bugs in the future when the underlying struct changes. I wrote an analyzer to detect and fix these issues. After fixing those, I ran `betteralign` against the whole code base.

Summary of savings:

```
/fasthttp/fasthttputil/inmemory_listener.go:16:23: 16 bytes saved: struct with 40 pointer bytes could be 24
/fasthttp/fasthttputil/pipeconns.go:44:16: 24 bytes saved: struct with 312 pointer bytes could be 288
/fasthttp/fasthttputil/pipeconns.go:95:15: 24 bytes saved: struct with 128 pointer bytes could be 104
/fasthttp/stackless/writer.go:41:13: 8 bytes saved: struct with 72 pointer bytes could be 64
/fasthttp/client.go:175:13: 144 bytes saved: struct with 288 pointer bytes could be 144
/fasthttp/client.go:684:17: 144 bytes saved: struct with 368 pointer bytes could be 224
/fasthttp/client.go:951:24: 24 bytes saved: struct with 48 pointer bytes could be 24
/fasthttp/client.go:2034:15: 8 bytes saved: struct with 40 pointer bytes could be 32
/fasthttp/client.go:2089:20: 8 bytes saved: struct with 40 pointer bytes could be 32
/fasthttp/client.go:2167:21: 72 bytes saved: struct with 144 pointer bytes could be 72
/fasthttp/client.go:2281:25: 88 bytes saved: struct with 208 pointer bytes could be 120
/fasthttp/client.go:2312:19: 24 bytes saved: struct with 1288 pointer bytes could be 1264
/fasthttp/cookie.go:67:13: 32 bytes saved: struct with 208 pointer bytes could be 176
/fasthttp/fs.go:253:9: 48 bytes saved: struct with 160 pointer bytes could be 112
/fasthttp/fs.go:504:16: 24 bytes saved: struct with 160 pointer bytes could be 136
/fasthttp/fs.go:522:13: 24 bytes saved: struct with 184 pointer bytes could be 160
/fasthttp/fs.go:847:27: 8 bytes saved: struct with 32 pointer bytes could be 24
/fasthttp/header.go:26:21: 32 bytes saved: struct with 304 pointer bytes could be 272
/fasthttp/header.go:61:20: 24 bytes saved: struct with 344 pointer bytes could be 320
/fasthttp/header.go:3233:20: 16 bytes saved: struct with 88 pointer bytes could be 72
/fasthttp/http.go:38:14: 8 bytes saved: struct with 776 pointer bytes could be 768
/fasthttp/http.go:89:15: 24 bytes saved: struct with 416 pointer bytes could be 392
/fasthttp/lbclient.go:27:15: 8 bytes saved: struct with 48 pointer bytes could be 40
/fasthttp/peripconn.go:9:23: 8 bytes saved: struct with 96 pointer bytes could be 88
/fasthttp/peripconn.go:41:16: 8 bytes saved: struct with 32 pointer bytes could be 24
/fasthttp/peripconn.go:48:19: 8 bytes saved: struct with 24 pointer bytes could be 16
/fasthttp/server.go:148:13: 8 bytes saved: struct of size 560 could be 552
/fasthttp/server.go:585:17: 48 bytes saved: struct with 1440 pointer bytes could be 1392
/fasthttp/tcpdialer.go:128:16: 24 bytes saved: struct with 80 pointer bytes could be 56
/fasthttp/tcpdialer.go:374:26: 8 bytes saved: struct with 32 pointer bytes could be 24
/fasthttp/tcpdialer.go:398:19: 24 bytes saved: struct with 56 pointer bytes could be 32
/fasthttp/uri.go:42:10: 8 bytes saved: struct with 280 pointer bytes could be 272
/fasthttp/workerpool.go:17:17: 56 bytes saved: struct with 144 pointer bytes could be 88
/fasthttp/examples/client/client.go:20:13: 8 bytes saved: struct with 16 pointer bytes could be 8
/fasthttp/fasthttpadaptor/adaptor.go:90:28: 8 bytes saved: struct with 40 pointer bytes could be 32
/fasthttp/prefork/prefork.go:44:14: 16 bytes saved: struct with 96 pointer bytes could be 80
/fasthttp/prefork/prefork.go:166:15: 8 bytes saved: struct with 24 pointer bytes could be 16
/fasthttp/client_test.go:1948:22: 8 bytes saved: struct with 40 pointer bytes could be 32
/fasthttp/client_test.go:3213:13: 8 bytes saved: struct with 48 pointer bytes could be 40
/fasthttp/client_test.go:3346:13: 16 bytes saved: struct with 72 pointer bytes could be 56
/fasthttp/client_test.go:3404:13: 8 bytes saved: struct with 32 pointer bytes could be 24
/fasthttp/client_timing_test.go:19:21: 24 bytes saved: struct with 56 pointer bytes could be 32
/fasthttp/server_test.go:2653:20: 8 bytes saved: struct with 16 pointer bytes could be 8
/fasthttp/server_test.go:4351:17: 8 bytes saved: struct with 16 pointer bytes could be 8
/fasthttp/server_timing_test.go:252:19: 40 bytes saved: struct with 64 pointer bytes could be 24
```

Total savings: **1336 bytes**

