### PR TITLE
perf: use buf in Args instead of bytebufferpool

### DIFF
--- a/args.go
+++ b/args.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"sort"
 	"sync"
-
-	"github.com/valyala/bytebufferpool"
 )
 
 const (
@@ -295,10 +293,8 @@ func (a *Args) GetUint(key string) (int, error) {
 
 // SetUint sets uint value for the given key.
 func (a *Args) SetUint(key string, value int) {
-	bb := bytebufferpool.Get()
-	bb.B = AppendUint(bb.B[:0], value)
-	a.SetBytesV(key, bb.B)
-	bytebufferpool.Put(bb)
+	a.buf = AppendUint(a.buf[:0], value)
+	a.SetBytesV(key, a.buf)
 }
 
 // SetUintBytes sets uint value for the given key.


### PR DESCRIPTION
Resolve #1856 

Since `Args` already contains a `buf` field, and multiple functions are designed to operate based on it, using the `buf` in `Args` results in a shorter process compared to using `bytebufferpool`. Additionally, based on the usage scenario, the number of calls to `SetUint` is unlikely to exceed 10, or even 100. Under such circumstances, using `buf` is significantly more efficient than `bytebufferpool`.

**Benchmark**

Call `SetUint` multiple times with the same key to compare the performance of the `AppendUint` step.

```go
func BenchmarkSetUint1(b *testing.B) {
	benchmarkSetUint(b, 1)
}

func BenchmarkSetUint10(b *testing.B) {
	benchmarkSetUint(b, 10)
}

func BenchmarkSetUint100(b *testing.B) {
	benchmarkSetUint(b, 100)
}

func benchmarkSetUint(b *testing.B, n int) {
	data := make([]int, n)

	for i := range data {
		data[i] = i
	}

	args := AcquireArgs()
	for i := 0; i < b.N; i++ {
		for j := range data {
			args.SetUint("key", data[j])
		}
		args.Reset()
	}
	ReleaseArgs(args)
}
```

**Result**

```
goos: linux
goarch: amd64
pkg: github.com/valyala/fasthttp
cpu: AMD EPYC 7763 64-Core Processor                
             │  old.txt    │              new.txt                │
             │   sec/op    │   sec/op     vs base                │
SetUint1-4     34.16n ± 3%   17.74n ± 1%  -48.06% (p=0.000 n=20)
SetUint10-4    336.0n ± 1%   169.0n ± 3%  -49.68% (p=0.000 n=20)
SetUint100-4   3.288µ ± 1%   1.640µ ± 1%  -50.13% (p=0.000 n=20)
geomean        335.4n        170.1n       -49.30%
…             │   old.txt    │              new.txt                │
             │  allocs/op   │ allocs/op   vs base                 │
SetUint1-4     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
SetUint10-4    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
SetUint100-4   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
geomean                   ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

The results show that the implementation using `buf` is approximately 50% faster than using `bytebufferpool`.
