### PR TITLE
feat (request): expose req timeout

### DIFF
--- a/http.go
+++ b/http.go
@@ -192,9 +192,9 @@ func (req *Request) SetConnectionClose() {
 	req.Header.SetConnectionClose()
 }
 
-// Get Request timeout as string
-func (req *Request) GetTimeOut() string {
-	return req.timeout.String()
+// Get Request timeout
+func (req *Request) GetTimeOut() time.Duration {
+	return req.timeout
 }
 
 // SendFile registers file on the given path to be used as response body

--- a/http.go
+++ b/http.go
@@ -192,7 +192,12 @@ func (req *Request) SetConnectionClose() {
 	req.Header.SetConnectionClose()
 }
 
-// Get Request timeout
+// GetTimeOut retrieves the timeout duration set for the Request.
+//
+// This method returns a time.Duration that determines how long the request
+// can wait before it times out. In the default use case, the timeout applies
+// to the entire request lifecycle, including both receiving the response
+// headers and the response body.
 func (req *Request) GetTimeOut() time.Duration {
 	return req.timeout
 }

--- a/http.go
+++ b/http.go
@@ -192,6 +192,11 @@ func (req *Request) SetConnectionClose() {
 	req.Header.SetConnectionClose()
 }
 
+// Get Request timeout as string
+func (req *Request) GetTimeOut() string {
+	return req.timeout.String()
+}
+
 // SendFile registers file on the given path to be used as response body
 // when Write is called.
 //

--- a/http_test.go
+++ b/http_test.go
@@ -3176,21 +3176,19 @@ func TestRespCopeToRace(t *testing.T) {
 }
 
 func TestRequestGetTimeOut(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		timeout  time.Duration
-		expected string
+		expected time.Duration
 	}{
-		{"Timeout set to 0", 0, "0s"},
-		{"Timeout set to 5s", 5 * time.Second, "5s"},
-		{"Timeout set to 1m", 1 * time.Minute, "1m0s"},
-		{"Timeout set to 500ms", 500 * time.Millisecond, "500ms"},
+		{"Timeout set to 0", 0, 0},
+		{"Timeout set to 5s", 5 * time.Second, 5 * time.Second},
+		{"Timeout set to 1m", 1 * time.Minute, 1 * time.Minute},
+		{"Timeout set to 500ms", 500 * time.Millisecond, 500 * time.Millisecond},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			req := &Request{timeout: test.timeout}
 
 			if got := req.GetTimeOut(); got != test.expected {

--- a/http_test.go
+++ b/http_test.go
@@ -3174,3 +3174,28 @@ func TestRespCopeToRace(t *testing.T) {
 		}
 	}
 }
+
+func TestRequestGetTimeOut(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		timeout  time.Duration
+		expected string
+	}{
+		{"Timeout set to 0", 0, "0s"},
+		{"Timeout set to 5s", 5 * time.Second, "5s"},
+		{"Timeout set to 1m", 1 * time.Minute, "1m0s"},
+		{"Timeout set to 500ms", 500 * time.Millisecond, "500ms"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			req := &Request{timeout: test.timeout}
+
+			if got := req.GetTimeOut(); got != test.expected {
+				t.Errorf("GetTimeOut() = %v, want %v", got, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Summary

Implemented `GetRequestTimeout` func to get the timeout attribute of the request.


# Related Issue
#1745


pd: is this what you guys had in mind?. I still need to document this btw.