### PR TITLE
docs: improve README formatting and section headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# fasthttp [![GoDoc](https://pkg.go.dev/badge/github.com/valyala/fasthttp)](https://pkg.go.dev/github.com/valyala/fasthttp) [![Go Report](https://goreportcard.com/badge/github.com/valyala/fasthttp)](https://goreportcard.com/report/github.com/valyala/fasthttp)
+# fasthttp
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/valyala/fasthttp)](https://pkg.go.dev/github.com/valyala/fasthttp) [![Go Report](https://goreportcard.com/badge/github.com/valyala/fasthttp)](https://goreportcard.com/report/github.com/valyala/fasthttp)
 
 ![FastHTTP – Fastest and reliable HTTP implementation in Go](https://github.com/fasthttp/docs-assets/raw/master/banner@0.5.png)
 
 Fast HTTP implementation for Go.
 
-# fasthttp might not be for you!
-fasthttp was designed for some high performance edge cases. **Unless** your server/client needs to handle **thousands of small to medium requests per second** and needs a consistent low millisecond response time fasthttp might not be for you. **For most cases `net/http` is much better** as it's easier to use and can handle more cases. For most cases you won't even notice the performance difference.
+## fasthttp might not be for you!
 
+fasthttp was designed for some high performance edge cases. **Unless** your server/client needs to handle **thousands of small to medium requests per second** and needs a consistent low millisecond response time fasthttp might not be for you. **For most cases `net/http` is much better** as it's easier to use and can handle more cases. For most cases you won't even notice the performance difference.
 
 ## General info and links
 


### PR DESCRIPTION
This PR changes section headers to improve rendering of README on pkg.go.dev. 

Before (currently at https://pkg.go.dev/github.com/valyala/fasthttp@v1.58.0):

<img width="745" alt="image" src="https://github.com/user-attachments/assets/ae6e3917-3c24-428d-95e6-fd1f2262c883" />

After merging this PR (https://pkg.go.dev/github.com/valyala/fasthttp@master):

<img width="815" alt="image" src="https://github.com/user-attachments/assets/5b36c0b8-8ce2-46a5-8971-d6ba34e0ea92" />
