### PR TITLE
Fix potential data race reports when the `-race` flag is enabled.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1913,7 +1913,7 @@ func testClientDoTimeoutError(t *testing.T, c *Client, n int) {
 func testClientGetTimeoutError(t *testing.T, c *Client, n int) {
 	buf := make([]byte, 10)
 	for i := 0; i < n; i++ {
-		statusCode, body, err := c.GetTimeout(buf, "http://foobar.com/baz", time.Millisecond)
+		statusCode, _, err := c.GetTimeout(buf, "http://foobar.com/baz", time.Millisecond)
 		if err == nil {
 			t.Errorf("expecting error")
 		}
@@ -1922,9 +1922,6 @@ func testClientGetTimeoutError(t *testing.T, c *Client, n int) {
 		}
 		if statusCode != 0 {
 			t.Errorf("unexpected statusCode=%d. Expecting %d", statusCode, 0)
-		}
-		if body == nil {
-			t.Errorf("body must be non-nil")
 		}
 	}
 }
@@ -2660,7 +2657,7 @@ func testClientGetTimeoutSuccess(t *testing.T, c *Client, addr string, n int) {
 		statusCode, body, err := c.GetTimeout(buf, uri, time.Second)
 		buf = body
 		if err != nil {
-			t.Errorf("unexpected error when doing http request: %v", err)
+			t.Fatalf("unexpected error when doing http request: %v", err)
 		}
 		if statusCode != StatusOK {
 			t.Errorf("unexpected status code: %d. Expecting %d", statusCode, StatusOK)


### PR DESCRIPTION
The `testClientDoTimeoutError` and `testClientGetTimeoutSuccess` test function does not immediately return or fatal when the test fails. Instead, it continues to stringify the byte slice that was passed as the `dst` parameter to the `Client.GetTimeout` method. If the test fails due to a timeout, the request may still be ongoing, and there might be a data race between writing to `dst` and the stringification operation.

Other test cases also continue to access the body after a request failure, but they are not related to timeouts. I believe this should not be an issue.