### PR TITLE
fix: explicit uint32 conversion so it works in linux-386 platform build

### DIFF
--- a/tcplisten/tcplisten.go
+++ b/tcplisten/tcplisten.go
@@ -184,7 +184,7 @@ func safeIntToUint32(i int) (uint32, error) {
 	if i < 0 {
 		return 0, errors.New("value is negative, cannot convert to uint32")
 	}
-	if i > math.MaxUint32 {
+	if uint32(i) > uint32(math.MaxUint32) {
 		return 0, errors.New("value exceeds uint32 max value")
 	}
 	return uint32(i), nil


### PR DESCRIPTION
Fix for issue: https://github.com/valyala/fasthttp/issues/1960

In Go, the math.MaxUint32 constant is an untyped integer constant that defaults to type int in contexts where a typed value is required. On a 32-bit architecture like linux-386, the int type is 32-bit signed, and math.MaxUint32 (which is 4294967295) exceeds the maximum value that can be represented by a 32-bit signed integer, causing an overflow error.

To avoid this error, you can explicitly convert math.MaxUint32 to an unsigned integer type like uint32 when using it in comparisons or assignments. This ensures that the constant is treated as an unsigned integer, which can handle the full range of MaxUint32 without overflow.