### PR TITLE
Improve the performance of ConnState.String()

### DIFF
--- a/server.go
+++ b/server.go
@@ -2973,7 +2973,7 @@ const (
 	StateClosed
 )
 
-var stateName = map[ConnState]string{
+var stateName = []string{
 	StateNew:      "new",
 	StateActive:   "active",
 	StateIdle:     "idle",


### PR DESCRIPTION
Decrease the `ConnState.String()` runtime by **95%**.

We can replace the `map` with `[]string` like the code in [https://github.com/valyala/fasthttp/blob/65e989e8b8bcf2541d840fcf27dcf8a11931b9db/status.go#L85-L151](https://github.com/valyala/fasthttp/blob/65e989e8b8bcf2541d840fcf27dcf8a11931b9db/status.go#L85-L151)

```go
func BenchmarkStatusToString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		StateNew.String()
		StateActive.String()
		StateIdle.String()
		StateHijacked.String()
		StateClosed.String()
	}
}
```

```
goos: linux
goarch: amd64
pkg: github.com/valyala/fasthttp
cpu: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
                 │    old.txt    │           new.txt            │
                 │    sec/op     │    sec/op     vs base        │
StatusToString-8   18.9250n ± 0%   0.8873n ± 1%  -95.31% (n=50)

                 │  old.txt   │            new.txt             │
                 │    B/op    │    B/op     vs base            │
StatusToString-8   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=50) ¹
¹ all samples are equal

                 │  old.txt   │            new.txt             │
                 │ allocs/op  │ allocs/op   vs base            │
StatusToString-8   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=50) ¹
¹ all samples are equal
```