### PR TITLE
fix: "identity" has been deprecated #1909

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -2551,6 +2551,10 @@ func TestResponseHeaderReadSuccess(t *testing.T) {
 	if !h.ConnectionClose() {
 		t.Fatalf("expecting connection: close for identity response")
 	}
+	// See https://github.com/valyala/fasthttp/issues/1909
+	if hasArg(h.h, HeaderTransferEncoding) {
+		t.Fatalf("unexpected header: 'Transfer-Encoding' should not be present in parsed headers")
+	}
 
 	// no content-type
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 400 OK\r\nContent-Length: 123\r\n\r\nfoiaaa",


### PR DESCRIPTION
Fixes #1909 

According to modern HTTP/1.1 specifications RFC 7230 `identity` as a value for `Transfer-Encoding` was removed in the errata to RFC 2616. See section "HTTP Transfer Coding Registry" in [https://www.iana.org/assignments/http-parameters/http-parameters.xhtml](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml)

In this PR, I still follow the implementation in [net/http](https://cs.opensource.google/go/go/+/master:src/net/http/transfer.go;l=612;drc=fafd4477f3d19f2c11a628e6e407ecf9924309c1) to retain the logic for handling `Transfer-Encoding: identity`. However, `identity` will not be included in the output headers.