### PR TITLE
fix: Done() should return close chan.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2753,8 +2753,8 @@ func (ctx *RequestCtx) Done() <-chan struct{} {
 	done := ctx.s.done
 
 	if done == nil {
-		done = make(chan struct{}, 1)
-		done <- struct{}{}
+		done = make(chan struct{})
+		close(done)
 		return done
 	}
 	return done


### PR DESCRIPTION
Done returns a channel that's closed when work done on behalf of this context should be canceled.