### PR TITLE
fix: compression priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 tags
 *.pprof
-*.fasthttp.gz
 *.fasthttp.br
+*.fasthttp.zst
+*.fasthttp.gz
 .idea
 .vscode
 .DS_Store

--- a/fs.go
+++ b/fs.go
@@ -133,6 +133,7 @@ var (
 		GenerateIndexPages: true,
 		Compress:           true,
 		CompressBrotli:     true,
+		CompressZstd:       true,
 		AcceptByteRange:    true,
 	}
 	rootFSHandler RequestHandler
@@ -156,6 +157,7 @@ func ServeFS(ctx *RequestCtx, filesystem fs.FS, path string) {
 		GenerateIndexPages: true,
 		Compress:           true,
 		CompressBrotli:     true,
+		CompressZstd:       true,
 		AcceptByteRange:    true,
 	}
 	handler := f.NewRequestHandler()
@@ -321,12 +323,19 @@ type FS struct {
 	// absolute paths on any filesystem.
 	AllowEmptyRoot bool
 
-	// Uses brotli encoding and fallbacks to gzip in responses if set to true, uses gzip if set to false.
+	// Uses brotli encoding and fallbacks to zstd or gzip in responses if set to true, uses zstd or gzip if set to false.
 	//
 	// This value has sense only if Compress is set.
 	//
 	// Brotli encoding is disabled by default.
 	CompressBrotli bool
+
+	// Uses zstd encoding and fallbacks to gzip in responses if set to true, uses gzip if set to false.
+	//
+	// This value has sense only if Compress is set.
+	//
+	// zstd encoding is disabled by default.
+	CompressZstd bool
 
 	// Index pages for directories without files matching IndexNames
 	// are automatically generated if set.
@@ -487,6 +496,7 @@ func (fs *FS) initRequestHandler() {
 		generateIndexPages:     fs.GenerateIndexPages,
 		compress:               fs.Compress,
 		compressBrotli:         fs.CompressBrotli,
+		compressZstd:           fs.CompressZstd,
 		compressRoot:           compressRoot,
 		pathNotFound:           fs.PathNotFound,
 		acceptByteRange:        fs.AcceptByteRange,
@@ -518,6 +528,7 @@ type fsHandler struct {
 	generateIndexPages bool
 	compress           bool
 	compressBrotli     bool
+	compressZstd       bool
 	acceptByteRange    bool
 }
 
@@ -1049,14 +1060,14 @@ func (h *fsHandler) handleRequest(ctx *RequestCtx) {
 			mustCompress = true
 			fileCacheKind = brotliCacheKind
 			fileEncoding = "br"
+		case h.compressZstd && ctx.Request.Header.HasAcceptEncodingBytes(strZstd):
+			mustCompress = true
+			fileCacheKind = zstdCacheKind
+			fileEncoding = "zstd"
 		case ctx.Request.Header.HasAcceptEncodingBytes(strGzip):
 			mustCompress = true
 			fileCacheKind = gzipCacheKind
 			fileEncoding = "gzip"
-		case ctx.Request.Header.HasAcceptEncodingBytes(strZstd):
-			mustCompress = true
-			fileCacheKind = zstdCacheKind
-			fileEncoding = "zstd"
 		}
 	}
 

--- a/fs.go
+++ b/fs.go
@@ -1133,10 +1133,13 @@ func (h *fsHandler) handleRequest(ctx *RequestCtx) {
 		switch fileEncoding {
 		case "br":
 			hdr.SetContentEncodingBytes(strBr)
+			hdr.addVaryBytes(strAcceptEncoding)
 		case "gzip":
 			hdr.SetContentEncodingBytes(strGzip)
+			hdr.addVaryBytes(strAcceptEncoding)
 		case "zstd":
 			hdr.SetContentEncodingBytes(strZstd)
+			hdr.addVaryBytes(strAcceptEncoding)
 		}
 	}
 

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -85,6 +85,11 @@ func TestFSServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q", string(ce), "br")
 	}
 
+	vary := resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
+	}
+
 	body, err := resp.BodyUnbrotli()
 	if err != nil {
 		t.Fatalf("unexpected error on unbrotli response body: %v", err)
@@ -113,6 +118,11 @@ func TestFSServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q", string(ce), "zstd")
 	}
 
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
+	}
+
 	body, err = resp.BodyUnzstd()
 	if err != nil {
 		t.Fatalf("unexpected error on unzstd response body: %v", err)
@@ -139,6 +149,11 @@ func TestFSServeFileCompressed(t *testing.T) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q", string(ce), "gzip")
+	}
+
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
 	}
 
 	body, err = resp.BodyGunzip()
@@ -179,6 +194,11 @@ func TestFSServeFileUncompressed(t *testing.T) {
 	ce := resp.Header.ContentEncoding()
 	if len(ce) > 0 {
 		t.Fatalf("unexpected 'Content-Encoding': %q. Expecting \"\"", string(ce))
+	}
+
+	vary := resp.Header.PeekBytes(strVary)
+	if len(vary) > 0 {
+		t.Fatalf("unexpected 'Vary': %q. Expecting \"\"", string(vary))
 	}
 
 	body := resp.Body()
@@ -329,6 +349,11 @@ func testFSFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Fatalf("unexpected 'Content-Encoding': %q. Expecting \"\"", string(ce))
 	}
 
+	vary := resp.Header.PeekBytes(strVary)
+	if len(vary) > 0 {
+		t.Fatalf("unexpected 'Vary': %q. Expecting \"\"", string(vary))
+	}
+
 	expectedBody := bytes.Clone(resp.Body())
 
 	// should prefer brotli over zstd, gzip and ignore unknown encoding
@@ -349,6 +374,11 @@ func testFSFSCompress(t *testing.T, h RequestHandler, filePath string) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "br" {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q. filePath=%q", string(ce), "br", filePath)
+	}
+
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
 	}
 
 	body, err := resp.BodyUnbrotli()
@@ -379,6 +409,11 @@ func testFSFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q. filePath=%q", string(ce), "zstd", filePath)
 	}
 
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
+	}
+
 	body, err = resp.BodyUnzstd()
 	if err != nil {
 		t.Fatalf("unexpected error on unzstd response body: %v. filePath=%q", err, filePath)
@@ -405,6 +440,11 @@ func testFSFSCompress(t *testing.T, h RequestHandler, filePath string) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q. filePath=%q", string(ce), "gzip", filePath)
+	}
+
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
 	}
 
 	body, err = resp.BodyGunzip()
@@ -543,6 +583,11 @@ func TestDirFSServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q", string(ce), "br")
 	}
 
+	vary := resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
+	}
+
 	body, err := resp.BodyUnbrotli()
 	if err != nil {
 		t.Fatalf("unexpected error on unbrotli response body: %v", err)
@@ -571,6 +616,11 @@ func TestDirFSServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q", string(ce), "zstd")
 	}
 
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
+	}
+
 	body, err = resp.BodyUnzstd()
 	if err != nil {
 		t.Fatalf("unexpected error on unzstd response body: %v", err)
@@ -597,6 +647,11 @@ func TestDirFSServeFileCompressed(t *testing.T) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q", string(ce), "gzip")
+	}
+
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
 	}
 
 	body, err = resp.BodyGunzip()

--- a/fs_test.go
+++ b/fs_test.go
@@ -956,7 +956,7 @@ func TestFileCacheForZstd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fs := FS{Root: os.TempDir(), Compress: true, CacheDuration: time.Second * 60}
+	fs := FS{Root: os.TempDir(), Compress: true, CompressZstd: true, CacheDuration: time.Second * 60}
 	h := fs.NewRequestHandler()
 	var ctx RequestCtx
 	var req Request

--- a/fs_test.go
+++ b/fs_test.go
@@ -232,6 +232,11 @@ func TestServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected 'Content-Encoding': %q. Expecting %q", string(ce), "br")
 	}
 
+	vary := resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
+	}
+
 	body, err := resp.BodyUnbrotli()
 	if err != nil {
 		t.Fatalf("unexpected error on unbrotli response body: %v", err)
@@ -260,6 +265,11 @@ func TestServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q", string(ce), "zstd")
 	}
 
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
+	}
+
 	body, err = resp.BodyUnzstd()
 	if err != nil {
 		t.Fatalf("unexpected error on unzstd response body: %v", err)
@@ -286,6 +296,11 @@ func TestServeFileCompressed(t *testing.T) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected 'Content-Encoding' %q. Expecting %q", string(ce), "gzip")
+	}
+
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
 	}
 
 	body, err = resp.BodyGunzip()
@@ -326,6 +341,11 @@ func TestServeFileUncompressed(t *testing.T) {
 	ce := resp.Header.ContentEncoding()
 	if len(ce) > 0 {
 		t.Fatalf("unexpected 'Content-Encoding': %q. Expecting \"\"", string(ce))
+	}
+
+	vary := resp.Header.PeekBytes(strVary)
+	if len(vary) > 0 {
+		t.Fatalf("unexpected 'Vary': %q. Expecting \"\"", string(vary))
 	}
 
 	body := resp.Body()
@@ -697,6 +717,11 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Fatalf("unexpected 'Content-Encoding': %q. Expecting \"\"", string(ce))
 	}
 
+	vary := resp.Header.PeekBytes(strVary)
+	if len(vary) > 0 {
+		t.Fatalf("unexpected 'Vary': %q. Expecting \"\"", string(vary))
+	}
+
 	expectedBody := bytes.Clone(resp.Body())
 
 	// should prefer brotli over zstd, gzip and ignore unknown encoding
@@ -717,6 +742,11 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "br" {
 		t.Fatalf("unexpected 'Content-Encoding': %q. Expecting %q. filePath=%q", string(ce), "br", filePath)
+	}
+
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
 	}
 
 	body, err := resp.BodyUnbrotli()
@@ -747,6 +777,11 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Fatalf("unexpected 'Content-Encoding': %q. Expecting %q. filePath=%q", string(ce), "zstd", filePath)
 	}
 
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
+	}
+
 	body, err = resp.BodyUnzstd()
 	if err != nil {
 		t.Fatalf("unexpected error on unzstd response body: %v. filePath=%q", err, filePath)
@@ -773,6 +808,11 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 	ce = resp.Header.ContentEncoding()
 	if string(ce) != "gzip" {
 		t.Fatalf("unexpected 'Content-Encoding': %q. Expecting %q. filePath=%q", string(ce), "gzip", filePath)
+	}
+
+	vary = resp.Header.PeekBytes(strVary)
+	if !bytes.Equal(vary, strAcceptEncoding) {
+		t.Fatalf("unexpected 'Vary': %q. Expecting %q", string(vary), HeaderAcceptEncoding)
 	}
 
 	body, err = resp.BodyGunzip()

--- a/fs_test.go
+++ b/fs_test.go
@@ -213,7 +213,7 @@ func TestServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// request compressed brotli over zstd, gzip and unknown encoding
+	// should prefer brotli over zstd, gzip and ignore unknown encoding
 	ctx.Request.SetRequestURI("http://foobar.com/baz")
 	ctx.Request.Header.Set(HeaderAcceptEncoding, "gzip, zstd, br, wompwomp")
 	ServeFile(&ctx, "fs.go")
@@ -240,7 +240,7 @@ func TestServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected body: len=%d. Expecting len=%d", len(body), len(expectedBody))
 	}
 
-	// should prefer zstd over gzip and unknown encoding
+	// should prefer zstd over gzip and ignore unknown encoding
 	ctx.Request.Reset()
 	ctx.Request.SetRequestURI("http://foobar.com/baz")
 	ctx.Request.Header.Set(HeaderAcceptEncoding, "gzip, zstd, wompwomp")
@@ -268,7 +268,7 @@ func TestServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected body: len=%d. Expecting len=%d", len(body), len(expectedBody))
 	}
 
-	// lastly, fallback to gzip and ignore unknown encoding
+	// should prefer gzip and ignore unknown encoding
 	ctx.Request.Reset()
 	ctx.Request.SetRequestURI("http://foobar.com/baz")
 	ctx.Request.Header.Set(HeaderAcceptEncoding, "gzip, wompwomp")
@@ -321,7 +321,7 @@ func TestServeFileCompressed(t *testing.T) {
 		t.Fatalf("unexpected body: len=%d. Expecting len=%d", len(body), len(expectedBody))
 	}
 
-	// return uncompressed
+	// lastly, return uncompressed
 	ctx.Request.Reset()
 	ctx.Request.SetRequestURI("http://foobar.com/baz")
 	ServeFile(&ctx, "fs.go")
@@ -729,7 +729,7 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// request compressed brotli over zstd, gzip and unknown encoding
+	// should prefer brotli over zstd, gzip and ignore unknown encoding
 	ctx.Request.SetRequestURI(filePath)
 	ctx.Request.Header.Set(HeaderAcceptEncoding, "gzip, zstd, br, wompwomp")
 	h(&ctx)
@@ -756,7 +756,7 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Fatalf("unexpected body: len=%d. Expecting len=%d. filePath=%q", len(body), len(expectedBody), filePath)
 	}
 
-	// request compressed zstd over gzip and unknown encoding
+	// should prefer zstd over gzip and ignore unknown encoding
 	ctx.Request.Reset()
 	ctx.Request.SetRequestURI(filePath)
 	ctx.Request.Header.Set(HeaderAcceptEncoding, "gzip, zstd, wompwomp")
@@ -784,7 +784,7 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Fatalf("unexpected body: len=%d. Expecting len=%d. filePath=%q", len(body), len(expectedBody), filePath)
 	}
 
-	// lastly, request compressed gzip and ignore unknown encoding
+	// should prefer gzip and ignore unknown encoding
 	ctx.Request.Reset()
 	ctx.Request.SetRequestURI(filePath)
 	ctx.Request.Header.Set(HeaderAcceptEncoding, "gzip, wompwomp")
@@ -837,7 +837,7 @@ func testFSCompress(t *testing.T, h RequestHandler, filePath string) {
 		t.Fatalf("unexpected body: len=%d. Expecting len=%d. filePath=%q", len(body), len(expectedBody), filePath)
 	}
 
-	// return uncompressed
+	// lastly, return uncompressed
 	ctx.Request.Reset()
 	ctx.Request.SetRequestURI(filePath)
 	h(&ctx)


### PR DESCRIPTION
Before this PR, fasthttp would never use zstd if clients sent their `Accept-Encoding` header including gzip because zstd was the last option and would only be used if zstd was the only encoding available in `Accept-Encoding` header. This is really an issue when serving precompressed sidecars of zstd and gzip where the server preferred the latter.

The following order has been established; first brotli, then zstd, and finally gzip. It takes into account whether `CompressBrotli` and the new `CompressZstd` option are enabled to select which compression to use.

It also fixes the missing Vary header on compressed assets.

~~There is also an issue that has been revealed with the rework of these tests that should be addressed in a separate PR~~