### PR TITLE
chore: Upgrade golangci-lint to 1.61.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.56.2
+        version: v1.61.0
         args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,10 @@ linters:
   enable-all: true
   disable:
     - cyclop
+    - copyloopvar
     - depguard
     - dupl
+    - err113
     - errname
     - errorlint
     - exhaustive
@@ -25,8 +27,10 @@ linters:
     - gomnd
     - gosec
     - inamedparam
+    - intrange
     - ireturn
     - maintidx
+    - mnd
     - nakedret
     - nestif
     - nlreturn
@@ -46,6 +50,8 @@ linters:
     # Deprecated linters
     - deadcode
     - exhaustivestruct
+    - exportloopref
+    - execinquery
     - golint
     - ifshort
     - interfacer

--- a/client_test.go
+++ b/client_test.go
@@ -3502,7 +3502,7 @@ func TestRevertPull1233(t *testing.T) {
 			conn, err := ln.Accept()
 			if err != nil {
 				if !strings.Contains(err.Error(), "closed") {
-					t.Errorf(err.Error())
+					t.Error(err)
 				}
 				return
 			}
@@ -3512,7 +3512,7 @@ func TestRevertPull1233(t *testing.T) {
 			}
 			err = conn.(*net.TCPConn).SetLinger(0)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err)
 			}
 			conn.Close()
 		}


### PR DESCRIPTION
The PR upgrades golangci-lint to the newest version [1.61.0](https://github.com/golangci/golangci-lint/releases/tag/v1.61.0).

Additionally, replaces `t.Errorf(err.Error())` with `t.Error(err)` as suggested by `govet`.