### PR TITLE
improve ishex and unhex by hex2intTable

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -536,21 +536,11 @@ func shouldEscape(c byte, mode encoding) bool {
 }
 
 func ishex(c byte) bool {
-	return ('0' <= c && c <= '9') ||
-		('a' <= c && c <= 'f') ||
-		('A' <= c && c <= 'F')
+	return hex2intTable[c] < 16
 }
 
 func unhex(c byte) byte {
-	switch {
-	case '0' <= c && c <= '9':
-		return c - '0'
-	case 'a' <= c && c <= 'f':
-		return c - 'a' + 10
-	case 'A' <= c && c <= 'F':
-		return c - 'A' + 10
-	}
-	return 0
+	return hex2intTable[c] & 15
 }
 
 // validOptionalPort reports whether port is either an empty string


### PR DESCRIPTION
Improve the performance of `ishex` and `unhex` by reducing branching through table lookup.