### PR TITLE
Fix improper memory reuse in NewFastHTTPHandler

### DIFF
--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -139,7 +139,7 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	}
 }
 
-func TestNewFastHTTPHandlerWithMiddleware(t *testing.T) {
+func TestNewFastHTTPHandlerWithCookies(t *testing.T) {
 	expectedMethod := fasthttp.MethodPost
 	expectedRequestURI := "/foo/bar?baz=123"
 	expectedHost := "foobar.com"

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -139,6 +139,53 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	}
 }
 
+func TestMiddleware(t *testing.T) {
+	expectedMethod := fasthttp.MethodPost
+	expectedRequestURI := "/foo/bar?baz=123"
+	expectedHost := "foobar.com"
+	expectedRemoteAddr := "1.2.3.4:6789"
+
+	var ctx fasthttp.RequestCtx
+	var req fasthttp.Request
+
+	req.Header.SetMethod(expectedMethod)
+	req.SetRequestURI(expectedRequestURI)
+	req.Header.SetHost(expectedHost)
+	req.Header.SetCookie("cookieOne", "valueCookieOne")
+	req.Header.SetCookie("cookieTwo", "valueCookieTwo")
+
+	remoteAddr, err := net.ResolveTCPAddr("tcp", expectedRemoteAddr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ctx.Init(&req, remoteAddr, nil)
+
+	nethttpH := func(w http.ResponseWriter, r *http.Request) {
+		// real handler warped by middleware, in this example do nothing
+	}
+	fasthttpH := NewFastHTTPHandler(http.HandlerFunc(nethttpH))
+
+	netMiddleware := func(_ http.ResponseWriter, r *http.Request) {
+		// assume middleware do some change on r, such as reset header's host
+		r.Header.Set("Host", "example.com")
+		// convert ctx again in case request may modify by middleware
+		ctx.Request.Header.Set("Host", r.Header.Get("Host"))
+		// since cookies of r are not changed, expect "cookieOne=valueCookieOne"
+		cookie, _ := r.Cookie("cookieOne")
+		if err != nil {
+			// will error, but if line 172 is commented, then no error will happen
+			t.Errorf("should not error")
+		}
+		if cookie.Value != "valueCookieOne" {
+			t.Errorf("cookie error, expect %s, find %s", "valueCookieOne", cookie.Value)
+		}
+		// instead of using responseWriter and r, use ctx again, like what have done in fiber
+		fasthttpH(&ctx)
+	}
+	fastMiddleware := NewFastHTTPHandler(http.HandlerFunc(netMiddleware))
+	fastMiddleware(&ctx)
+}
+
 func setContextValueMiddleware(next fasthttp.RequestHandler, key string, value any) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		ctx.SetUserValue(key, value)

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -139,7 +139,7 @@ func TestNewFastHTTPHandler(t *testing.T) {
 	}
 }
 
-func TestMiddleware(t *testing.T) {
+func TestNewFastHTTPHandlerWithMiddleware(t *testing.T) {
 	expectedMethod := fasthttp.MethodPost
 	expectedRequestURI := "/foo/bar?baz=123"
 	expectedHost := "foobar.com"

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/valyala/fasthttp"
 )
@@ -58,7 +59,8 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 		case "Transfer-Encoding":
 			r.TransferEncoding = append(r.TransferEncoding, sv)
 		default:
-			r.Header.Set(sk, sv)
+			svCopy := strings.Clone(sv)
+			r.Header.Set(sk, svCopy)
 		}
 	})
 

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -59,8 +59,10 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 		case "Transfer-Encoding":
 			r.TransferEncoding = append(r.TransferEncoding, sv)
 		default:
-			svCopy := strings.Clone(sv)
-			r.Header.Set(sk, svCopy)
+			if sk == fasthttp.HeaderCookie {
+				sv = strings.Clone(sv)
+			}
+			r.Header.Set(sk, sv)
 		}
 	})
 

--- a/header.go
+++ b/header.go
@@ -1286,8 +1286,9 @@ func (h *RequestHeader) VisitAll(f func(key, value []byte)) {
 
 	h.collectCookies()
 	if len(h.cookies) > 0 {
-		h.bufV = appendRequestCookieBytes(h.bufV[:0], h.cookies)
-		f(strCookie, h.bufV)
+		buf := make([]byte, 0)
+		buf = appendRequestCookieBytes(buf[:0], h.cookies)
+		f(strCookie, buf)
 	}
 	visitArgs(h.h, f)
 	if h.ConnectionClose() {

--- a/header.go
+++ b/header.go
@@ -1286,9 +1286,8 @@ func (h *RequestHeader) VisitAll(f func(key, value []byte)) {
 
 	h.collectCookies()
 	if len(h.cookies) > 0 {
-		buf := make([]byte, 0)
-		buf = appendRequestCookieBytes(buf[:0], h.cookies)
-		f(strCookie, buf)
+		h.bufV = appendRequestCookieBytes(h.bufV[:0], h.cookies)
+		f(strCookie, h.bufV)
 	}
 	visitArgs(h.h, f)
 	if h.ConnectionClose() {


### PR DESCRIPTION
Hi Developers,

This pull request fixes the improper memory reuse in NewFastHTTPHandler reported in this [issue](https://github.com/valyala/fasthttp/issues/1859).

If there are any further adjustments or improvements you'd like me to make, please don't hesitate to reach out :)

Best regards!