### PR TITLE
Fix issues with tests interfering with each other in certain situations.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1432,6 +1432,7 @@ func TestHostClientMaxConnsWithDeadline(t *testing.T) {
 						continue
 					}
 					t.Errorf("unexpected error: %v", err)
+					return
 				}
 				break
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -4141,7 +4141,10 @@ func TestMaxReadTimeoutPerRequest(t *testing.T) {
 		// write body
 		for i := 0; i < 5*1024; i++ {
 			time.Sleep(time.Millisecond)
-			cc.Write([]byte{'a'}) //nolint:errcheck
+			_, err = cc.Write([]byte{'a'})
+			if err != nil {
+				return
+			}
 		}
 	}()
 	ch := make(chan error)
@@ -4168,7 +4171,10 @@ func TestMaxWriteTimeoutPerRequest(t *testing.T) {
 			ctx.SetBodyStreamWriter(func(w *bufio.Writer) {
 				var buf [192]byte
 				for {
-					w.Write(buf[:]) //nolint:errcheck
+					_, err := w.Write(buf[:])
+					if err != nil {
+						return
+					}
 				}
 			})
 		},
@@ -4201,7 +4207,10 @@ func TestMaxWriteTimeoutPerRequest(t *testing.T) {
 		var chunk [192]byte
 		for {
 			time.Sleep(time.Millisecond)
-			br.Read(chunk[:]) //nolint:errcheck
+			_, err = br.Read(chunk[:])
+			if err != nil {
+				return
+			}
 		}
 	}()
 	ch := make(chan error)


### PR DESCRIPTION
In some cases, the goroutines started by one test do not terminate smoothly before the next round of tests begins, causing interference between tests.

Performance Impact: This results in test completion times not increasing linearly with the count value.

Correctness Impact: It affects the accuracy of memory allocation test cases.

Fix partial issues of this issue.: https://github.com/valyala/fasthttp/issues/1839