### PR TITLE
Remove idleConns mutex for every request

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -3832,6 +3832,10 @@ func TestShutdownCloseIdleConns(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
+
+		if _, err := conn.Read(make([]byte, 1)); err == nil {
+			t.Fatal("connection not closed")
+		}
 	}
 }
 


### PR DESCRIPTION
Locking and unlocking a mutex multiple times per request is a major slowdown that we can avoid with clever use of atomics.

Before:
```
BenchmarkServerGet100ReqPerConn10KClients-12    	 84167428	       867.7 ns/op
```
After:
```
BenchmarkServerGet100ReqPerConn10KClients-12    	187397954	       386.3 ns/op
```

See: https://github.com/valyala/fasthttp/issues/1975