### PR TITLE
refactor: fix revive.indent-error-flow lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters-settings:
   revive:
     # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
     rules:
+      - name: indent-error-flow
       - name: use-any
   lll:
     line-length: 130

--- a/client.go
+++ b/client.go
@@ -3060,9 +3060,8 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 			return nil
 		})
 		return false, nil
-	} else {
-		hc.releaseReader(br)
 	}
+	hc.releaseReader(br)
 
 	if closeConn {
 		hc.closeConn(cc)

--- a/http.go
+++ b/http.go
@@ -1590,9 +1590,8 @@ func (req *Request) Write(w *bufio.Writer) error {
 		if len(req.Header.Host()) == 0 {
 			if len(host) == 0 {
 				return errRequestHostRequired
-			} else {
-				req.Header.SetHostBytes(host)
 			}
+			req.Header.SetHostBytes(host)
 		} else if !req.UseHostHeader {
 			req.Header.SetHostBytes(host)
 		}

--- a/uri.go
+++ b/uri.go
@@ -312,11 +312,11 @@ func (u *URI) parse(host, uri []byte, isTLS bool) error {
 	}
 
 	u.host = append(u.host, host...)
-	if parsedHost, err := parseHost(u.host); err != nil {
+	parsedHost, err := parseHost(u.host)
+	if err != nil {
 		return err
-	} else {
-		u.host = parsedHost
 	}
+	u.host = parsedHost
 	lowercaseBytes(u.host)
 
 	b := uri


### PR DESCRIPTION
The PR enables the rule `revive.indent-error-flow` and fix up lint issues.