### PR TITLE
Fix parsing of bad urls with #

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -857,15 +857,16 @@ func splitHostURI(host, uri []byte) ([]byte, []byte, []byte) {
 	uri = uri[n:]
 	n = bytes.IndexByte(uri, '/')
 	nq := bytes.IndexByte(uri, '?')
-	if nq >= 0 && nq < n {
+	if nq >= 0 && (n < 0 || nq < n) {
 		// A hack for urls like foobar.com?a=b/xyz
 		n = nq
-	} else if n < 0 {
-		// A hack for bogus urls like foobar.com?a=b without
-		// slash after host.
-		if nq >= 0 {
-			return scheme, uri[:nq], uri[nq:]
-		}
+	}
+	nh := bytes.IndexByte(uri, '#')
+	if nh >= 0 && (n < 0 || nh < n) {
+		// A hack for urls like foobar.com#abc.com
+		n = nh
+	}
+	if n < 0 {
 		return scheme, uri, strSlash
 	}
 	return scheme, uri[:n], uri[n:]

--- a/uri_test.go
+++ b/uri_test.go
@@ -484,3 +484,17 @@ func TestNoOverwriteInput(t *testing.T) {
 		t.Errorf("%q", u.String())
 	}
 }
+
+func TestFragmentInHost(t *testing.T) {
+	url := "http://google.com#@github.com"
+	u := AcquireURI()
+	defer ReleaseURI(u)
+
+	if err := u.Parse(nil, []byte(url)); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := string(u.Host()); got != "google.com" {
+		t.Fatalf("Unexpected host %q. Expected %q", got, "google.com")
+	}
+}


### PR DESCRIPTION
`http://google.com#@github.com` parses incorrectly as `github.com` instead of `google.com`.

Reported by Jesse Yang