### PR TITLE
Make the tests complete earlier.

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -3836,13 +3836,14 @@ func TestShutdownCloseIdleConns(t *testing.T) {
 }
 
 func TestShutdownWithContext(t *testing.T) {
+	t.Parallel()
 	done := make(chan struct{})
+	defer close(done)
 	ln := fasthttputil.NewInmemoryListener()
 	s := &Server{
 		Handler: func(ctx *RequestCtx) {
-			time.Sleep(4 * time.Second)
+			<-done
 			ctx.Success("aaa/bbb", []byte("real response"))
-			close(done)
 		},
 	}
 	go func() {
@@ -3885,7 +3886,6 @@ func TestShutdownWithContext(t *testing.T) {
 	if o := atomic.LoadInt32(&s.open); o != 1 {
 		t.Fatalf("unexpected open connection num: %#v. Expecting %#v", o, 1)
 	}
-	<-done
 }
 
 func TestMultipleServe(t *testing.T) {


### PR DESCRIPTION
Reduce the test duration to 36% of the original time.
Before Time Spend See Issue: https://github.com/valyala/fasthttp/issues/1839
After Commit:
```bash
~/GolandProjects/cbrotli_bug/fasthttp fasthttp_test_issue2*
❯ go test .
ok  	github.com/valyala/fasthttp	2.558s

~/GolandProjects/cbrotli_bug/fasthttp fasthttp_test_issue2*
❯ go test -count=2
PASS
ok  	github.com/valyala/fasthttp	4.976s

~/GolandProjects/cbrotli_bug/fasthttp fasthttp_test_issue2* 5s
❯ go test -count=3 .
ok  	github.com/valyala/fasthttp	7.389s

~/GolandProjects/cbrotli_bug/fasthttp fasthttp_test_issue2* 8s
❯ go test -count=4 .
ok  	github.com/valyala/fasthttp	9.991s
```