### PR TITLE
modify `acceptConn` for `RIO`

### DIFF
--- a/server.go
+++ b/server.go
@@ -1979,6 +1979,12 @@ func (s *Server) ShutdownWithContext(ctx context.Context) (err error) {
 	}
 }
 
+type connKeepAliveer interface {
+	SetKeepAlive(keepalive bool) error
+	SetKeepAlivePeriod(d time.Duration) error
+	io.Closer
+}
+
 func acceptConn(s *Server, ln net.Listener, lastPerIPErrorTime *time.Time) (net.Conn, error) {
 	for {
 		c, err := ln.Accept()
@@ -1995,7 +2001,7 @@ func acceptConn(s *Server, ln net.Listener, lastPerIPErrorTime *time.Time) (net.
 			return nil, io.EOF
 		}
 
-		if tc, ok := c.(*net.TCPConn); ok && s.TCPKeepalive {
+		if tc, ok := c.(connKeepAliveer); ok && s.TCPKeepalive {
 			if err := tc.SetKeepAlive(s.TCPKeepalive); err != nil {
 				_ = tc.Close()
 				return nil, err


### PR DESCRIPTION
* add connKeepAliveer interface{}.
* use connKeepAliveer insteadof *net.TCPConn to set `TCPKeepalive` and `TCPKeepalivePeriod`.

I create a [rio](https://github.com/brickingsoft/rio) project, which is based on `IOURING`.

Because `rio.TCPConn` implmenets `net.Conn`, and has same functions as `net.TCPConn` had. 
For `rio` can be used as a network library for `FastHTTP`, so I create `connKeepAliveer` interface, use it to set `TCPKeepalive` and `TCPKeepalivePeriod`.

