### PR TITLE
fix: incorrect handling of negative cookie.maxAge #1900

### DIFF
--- a/cookie_test.go
+++ b/cookie_test.go
@@ -213,6 +213,13 @@ func TestCookieMaxAge(t *testing.T) {
 	if s != "foo=bar; expires=Thu, 01 Jan 1970 00:01:40 GMT" {
 		t.Fatalf("missing expires %q", s)
 	}
+
+	c.SetMaxAge(-100)
+	result := strings.ToLower(c.String())
+	const expectedMaxAge0 = "max-age=0"
+	if !strings.Contains(result, expectedMaxAge0) {
+		t.Fatalf("Unexpected cookie %q. Should contain %q", result, expectedMaxAge0)
+	}
 }
 
 func TestCookieHttpOnly(t *testing.T) {


### PR DESCRIPTION
This PR fixes issue #1900 

According to [RFC6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.2), a max-age value of 0 or less is valid and is interpreted as forcing the cookie to expire immediately.

In the Go `net/http` package, they set `Max-Age` to `0` when the `cookie.MaxAge < 0`. 

Before the fix

|                    |       net/http           |        fasthttp           |
|--------------|----------------------|---------------------|
|maxAge = 0 | unset                      |         unset             |
|maxAge > 0 | Max-Age=maxAge | Max-Age=maxAge| 
|<mark>maxAge < 0</mark> | <mark>Max-Age=0</mark>            |         <mark>unset</mark>             |

After the fix

|                    |       net/http           |        fasthttp           |
|--------------|----------------------|---------------------|
|maxAge = 0 | unset                      |         unset             |
|maxAge > 0 | Max-Age=maxAge | Max-Age=maxAge| 
|<mark>maxAge < 0</mark> | <mark>Max-Age=0</mark>            |         <mark>Max-Age=0</mark>             |