### PR TITLE
fix RequestCtx is canceled (#1879)

### DIFF
--- a/server.go
+++ b/server.go
@@ -2789,6 +2789,7 @@ func (ctx *RequestCtx) Value(key any) any {
 }
 
 var fakeServer = &Server{
+	done: make(chan struct{}),
 	// Initialize concurrencyCh for TimeoutHandler
 	concurrencyCh: make(chan struct{}, DefaultConcurrency),
 }

--- a/server_test.go
+++ b/server_test.go
@@ -4414,3 +4414,13 @@ func TestRequestBodyStreamReadIssue1816(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRequestCtxInitShouldNotBeCanceledIssue1879(t *testing.T) {
+	var r Request
+	var requestCtx RequestCtx
+	requestCtx.Init(&r, nil, nil)
+	err := requestCtx.Err()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
In my opinion, the root cause of issue #1879 is that the `done` channel in `ctx.s` is nil. We can simply create `done` channel in `fakeServe`r during the initialization of RequestCtx.

Original
```
requestCtx.Init()
→ ctx.Init2
→ ctx.s = fakeServer        (the ctx.s.done is nil)

requestCtx.Err()
→ ctx.Done()        (generate the new buffered channel and send struct{}{} since the ctx.s.done is nil)
→ error is returned
```

Fix

```
requestCtx.Init()
→ ctx.Init2
→ ctx.s = fakeServer        (the ctx.s.done is initialized)

requestCtx.Err()
→ ctx.Done()        (return ctx.s.done since it is non nil)
→ error is nil
```