### PR TITLE
TestHostClientMaxConnWaitTimeoutError test case sometimes fails

### DIFF
--- a/client.go
+++ b/client.go
@@ -1552,6 +1552,7 @@ func (c *HostClient) acquireConn(reqTimeout time.Duration, connectionClose bool)
 		case <-w.ready:
 			return w.conn, w.err
 		case <-tc.C:
+			c.connsWait.failedWaiters.Add(1)
 			if timeoutOverridden {
 				return nil, ErrTimeout
 			}
@@ -1697,6 +1698,7 @@ func (c *HostClient) decConnsCount() {
 				dialed = true
 				break
 			}
+			c.connsWait.failedWaiters.Add(-1)
 		}
 	}
 	if !dialed {
@@ -1751,6 +1753,7 @@ func (c *HostClient) releaseConn(cc *clientConn) {
 				delivered = w.tryDeliver(cc, nil)
 				break
 			}
+			c.connsWait.failedWaiters.Add(-1)
 		}
 	}
 	if !delivered {
@@ -2106,11 +2109,17 @@ type wantConnQueue struct {
 	head    []*wantConn
 	tail    []*wantConn
 	headPos int
+	// failedWaiters is the number of waiters in the head or tail queue,
+	// but is invalid.
+	// These state waiters cannot truly be considered as waiters; the current
+	// implementation does not immediately remove them when they become
+	// invalid but instead only marks them.
+	failedWaiters atomic.Int64
 }
 
 // len returns the number of items in the queue.
 func (q *wantConnQueue) len() int {
-	return len(q.head) - q.headPos + len(q.tail)
+	return len(q.head) - q.headPos + len(q.tail) - int(q.failedWaiters.Load())
 }
 
 // pushBack adds w to the back of the queue.
@@ -2154,6 +2163,7 @@ func (q *wantConnQueue) clearFront() (cleaned bool) {
 			return cleaned
 		}
 		q.popFront()
+		q.failedWaiters.Add(-1)
 		cleaned = true
 	}
 }


### PR DESCRIPTION
The current implementation makes some incorrect assumptions about observing changes in the state of wantConn.

The following two pull requests failed the GitHub workflow named `test` due to the `TestHostClientMaxConnWaitTimeoutError` test case.
https://github.com/valyala/fasthttp/pull/1818
https://github.com/valyala/fasthttp/pull/1829

Of course, we don't need to guarantee that the return value of HostClient.connsWait.len() is zero when all client calls have exited, because this doesn't affect the correctness of the program in the same way as the HostClient.MaxConns field does. 

There is a test in the suite, TestHostClientMaxConnWaitTimeoutError, which can cause the test to fail under certain conditions. We either need to remove this test or find a way to fix it. Additionally, false waiters could slightly impact the number of iterations in the loop during handle MaxConns semaphore  in the HostClient.releaseConn method.

This fix should resolve the issue.
The reason for the failure of this test case is related to the issue described in https://github.com/valyala/fasthttp/issues/1830.



