### PR TITLE
refactor: using maps.Clone to simplify the code

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -7,6 +7,7 @@ import (
 	"html"
 	"io"
 	"io/fs"
+	"maps"
 	"mime"
 	"net/http"
 	"os"
@@ -467,10 +468,7 @@ func (fs *FS) initRequestHandler() {
 		compressedFileSuffixes["br"] == compressedFileSuffixes["zstd"] ||
 		compressedFileSuffixes["gzip"] == compressedFileSuffixes["zstd"] {
 		// Copy global map
-		compressedFileSuffixes = make(map[string]string, len(FSCompressedFileSuffixes))
-		for k, v := range FSCompressedFileSuffixes {
-			compressedFileSuffixes[k] = v
-		}
+		compressedFileSuffixes = maps.Clone(FSCompressedFileSuffixes)
 	}
 
 	if fs.CompressedFileSuffix != "" {


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/maps@go1.21.1#Clone) added in the go1.21 standard library, which can make the code more concise and easy to read.