### PR TITLE
add dummy support for js,wasm

### DIFF
--- a/tcplisten/socket.go
+++ b/tcplisten/socket.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd || rumprun || (zos && s390x)
+//go:build !js && !wasm && (linux || darwin || dragonfly || freebsd || netbsd || openbsd || rumprun || (zos && s390x))
 
 package tcplisten
 

--- a/tcplisten/socket_other.go
+++ b/tcplisten/socket_other.go
@@ -1,4 +1,4 @@
-//go:build linux || dragonfly || freebsd || netbsd || openbsd || rumprun
+//go:build !js && !wasm && (linux || dragonfly || freebsd || netbsd || openbsd || rumprun)
 
 package tcplisten
 

--- a/tcplisten/tcplisten_js_wasm.go
+++ b/tcplisten/tcplisten_js_wasm.go
@@ -1,0 +1,17 @@
+package tcplisten
+
+import (
+	"net"
+)
+
+// A dummy implementation for js,wasm
+type Config struct {
+	ReusePort   bool
+	DeferAccept bool
+	FastOpen    bool
+	Backlog     int
+}
+
+func (cfg *Config) NewListener(network, addr string) (net.Listener, error) {
+	return net.Listen(network, addr)
+}


### PR DESCRIPTION
@erikdubbelboer Can this be merged and a **new version be tagged**.

It is to support this: https://github.com/gofiber/fiber/issues/3298 & https://github.com/nlepage/go-wasm-http-server/issues/18

fasthttp wasn't building for `GOOS=js GOARCH=wasm go build` producing this build error:

```
../../go/pkg/mod/github.com/valyala/tcplisten@v1.0.0/socket_other.go:11:48: undefined: syscall.SOCK_NONBLOCK
../../go/pkg/mod/github.com/valyala/tcplisten@v1.0.0/socket_other.go:11:70: undefined: syscall.SOCK_CLOEXEC
```