### PR TITLE
Add RetryIfErr for Client too

### DIFF
--- a/client.go
+++ b/client.go
@@ -197,9 +197,15 @@ type Client struct {
 	TLSConfig *tls.Config
 
 	// RetryIf controls whether a retry should be attempted after an error.
+	// By default, it uses the isIdempotent function.
 	//
-	// By default will use isIdempotent function.
+	// Deprecated: Use RetryIfErr instead.
+	// Panics if both RetryIf and RetryIfErr are set.
 	RetryIf RetryIfFunc
+
+	// RetryIfErr controls whether a retry should be attempted after an error.
+	// By default, it uses the isIdempotent function.
+	RetryIfErr RetryIfErrFunc
 
 	// ConfigureClient configures the fasthttp.HostClient.
 	ConfigureClient func(hc *HostClient) error
@@ -537,6 +543,7 @@ func (c *Client) Do(req *Request, resp *Response) error {
 				DisablePathNormalizing:        c.DisablePathNormalizing,
 				MaxConnWaitTimeout:            c.MaxConnWaitTimeout,
 				RetryIf:                       c.RetryIf,
+				RetryIfErr:                    c.RetryIfErr,
 				ConnPoolStrategy:              c.ConnPoolStrategy,
 				StreamResponseBody:            c.StreamResponseBody,
 				clientReaderPool:              &c.readerPool,

--- a/client_test.go
+++ b/client_test.go
@@ -2156,7 +2156,7 @@ func TestClientRetryRequestWithCustomDecider(t *testing.T) {
 				return nil, fmt.Errorf("unexpected number of dials: %d", dialsCount)
 			}
 		},
-		RetryIf: func(req *Request) bool {
+		RetryIfErr: func(req *Request, err error) bool {
 			return req.URI().String() == "http://foobar/a/b"
 		},
 	}


### PR DESCRIPTION
Fix #1744
In PR [1818](https://github.com/valyala/fasthttp/pull/1818#issuecomment-2308875848), we only add `RetryIfErr` for `HostClient` but not for `Client`.

