### PR TITLE
feat: Add iter.Seq2 iterator

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -68,7 +68,7 @@ func TestArgsAdd(t *testing.T) {
 	}
 
 	var barFound, bazFound, oneFound, emptyFound1, emptyFound2, baFound bool
-	a1.VisitAll(func(k, v []byte) {
+	for k, v := range a1.All() {
 		switch string(k) {
 		case "foo":
 			switch string(v) {
@@ -95,7 +95,7 @@ func TestArgsAdd(t *testing.T) {
 		default:
 			t.Fatalf("unexpected key found %q", k)
 		}
-	})
+	}
 	if !barFound || !bazFound || !oneFound || !emptyFound1 || !emptyFound2 || !baFound {
 		t.Fatalf("something is missing: %v, %v, %v, %v, %v, %v", barFound, bazFound, oneFound, emptyFound1, emptyFound2, baFound)
 	}
@@ -329,9 +329,9 @@ func TestArgsCopyTo(t *testing.T) {
 
 func testCopyTo(t *testing.T, a *Args) {
 	keys := make(map[string]struct{})
-	a.VisitAll(func(k, _ []byte) {
+	for k := range a.All() {
 		keys[string(k)] = struct{}{}
-	})
+	}
 
 	var b Args
 	a.CopyTo(&b)
@@ -340,12 +340,12 @@ func testCopyTo(t *testing.T, a *Args) {
 		t.Fatalf("ArgsCopyTo fail, a: \n%+v\nb: \n%+v\n", a, &b)
 	}
 
-	b.VisitAll(func(k, _ []byte) {
+	for k := range b.All() {
 		if _, ok := keys[string(k)]; !ok {
 			t.Fatalf("unexpected key %q after copying from %q", k, a.String())
 		}
 		delete(keys, string(k))
-	})
+	}
 	if len(keys) > 0 {
 		t.Fatalf("missing keys %#v after copying from %q", keys, a.String())
 	}

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -51,7 +51,7 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 		}
 	}
 
-	ctx.Request.Header.VisitAll(func(k, v []byte) {
+	for k, v := range ctx.Request.Header.All() {
 		sk := b2s(k)
 		sv := b2s(v)
 
@@ -64,7 +64,7 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 			}
 			r.Header.Set(sk, sv)
 		}
-	})
+	}
 
 	return nil
 }

--- a/header_test.go
+++ b/header_test.go
@@ -171,9 +171,9 @@ func TestResponseHeaderMultiLineName(t *testing.T) {
 	header := new(ResponseHeader)
 	if _, err := header.parse([]byte(s)); err != errInvalidName {
 		m := make(map[string]string)
-		header.VisitAll(func(key, value []byte) {
-			m[string(key)] = string(value)
-		})
+		for k, v := range header.All() {
+			m[string(k)] = string(v)
+		}
 		t.Errorf("expected error, got %q (%v)", m, err)
 	}
 
@@ -530,7 +530,7 @@ func TestResponseHeaderAdd(t *testing.T) {
 		t.Fatalf("unexpected header len %d. Expecting 12", h.Len())
 	}
 
-	h.VisitAll(func(k, v []byte) {
+	for k, v := range h.All() {
 		switch string(k) {
 		case "Aaa", "Foo-Bar", "Content-Type":
 			if _, ok := m[string(v)]; !ok {
@@ -540,7 +540,7 @@ func TestResponseHeaderAdd(t *testing.T) {
 		default:
 			t.Fatalf("unexpected key found: %q", k)
 		}
-	})
+	}
 	if len(m) > 0 {
 		t.Fatalf("%d headers are missed", len(m))
 	}
@@ -552,14 +552,14 @@ func TestResponseHeaderAdd(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	h.VisitAll(func(k, v []byte) {
+	for k, v := range h.All() {
 		switch string(k) {
 		case "Aaa", "Foo-Bar", "Content-Type":
 			m[string(v)] = struct{}{}
 		default:
 			t.Fatalf("unexpected key found: %q", k)
 		}
-	})
+	}
 	if len(m) != 12 {
 		t.Fatalf("unexpected number of headers: %d. Expecting 12", len(m))
 	}
@@ -583,7 +583,7 @@ func TestRequestHeaderAdd(t *testing.T) {
 		t.Fatalf("unexpected header len %d. Expecting 12", h.Len())
 	}
 
-	h.VisitAll(func(k, v []byte) {
+	for k, v := range h.All() {
 		switch string(k) {
 		case "Aaa", "Foo-Bar", "User-Agent":
 			if _, ok := m[string(v)]; !ok {
@@ -593,7 +593,7 @@ func TestRequestHeaderAdd(t *testing.T) {
 		default:
 			t.Fatalf("unexpected key found: %q", k)
 		}
-	})
+	}
 	if len(m) > 0 {
 		t.Fatalf("%d headers are missed", len(m))
 	}
@@ -605,14 +605,14 @@ func TestRequestHeaderAdd(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	h.VisitAll(func(k, v []byte) {
+	for k, v := range h.All() {
 		switch string(k) {
 		case "Aaa", "Foo-Bar", "User-Agent":
 			m[string(v)] = struct{}{}
 		default:
 			t.Fatalf("unexpected key found: %q", k)
 		}
-	})
+	}
 	if len(m) != 12 {
 		t.Fatalf("unexpected number of headers: %d. Expecting 12", len(m))
 	}
@@ -1933,7 +1933,7 @@ func TestResponseHeaderCookie(t *testing.T) {
 		t.Fatalf("unexpected cookie\n%v\nExpected\n%v\n", &c, &expectedC2)
 	}
 
-	h.VisitAllCookie(func(key, value []byte) {
+	for key, value := range h.Cookies() {
 		var cc Cookie
 		if err := cc.ParseBytes(value); err != nil {
 			t.Fatal(err)
@@ -1953,7 +1953,7 @@ func TestResponseHeaderCookie(t *testing.T) {
 		default:
 			t.Fatalf("unexpected cookie key %q", key)
 		}
-	})
+	}
 
 	w := &bytes.Buffer{}
 	bw := bufio.NewWriter(w)
@@ -2094,11 +2094,12 @@ func TestResponseHeaderCookieIssue4(t *testing.T) {
 		t.Fatalf("Unexpected Set-Cookie header %q. Expected %q", h.Peek(HeaderSetCookie), "foo=bar")
 	}
 	cookieSeen := false
-	h.VisitAll(func(key, _ []byte) {
+	for key := range h.All() {
 		if string(key) == HeaderSetCookie {
 			cookieSeen = true
+			break
 		}
-	})
+	}
 	if !cookieSeen {
 		t.Fatalf("Set-Cookie not present in VisitAll")
 	}
@@ -2114,11 +2115,12 @@ func TestResponseHeaderCookieIssue4(t *testing.T) {
 		t.Fatalf("Unexpected Set-Cookie header %q. Expected %q", h.Peek(HeaderSetCookie), "foo=bar")
 	}
 	cookieSeen = false
-	h.VisitAll(func(key, _ []byte) {
+	for key := range h.All() {
 		if string(key) == HeaderSetCookie {
 			cookieSeen = true
+			break
 		}
-	})
+	}
 	if !cookieSeen {
 		t.Fatalf("Set-Cookie not present in VisitAll")
 	}
@@ -2137,11 +2139,12 @@ func TestRequestHeaderCookieIssue313(t *testing.T) {
 		t.Fatalf("Unexpected Cookie header %q. Expected %q", h.Peek(HeaderCookie), "foo=bar")
 	}
 	cookieSeen := false
-	h.VisitAll(func(key, _ []byte) {
+	for key := range h.All() {
 		if string(key) == HeaderCookie {
 			cookieSeen = true
+			break
 		}
-	})
+	}
 	if !cookieSeen {
 		t.Fatalf("Cookie not present in VisitAll")
 	}
@@ -2154,11 +2157,12 @@ func TestRequestHeaderCookieIssue313(t *testing.T) {
 		t.Fatalf("Unexpected Cookie header %q. Expected %q", h.Peek(HeaderCookie), "foo=bar")
 	}
 	cookieSeen = false
-	h.VisitAll(func(key, _ []byte) {
+	for key := range h.All() {
 		if string(key) == HeaderCookie {
 			cookieSeen = true
+			break
 		}
-	})
+	}
 	if !cookieSeen {
 		t.Fatalf("Cookie not present in VisitAll")
 	}


### PR DESCRIPTION
Resolves #2010

Create iterator for 
+ `Args.VisitAll` → `Args.All`
+ `ResponseHeader.VisitAll` → `ResponseHeader.All`
+ `ResponseHeader.VisitAllTrailer` → `ResponseHeader.Trailers`
+ `ResponseHeader.VisitAllCookie` → `ResponseHeader.Cookies`
+ `RequestHeader.VisitAll` → `RequestHeader.All`
+ `RequestHeader.VisitAllTrailer` → `RequestHeader.Trailers`
+ `RequestHeader.VisitAllCookie` → `RequestHeader.Cookies`
+ `RequestHeader.VisitAllInOrder` → `RequestHeader.AllInOrder`