### PR TITLE
WIP: Improved idle connections timeout handling.

### DIFF
--- a/server_idle_conn_list.go
+++ b/server_idle_conn_list.go
@@ -26,12 +26,14 @@ func (l *idleConnList) insertBack(itemPtr uintptr) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	item.prevItem = l.lastItem
-	if item.prevItem != nil {
-		item.prevItem.nextItem = item
+	if l.lastItem == nil {
+		l.firstItem = item
+		l.lastItem = item
+	} else {
+		l.lastItem.nextItem = item
+		item.prevItem = l.lastItem
+		l.lastItem = item
 	}
-	item.nextItem = nil
-	l.lastItem = item
 }
 
 func (l *idleConnList) remove(itemPtr uintptr) {

--- a/server_idle_conn_list.go
+++ b/server_idle_conn_list.go
@@ -1,0 +1,71 @@
+package fasthttp
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+type idleConnList struct {
+	mtx       sync.Mutex
+	firstItem *idleConnListItem
+	lastItem  *idleConnListItem
+}
+
+type idleConnListItem struct {
+	nextItem *idleConnListItem
+	prevItem *idleConnListItem
+	c        net.Conn
+	connTime atomic.Int64
+}
+
+func (l *idleConnList) insertBack(itemPtr uintptr) {
+	item := (*idleConnListItem)(unsafe.Pointer(itemPtr))
+
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	item.prevItem = l.lastItem
+	if item.prevItem != nil {
+		item.prevItem.nextItem = item
+	}
+	item.nextItem = nil
+	l.lastItem = item
+}
+
+func (l *idleConnList) remove(itemPtr uintptr) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	l.removeNoLock(itemPtr)
+}
+
+func (l *idleConnList) removeNoLock(itemPtr uintptr) {
+	item := (*idleConnListItem)(unsafe.Pointer(itemPtr))
+
+	if item.prevItem != nil {
+		item.prevItem.nextItem = item.nextItem
+	} else {
+		l.firstItem = item.nextItem
+	}
+	if item.nextItem != nil {
+		item.nextItem.prevItem = item.prevItem
+	} else {
+		l.lastItem = item.prevItem
+	}
+	item.prevItem = nil
+	item.nextItem = nil
+}
+
+func (l *idleConnList) forEach(f func(item *idleConnListItem)) {
+	var nextItem *idleConnListItem
+
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	for item := l.firstItem; item != nil; item = nextItem {
+		nextItem = item.nextItem
+		f(item)
+	}
+}


### PR DESCRIPTION
Hi @erikdubbelboer, hope you are doing well.

This is a proposal for a change in how idle connections timeouts are handled.

As I suspected, the `v ;= &atomic.Int64{}` does an allocation but the Go test framework does not show it because the `testing.AllocsPerRun` does an integer division (the why is documented) and, because no parallel execution, that allocated atomic value is reused on each run (because of the pool).

Because all the serving is enclosed in a single function my proposal is the following:

1. A fixed set of double-linked list were added to the `Server` struct, in order to reduce the lock time on the `closeIdleConns` loop.
2. An entry is allocated on the stack with the connection and atomic int for the timestamp, and then added to the list. I'm using unsafe pointers on purpose to avoid the compiler assume the list item will escape.
3. The entry is removed from the list before the function exits.
4. I'm not removing the entry if the idle time times out. Closing the connection should be enough to break the main serve routine and, on exit, it will be removed. Also allows to avoid the extra "already removed" check.

I'm keeping the PR a work-in-progress until your feedback,

Kind regards,
Mauro.