### PR TITLE
perf: split delAllArgs into delAllArgs and delAllArgsStable

### DIFF
--- a/args.go
+++ b/args.go
@@ -155,12 +155,12 @@ func (a *Args) WriteTo(w io.Writer) (int64, error) {
 
 // Del deletes argument with the given key from query args.
 func (a *Args) Del(key string) {
-	a.args = delAllArgs(a.args, key)
+	a.args = delAllArgsStable(a.args, key)
 }
 
 // DelBytes deletes argument with the given key from query args.
 func (a *Args) DelBytes(key []byte) {
-	a.args = delAllArgs(a.args, b2s(key))
+	a.args = delAllArgsStable(a.args, b2s(key))
 }
 
 // Add adds 'key=value' argument.
@@ -392,11 +392,7 @@ func copyArgs(dst, src []argsKV) []argsKV {
 	return dst
 }
 
-func delAllArgsBytes(args []argsKV, key []byte) []argsKV {
-	return delAllArgs(args, b2s(key))
-}
-
-func delAllArgs(args []argsKV, key string) []argsKV {
+func delAllArgsStable(args []argsKV, key string) []argsKV {
 	for i, n := 0, len(args); i < n; i++ {
 		kv := &args[i]
 		if key == string(kv.key) {
@@ -409,6 +405,18 @@ func delAllArgs(args []argsKV, key string) []argsKV {
 		}
 	}
 	return args
+}
+
+func delAllArgs(args []argsKV, key string) []argsKV {
+	n := len(args)
+	for i := 0; i < n; i++ {
+		if key == string(args[i].key) {
+			args[i], args[n-1] = args[n-1], args[i]
+			n--
+			i--
+		}
+	}
+	return args[:n]
 }
 
 func setArgBytes(h []argsKV, key, value []byte, noValue bool) []argsKV {

--- a/header.go
+++ b/header.go
@@ -193,7 +193,7 @@ func (h *ResponseHeader) SetConnectionClose() {
 func (h *ResponseHeader) ResetConnectionClose() {
 	if h.connectionClose {
 		h.connectionClose = false
-		h.h = delAllArgsBytes(h.h, strConnection)
+		h.h = delAllArgs(h.h, HeaderConnection)
 	}
 }
 
@@ -211,7 +211,7 @@ func (h *RequestHeader) SetConnectionClose() {
 func (h *RequestHeader) ResetConnectionClose() {
 	if h.connectionClose {
 		h.connectionClose = false
-		h.h = delAllArgsBytes(h.h, strConnection)
+		h.h = delAllArgs(h.h, HeaderConnection)
 	}
 }
 
@@ -251,7 +251,7 @@ func (h *ResponseHeader) SetContentLength(contentLength int) {
 	h.contentLength = contentLength
 	if contentLength >= 0 {
 		h.contentLengthBytes = AppendUint(h.contentLengthBytes[:0], contentLength)
-		h.h = delAllArgsBytes(h.h, strTransferEncoding)
+		h.h = delAllArgs(h.h, HeaderTransferEncoding)
 		return
 	} else if contentLength == -1 {
 		h.contentLengthBytes = h.contentLengthBytes[:0]
@@ -296,7 +296,7 @@ func (h *RequestHeader) SetContentLength(contentLength int) {
 	h.contentLength = contentLength
 	if contentLength >= 0 {
 		h.contentLengthBytes = AppendUint(h.contentLengthBytes[:0], contentLength)
-		h.h = delAllArgsBytes(h.h, strTransferEncoding)
+		h.h = delAllArgs(h.h, HeaderTransferEncoding)
 	} else {
 		h.contentLengthBytes = h.contentLengthBytes[:0]
 		h.h = setArgBytes(h.h, strTransferEncoding, strChunked, argsHasValue)
@@ -1342,7 +1342,7 @@ func (h *ResponseHeader) del(key []byte) {
 	case HeaderTrailer:
 		h.trailer = h.trailer[:0]
 	}
-	h.h = delAllArgsBytes(h.h, key)
+	h.h = delAllArgs(h.h, b2s(key))
 }
 
 // Del deletes header with the given key.
@@ -1376,7 +1376,7 @@ func (h *RequestHeader) del(key []byte) {
 	case HeaderTrailer:
 		h.trailer = h.trailer[:0]
 	}
-	h.h = delAllArgsBytes(h.h, key)
+	h.h = delAllArgs(h.h, b2s(key))
 }
 
 // setSpecialHeader handles special headers and return true when a header is processed.


### PR DESCRIPTION
The original `delAllArgs` method is stable but requires more copying operations to maintain the order of elements.

- Renamed the original `delAllArgs` method to `delAllArgsStable` to maintain stable behavior.
- Added a new `delAllArgs` method for non-stable functionality, improving runtime efficiency.

Depending on the specific use case:

+ Use `delAllArgsStable` when stability (order preservation) is required.
+ Use `delAllArgs` when stability is not necessary.

In the case of handling headers in `h.h`, the order of headers is not important. Refer to net/http [header.go](https://cs.opensource.google/go/go/+/refs/tags/go1.23.5:src/net/http/header.go;l=80-82;drc=4f0408a3a205a88624dced4b188e11dd429bc3ad), where the Del function calls [textproto.MIMEHeader.Del](https://cs.opensource.google/go/go/+/refs/tags/go1.23.5:src/net/textproto/header.go;l=54-56;drc=1d45a7ef560a76318ed59dfdb178cecd58caf948). This function is implemented using a map, and the map delete operation is inherently unstable.

Benchmark compare `delAllArgsStable` and `delAllArgs`

```go
func BenchmarkArgsDel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		b.StopTimer()
		var a []argsKV
		for j := 1; j < 10; j++ {
			a = appendArg(a, fmt.Sprintf("item%d", j), "val", argsHasValue)
		}
		for j := 1; j < 10; j++ {
			a = appendArg(a, fmt.Sprintf("item%d", j), "val", argsHasValue)
		}
		b.StartTimer()
		for j := 1; j < 10; j++ {
			a = delAllArgs(a, fmt.Sprintf("item%d", j))
		}
	}
}

func BenchmarkArgsDelStable(b *testing.B) {
	for i := 0; i < b.N; i++ {
		b.StopTimer()
		var a []argsKV
		for j := 1; j < 10; j++ {
			a = appendArg(a, fmt.Sprintf("item%d", j), "val", argsHasValue)
		}
		for j := 1; j < 10; j++ {
			a = appendArg(a, fmt.Sprintf("item%d", j), "val", argsHasValue)
		}
		b.StartTimer()
		for j := 1; j < 10; j++ {
			a = delAllArgsStable(a, fmt.Sprintf("item%d", j))
		}
	}
}
```

Benchmark result:

```
$ go test --run=^$ --bench BenchmarkArgsDel -benchtime=100000x
goos: linux
goarch: amd64
pkg: github.com/valyala/fasthttp
cpu: AMD EPYC 7763 64-Core Processor                
BenchmarkArgsDel-4                100000              2072 ns/op
BenchmarkArgsDelStable-4          100000              2370 ns/op
PASS
ok      github.com/valyala/fasthttp     8.312s
```