### PR TITLE
Add support for streaming identity-encoded or unknown length response bodies

### DIFF
--- a/http.go
+++ b/http.go
@@ -1486,8 +1486,12 @@ func (resp *Response) ReadBody(r *bufio.Reader, maxBodySize int) (err error) {
 			bodyBuf.B, err = readBodyChunked(r, maxBodySize, bodyBuf.B)
 		}
 	default:
-		bodyBuf.B, err = readBodyIdentity(r, maxBodySize, bodyBuf.B)
-		resp.Header.SetContentLength(len(bodyBuf.B))
+		if resp.StreamBody {
+			resp.bodyStream = acquireRequestStream(bodyBuf, r, &resp.Header)
+		} else {
+			bodyBuf.B, err = readBodyIdentity(r, maxBodySize, bodyBuf.B)
+			resp.Header.SetContentLength(len(bodyBuf.B))
+		}
 	}
 	if err == nil && resp.StreamBody && resp.bodyStream == nil {
 		resp.bodyStream = bytes.NewReader(bodyBuf.B)

--- a/http_test.go
+++ b/http_test.go
@@ -3057,6 +3057,31 @@ func TestResponseBodyStream(t *testing.T) {
 				t.Fatalf("unexpected body content, got: %#v, want: %#v", string(content), "0123456789")
 			}
 		})
+
+		t.Run("identity", func(t *testing.T) {
+			t.Parallel()
+
+			client := Client{StreamResponseBody: true, DisablePathNormalizing: true}
+			resp := AcquireResponse()
+			request := AcquireRequest()
+			request.SetRequestURI(server.URL + "?400BadRequest")
+			if err := client.Do(request, resp); err != nil {
+				t.Fatal(err)
+			}
+			stream := resp.BodyStream()
+			defer func() {
+				if err := resp.CloseBodyStream(); err != nil {
+					t.Fatalf("close stream err: %v", err)
+				}
+			}()
+			content, err := io.ReadAll(stream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(content) != "400 Bad Request" {
+				t.Fatalf("unexpected body content, got: %#v, want: %#v", string(content), "400 Bad Request")
+			}
+		})
 	})
 }
 

--- a/streaming.go
+++ b/streaming.go
@@ -74,7 +74,7 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 		return n, err
 	}
 	left := rs.header.ContentLength() - rs.totalBytesRead
-	if len(p) > left {
+	if left > 0 && len(p) > left {
 		p = p[:left]
 	}
 	n, err = rs.reader.Read(p)


### PR DESCRIPTION
This change adds support for streaming response bodies when the `Transfer-Encoding` is identity (or when `Content-Length` is not provided).