### PR TITLE
Add reuseport support for Solaris

### DIFF
--- a/reuseport/reuseport.go
+++ b/reuseport/reuseport.go
@@ -1,4 +1,4 @@
-//go:build !windows && !aix
+//go:build !windows && !aix && !solaris
 
 // Package reuseport provides TCP net.Listener with SO_REUSEPORT support.
 //

--- a/reuseport/reuseport_solaris.go
+++ b/reuseport/reuseport_solaris.go
@@ -1,0 +1,31 @@
+//go:build solaris
+
+package reuseport
+
+import (
+	"context"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	_SO_REUSEPORT = 0x100e
+)
+
+var listenConfig = net.ListenConfig{
+	Control: func(network, address string, c syscall.RawConn) (err error) {
+		return c.Control(func(fd uintptr) {
+			err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+			if err == nil {
+				err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, _SO_REUSEPORT, 1)
+			}
+		})
+	},
+}
+
+// Listen returns a TCP listener with the SO_REUSEADDR and SO_REUSEPORT options set.
+func Listen(network, addr string) (net.Listener, error) {
+	return listenConfig.Listen(context.Background(), network, addr)
+}


### PR DESCRIPTION
Copied from reuseport_aix.go to reuseport_solaris.go

SO_REUSEPORT is works on Solaris, but fails on illumos as intended.
I choose to avoid using tcplisten, because the unix.Listen from golang.org/x/sys/unix is currently broken.