### PR TITLE
add helper functions to allow set time or conntime (useful in tests)

### DIFF
--- a/server.go
+++ b/server.go
@@ -3047,3 +3047,23 @@ var stateName = []string{
 func (c ConnState) String() string {
 	return stateName[c]
 }
+
+// RequestCtxSwapTime is a helper function that allows swap the request time,
+// returning the old value.
+func RequestCtxSwapTime(ctx *RequestCtx, time time.Time) time.Time {
+	old := ctx.Time()
+
+	ctx.time = time
+
+	return old
+}
+
+// RequestCtxSwapConnTime is a helper function that allows swap the connection time,
+// returning the old value.
+func RequestCtxSwapConnTime(ctx *RequestCtx, connTime time.Time) time.Time {
+	old := ctx.ConnTime()
+
+	ctx.connTime = connTime
+
+	return old
+}

--- a/server_test.go
+++ b/server_test.go
@@ -4471,3 +4471,45 @@ func TestRequestCtxInitShouldNotBeCanceledIssue1879(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRequestCtxSwapTime(t *testing.T) {
+	var r Request
+	var requestCtx RequestCtx
+
+	requestCtx.Init(&r, nil, nil)
+
+	now := time.Date(2025, 6, 20, 0, 0, 0, 0, time.UTC)
+
+	previousRequestCtxTime := RequestCtxSwapTime(&requestCtx, now)
+
+	if !previousRequestCtxTime.IsZero() {
+		t.Fatalf("request ctx time after init should be zero, instead %v", previousRequestCtxTime)
+	}
+
+	requestCtxTime := requestCtx.Time()
+
+	if requestCtxTime != now {
+		t.Fatalf("request ctx time should be 2025/06/20, instead %v", requestCtxTime)
+	}
+}
+
+func TestRequestCtxSwapConnTime(t *testing.T) {
+	var r Request
+	var requestCtx RequestCtx
+
+	requestCtx.Init(&r, nil, nil)
+
+	now := time.Date(2025, 6, 20, 0, 0, 0, 0, time.UTC)
+
+	previousRequestCtxConnTime := RequestCtxSwapConnTime(&requestCtx, now)
+
+	if previousRequestCtxConnTime.IsZero() {
+		t.Fatalf("request ctx conn time after init should be zero, instead %v", previousRequestCtxConnTime)
+	}
+
+	connTime := requestCtx.ConnTime()
+
+	if connTime != now {
+		t.Fatalf("request ctx conn time should be 2025/06/20, instead %v", connTime)
+	}
+}


### PR DESCRIPTION
On my programs, sometimes I need to fetch the fasthttp.RequestCtx Time (or ConnTime) and if I need to test it properly I need to inject some fake time.

Since time is a private field, I add two helper functions that can swap the content of each attribute.

I call it `RequestCtxSwapTime` because it return the previous value, to be restored if needed.

I think the usage of this feature will be very limited, but it will work for me :)