### PR TITLE
How to handle TCP keepalive-related configurations more effectively?

### DIFF
--- a/server.go
+++ b/server.go
@@ -294,9 +294,11 @@ type Server struct {
 	// worker pool of the Server. Idle workers beyond this time will be cleared.
 	MaxIdleWorkerDuration time.Duration
 
-	// Period between tcp keep-alive messages.
+	// TCPKeepalivePeriod is the duration the connection needs to
+	// remain idle before TCP starts sending keepalive probes.
 	//
-	// TCP keep-alive period is determined by operation system by default.
+	// This field is only effective when TCPKeepalive is set to true.
+	// A zero value indicates that the operating system's default setting will be used.
 	TCPKeepalivePeriod time.Duration
 
 	// Maximum request body size.
@@ -329,11 +331,14 @@ type Server struct {
 	// By default keep-alive connections are enabled.
 	DisableKeepalive bool
 
-	// Whether to enable tcp keep-alive connections.
-	//
 	// Whether the operating system should send tcp keep-alive messages on the tcp connection.
 	//
-	// By default tcp keep-alive connections are disabled.
+	// When this field is set to false, it is only effective if the net.Listener
+	// is created by this package itself. i.e. listened by ListenAndServe, ListenAndServeUNIX,
+	// ListenAndServeTLS and  ListenAndServeTLSEmbed method.
+	//
+	// If you have created a net.Listener yourself and configured TCP keepalive,
+	// this field should be set to false to avoid redundant additional system calls.
 	TCPKeepalive bool
 
 	// Aggressively reduces memory usage at the cost of higher CPU usage
@@ -1623,7 +1628,7 @@ func (s *Server) getNextProto(c net.Conn) (proto string, err error) {
 //
 // Accepted connections are configured to enable TCP keep-alives.
 func (s *Server) ListenAndServe(addr string) error {
-	ln, err := net.Listen("tcp4", addr)
+	ln, err := createTCPListener("tcp4", addr)
 	if err != nil {
 		return err
 	}
@@ -1639,7 +1644,7 @@ func (s *Server) ListenAndServeUNIX(addr string, mode os.FileMode) error {
 	if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("unexpected error when trying to remove unix socket file %q: %w", addr, err)
 	}
-	ln, err := net.Listen("unix", addr)
+	ln, err := createTCPListener("unix", addr)
 	if err != nil {
 		return err
 	}
@@ -1661,7 +1666,7 @@ func (s *Server) ListenAndServeUNIX(addr string, mode os.FileMode) error {
 //
 // Accepted connections are configured to enable TCP keep-alives.
 func (s *Server) ListenAndServeTLS(addr, certFile, keyFile string) error {
-	ln, err := net.Listen("tcp4", addr)
+	ln, err := createTCPListener("tcp4", addr)
 	if err != nil {
 		return err
 	}
@@ -1680,7 +1685,7 @@ func (s *Server) ListenAndServeTLS(addr, certFile, keyFile string) error {
 //
 // Accepted connections are configured to enable TCP keep-alives.
 func (s *Server) ListenAndServeTLSEmbed(addr string, certData, keyData []byte) error {
-	ln, err := net.Listen("tcp4", addr)
+	ln, err := createTCPListener("tcp4", addr)
 	if err != nil {
 		return err
 	}
@@ -2982,4 +2987,20 @@ var stateName = map[ConnState]string{
 
 func (c ConnState) String() string {
 	return stateName[c]
+}
+
+// If the net.Listener is created by us, we override the default TCP
+// keepalive behavior of net.ListenConfig, so that whether TCP keepalive is
+// enabled is entirely determined by Server.KeepAlive.
+//
+// In the implementation of the net package, TCPListener
+// by default always enables KeepAlive for new connections.
+func createTCPListener(network, addr string) (ln net.Listener, err error) {
+	var lc net.ListenConfig
+	// Overriding the default TCP keepalive behavior of
+	// net.ListenConfig, whether TCP keepalive is enabled
+	// is determined by Server.KeepAlive.
+	lc.KeepAlive = -1
+	ln, err = lc.Listen(context.Background(), network, addr)
+	return
 }


### PR DESCRIPTION
Currently, when Server.TCPKeepalive is set to false, if the net.Listener is created by the package itself, it does not override the default behavior of net.ListenConfig, which keeps TCP keepalive enabled.

I also added TCPKeepalive and TCPKeepalivePeriod fields to the client to make its behavior consistent with the server. 

**The goal of this pull request is to ensure that whether TCP keepalive is enabled is entirely controlled by the configuration fields provided by the package when net.TCPConn is created by the package itself.**
**If net.TCPConn is created by the user, it means that on the server side, the user provides their own net.Listener, and on the client side, the user provides their own Dial and DialTimeout functions. The TCP keepalive mechanism is managed by the user in this case, When TCPKeepalive field is false.**

If the user provides their own net.Listener, even after this pull request is accepted, the  implementation of fasthttp means that Server.TCPKeepalive is only meaningful when set to true. If set to false, it does not change the existing TCP keepalive behavior of the net.TCPConn created by the user-provided net.Listener.
https://github.com/valyala/fasthttp/blob/43c7b83ee54b9e78ecb79ae1a6346e9a82342f03/server.go#L1956-L1967

To avoid unnecessary and redundant system calls, I think this behavior is acceptable. At the same time add some relevant comments to make the meaning clearer.
```go
	// Whether the operating system should send tcp keep-alive messages on the tcp connection.
	//
	// When this field is set to false, it is only effective if the net.Listener
	// is created by this package itself. i.e. listened by ListenAndServe, ListenAndServeUNIX,
	// ListenAndServeTLS and  ListenAndServeTLSEmbed method.
	//
	// If you have created a net.Listener yourself and configured TCP keepalive,
	// this field should be set to false to avoid redundant additional system calls.
	TCPKeepalive bool
```
The root of the problem is that the net package defaults to having TCP keepalive enabled, while the fasthttp package defaults to having TCP keepalive disabled. Clearly, the behavior of the fasthttp package is more reasonable.

The changes brought by this pull request makes the semantics of the configuration fields related to TCP keepalive clearer and more precise.

This is a preliminary personal thought; discussions are welcome.