### PR TITLE
Update the supported version to the same as Go itself

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -603,7 +603,9 @@ This is an **unsafe** way, the result string and `[]byte` buffer share the same 
 
 * *Which GO versions are supported by fasthttp?*
 
-  Go 1.22.x and newer. Older versions might work, but won't officially be supported.
+  We support the same versions the Go team supports.
+  Currently that is Go 1.23.x and newer.
+  Older versions might work, but won't officially be supported.
 
 * *Please provide real benchmark data and server information*
 

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -297,7 +297,7 @@ func TestFSFSCompressConcurrent(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		select {
 		case <-ch:
-		case <-time.After(time.Second * 2):
+		case <-time.After(time.Second * 4):
 			t.Fatalf("timeout")
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/valyala/fasthttp
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/andybalholm/brotli v1.1.1
 	github.com/klauspost/compress v1.18.0
 	github.com/valyala/bytebufferpool v1.0.0
-	golang.org/x/crypto v0.33.0
+	golang.org/x/crypto v0.35.0
 	golang.org/x/net v0.35.0
 	golang.org/x/sys v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
-golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
-golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
+golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
+golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
 golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=

--- a/server.go
+++ b/server.go
@@ -1706,7 +1706,7 @@ func (s *Server) ServeTLS(ln net.Listener, certFile, keyFile string) error {
 
 	// BuildNameToCertificate has been deprecated since 1.14.
 	// But since we also support older versions we'll keep this here.
-	s.TLSConfig.BuildNameToCertificate() //nolint:staticcheck
+	s.TLSConfig.BuildNameToCertificate()
 
 	s.mu.Unlock()
 
@@ -1734,7 +1734,7 @@ func (s *Server) ServeTLSEmbed(ln net.Listener, certData, keyData []byte) error 
 
 	// BuildNameToCertificate has been deprecated since 1.14.
 	// But since we also support older versions we'll keep this here.
-	s.TLSConfig.BuildNameToCertificate() //nolint:staticcheck
+	s.TLSConfig.BuildNameToCertificate()
 
 	s.mu.Unlock()
 

--- a/server_test.go
+++ b/server_test.go
@@ -3657,7 +3657,7 @@ func TestCloseOnShutdown(t *testing.T) {
 	done := 0
 	for {
 		select {
-		case <-time.After(time.Second):
+		case <-time.After(time.Second * 2):
 			t.Fatal("shutdown took too long")
 		case <-serveCh:
 			done++


### PR DESCRIPTION
Some of our dependencies only support the officially supported Go versions by the Go team.

For example `github.com/golang/crypto` now requires 1.23 or higher. See: https://github.com/golang/crypto/commit/89ff08d67c4d79f9ac619aaf1f7388888798651fa

For more information on the new policy of the Go team see: https://github.com/golang/go/issues/69095