### PR TITLE
feat(fasthttpproxy): add dual-stack connection support to enable IPv6 proxies for HTTP and SOCKS5 dialers

### DIFF
--- a/fasthttpproxy/http.go
+++ b/fasthttpproxy/http.go
@@ -3,9 +3,8 @@ package fasthttpproxy
 import (
 	"time"
 
-	"golang.org/x/net/http/httpproxy"
-
 	"github.com/valyala/fasthttp"
+	"golang.org/x/net/http/httpproxy"
 )
 
 // FasthttpHTTPDialer returns a fasthttp.DialFunc that dials using
@@ -57,7 +56,10 @@ func FasthttpHTTPDialerDualStack(proxy string) fasthttp.DialFunc {
 //		Dial: fasthttpproxy.FasthttpHTTPDialerDualStackTimeout("username:password@localhost:9050", time.Second * 2),
 //	}
 func FasthttpHTTPDialerDualStackTimeout(proxy string, timeout time.Duration) fasthttp.DialFunc {
-	d := Dialer{Config: httpproxy.Config{HTTPProxy: proxy, HTTPSProxy: proxy}, Timeout: timeout, ConnectTimeout: timeout, DialDualStack: true}
+	d := Dialer{
+		Config: httpproxy.Config{HTTPProxy: proxy, HTTPSProxy: proxy}, Timeout: timeout, ConnectTimeout: timeout,
+		DialDualStack: true,
+	}
 	dialFunc, _ := d.GetDialFunc(false)
 	return dialFunc
 }

--- a/fasthttpproxy/http.go
+++ b/fasthttpproxy/http.go
@@ -3,8 +3,9 @@ package fasthttpproxy
 import (
 	"time"
 
-	"github.com/valyala/fasthttp"
 	"golang.org/x/net/http/httpproxy"
+
+	"github.com/valyala/fasthttp"
 )
 
 // FasthttpHTTPDialer returns a fasthttp.DialFunc that dials using
@@ -30,6 +31,33 @@ func FasthttpHTTPDialer(proxy string) fasthttp.DialFunc {
 //	}
 func FasthttpHTTPDialerTimeout(proxy string, timeout time.Duration) fasthttp.DialFunc {
 	d := Dialer{Config: httpproxy.Config{HTTPProxy: proxy, HTTPSProxy: proxy}, Timeout: timeout, ConnectTimeout: timeout}
+	dialFunc, _ := d.GetDialFunc(false)
+	return dialFunc
+}
+
+// FasthttpHTTPDialerDualStack returns a fasthttp.DialFunc that dials using
+// the provided HTTP proxy with support for both IPv4 and IPv6.
+//
+// Example usage:
+//
+//	c := &fasthttp.Client{
+//		Dial: fasthttpproxy.FasthttpHTTPDialerDualStack("username:password@localhost:9050"),
+//	}
+func FasthttpHTTPDialerDualStack(proxy string) fasthttp.DialFunc {
+	return FasthttpHTTPDialerDualStackTimeout(proxy, 0)
+}
+
+// FasthttpHTTPDialerDualStackTimeout returns a fasthttp.DialFunc that dials using
+// the provided HTTP proxy with support for both IPv4 and IPv6, using the given timeout.
+// The timeout parameter determines both the dial timeout and the CONNECT request timeout.
+//
+// Example usage:
+//
+//	c := &fasthttp.Client{
+//		Dial: fasthttpproxy.FasthttpHTTPDialerDualStackTimeout("username:password@localhost:9050", time.Second * 2),
+//	}
+func FasthttpHTTPDialerDualStackTimeout(proxy string, timeout time.Duration) fasthttp.DialFunc {
+	d := Dialer{Config: httpproxy.Config{HTTPProxy: proxy, HTTPSProxy: proxy}, Timeout: timeout, ConnectTimeout: timeout, DialDualStack: true}
 	dialFunc, _ := d.GetDialFunc(false)
 	return dialFunc
 }

--- a/fasthttpproxy/socks5.go
+++ b/fasthttpproxy/socks5.go
@@ -1,8 +1,9 @@
 package fasthttpproxy
 
 import (
-	"github.com/valyala/fasthttp"
 	"golang.org/x/net/http/httpproxy"
+
+	"github.com/valyala/fasthttp"
 )
 
 // FasthttpSocksDialer returns a fasthttp.DialFunc that dials using
@@ -15,6 +16,20 @@ import (
 //	}
 func FasthttpSocksDialer(proxyAddr string) fasthttp.DialFunc {
 	d := Dialer{Config: httpproxy.Config{HTTPProxy: proxyAddr, HTTPSProxy: proxyAddr}}
+	dialFunc, _ := d.GetDialFunc(false)
+	return dialFunc
+}
+
+// FasthttpSocksDialerDualStack returns a fasthttp.DialFunc that dials using
+// the provided SOCKS5 proxy with support for both IPv4 and IPv6.
+//
+// Example usage:
+//
+//	c := &fasthttp.Client{
+//		Dial: fasthttpproxy.FasthttpSocksDialerDualStack("socks5://localhost:9050"),
+//	}
+func FasthttpSocksDialerDualStack(proxyAddr string) fasthttp.DialFunc {
+	d := Dialer{Config: httpproxy.Config{HTTPProxy: proxyAddr, HTTPSProxy: proxyAddr}, DialDualStack: true}
 	dialFunc, _ := d.GetDialFunc(false)
 	return dialFunc
 }

--- a/fasthttpproxy/socks5.go
+++ b/fasthttpproxy/socks5.go
@@ -1,9 +1,8 @@
 package fasthttpproxy
 
 import (
-	"golang.org/x/net/http/httpproxy"
-
 	"github.com/valyala/fasthttp"
+	"golang.org/x/net/http/httpproxy"
 )
 
 // FasthttpSocksDialer returns a fasthttp.DialFunc that dials using


### PR DESCRIPTION
- Added `FasthttpHTTPDialerDualStack` to support dual-stack (IPv4 and IPv6) connections for HTTP proxies, enabling IPv6 proxy usage.
- Added `FasthttpSocksDialerDualStack` to support dual-stack (IPv4 and IPv6) connections for SOCKS5 proxies, enabling IPv6 proxy usage.
- Improved dialer configuration to ensure compatibility with both IPv4 and IPv6 proxies.