### PR TITLE
fix: lenient chunk extension parsing leading to request smuggling issues

### DIFF
--- a/http.go
+++ b/http.go
@@ -2511,6 +2511,13 @@ func parseChunkSize(r *bufio.Reader) (int, error) {
 		// Skip chunk extension after chunk size.
 		// Add support later if anyone needs it.
 		if c != '\r' {
+			// Security: Don't allow newlines in chunk extensions.
+			// This can lead to request smuggling issues with some reverse proxies.
+			if c == '\n' {
+				return -1, ErrBrokenChunk{
+					error: fmt.Errorf("invalid character '\\n' after chunk size"),
+				}
+			}
 			continue
 		}
 		if err := r.UnreadByte(); err != nil {

--- a/http.go
+++ b/http.go
@@ -2515,7 +2515,7 @@ func parseChunkSize(r *bufio.Reader) (int, error) {
 			// This can lead to request smuggling issues with some reverse proxies.
 			if c == '\n' {
 				return -1, ErrBrokenChunk{
-					error: fmt.Errorf("invalid character '\\n' after chunk size"),
+					error: errors.New("invalid character '\\n' after chunk size"),
 				}
 			}
 			continue

--- a/http.go
+++ b/http.go
@@ -2505,7 +2505,7 @@ func parseChunkSize(r *bufio.Reader) (int, error) {
 		c, err := r.ReadByte()
 		if err != nil {
 			return -1, ErrBrokenChunk{
-				error: fmt.Errorf("cannot read '\r' char at the end of chunk size: %w", err),
+				error: fmt.Errorf("cannot read '\\r' char at the end of chunk size: %w", err),
 			}
 		}
 		// Skip chunk extension after chunk size.
@@ -2522,7 +2522,7 @@ func parseChunkSize(r *bufio.Reader) (int, error) {
 		}
 		if err := r.UnreadByte(); err != nil {
 			return -1, ErrBrokenChunk{
-				error: fmt.Errorf("cannot unread '\r' char at the end of chunk size: %w", err),
+				error: fmt.Errorf("cannot unread '\\r' char at the end of chunk size: %w", err),
 			}
 		}
 		break


### PR DESCRIPTION
fasthttp allows newlines (\n) between the chunk size and the CRLF (i.e. in the chunk extension). This can cause request smuggling issues with some reverse proxies. This PR prevents this potential vulnerability by disallowing newlines in the chunk extension. 

I've also corrected two unescaped carriage returns in error messages which messed with the output formatting.