### PR TITLE
test: replace atomic operations with atomic types

### DIFF
--- a/client_timing_test.go
+++ b/client_timing_test.go
@@ -101,9 +101,9 @@ func BenchmarkClientGetTimeoutFastServer(b *testing.B) {
 		},
 	}
 
-	nn := uint32(0)
+	var nn atomic.Uint32
 	b.RunParallel(func(pb *testing.PB) {
-		url := fmt.Sprintf("http://foobar%d.com/aaa/bbb", atomic.AddUint32(&nn, 1))
+		url := fmt.Sprintf("http://foobar%d.com/aaa/bbb", nn.Add(1))
 		var statusCode int
 		var bodyBuf []byte
 		var err error
@@ -132,11 +132,11 @@ func BenchmarkClientDoFastServer(b *testing.B) {
 		MaxConnsPerHost: runtime.GOMAXPROCS(-1),
 	}
 
-	nn := uint32(0)
+	var nn atomic.Uint32
 	b.RunParallel(func(pb *testing.PB) {
 		var req Request
 		var resp Response
-		req.Header.SetRequestURI(fmt.Sprintf("http://foobar%d.com/aaa/bbb", atomic.AddUint32(&nn, 1)))
+		req.Header.SetRequestURI(fmt.Sprintf("http://foobar%d.com/aaa/bbb", nn.Add(1)))
 		for pb.Next() {
 			if err := c.Do(&req, &resp); err != nil {
 				b.Fatalf("unexpected error: %v", err)
@@ -163,9 +163,9 @@ func BenchmarkNetHTTPClientDoFastServer(b *testing.B) {
 		},
 	}
 
-	nn := uint32(0)
+	var nn atomic.Uint32
 	b.RunParallel(func(pb *testing.PB) {
-		req, err := http.NewRequest(MethodGet, fmt.Sprintf("http://foobar%d.com/aaa/bbb", atomic.AddUint32(&nn, 1)), http.NoBody)
+		req, err := http.NewRequest(MethodGet, fmt.Sprintf("http://foobar%d.com/aaa/bbb", nn.Add(1)), http.NoBody)
 		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}

--- a/coarsetime_test.go
+++ b/coarsetime_test.go
@@ -7,31 +7,31 @@ import (
 )
 
 func BenchmarkCoarseTimeNow(b *testing.B) {
-	var zeroTimeCount uint64
+	var zeroTimeCount atomic.Uint64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			t := CoarseTimeNow()
 			if t.IsZero() {
-				atomic.AddUint64(&zeroTimeCount, 1)
+				zeroTimeCount.Add(1)
 			}
 		}
 	})
-	if zeroTimeCount > 0 {
+	if zeroTimeCount.Load() > 0 {
 		b.Fatalf("zeroTimeCount must be zero")
 	}
 }
 
 func BenchmarkTimeNow(b *testing.B) {
-	var zeroTimeCount uint64
+	var zeroTimeCount atomic.Uint64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			t := time.Now()
 			if t.IsZero() {
-				atomic.AddUint64(&zeroTimeCount, 1)
+				zeroTimeCount.Add(1)
 			}
 		}
 	})
-	if zeroTimeCount > 0 {
+	if zeroTimeCount.Load() > 0 {
 		b.Fatalf("zeroTimeCount must be zero")
 	}
 }

--- a/stackless/func_test.go
+++ b/stackless/func_test.go
@@ -10,9 +10,9 @@ import (
 func TestNewFuncSimple(t *testing.T) {
 	t.Parallel()
 
-	var n uint64
+	var n atomic.Uint64
 	f := NewFunc(func(ctx any) {
-		atomic.AddUint64(&n, uint64(ctx.(int)))
+		n.Add(uint64(ctx.(int)))
 	})
 
 	iterations := 4 * 1024
@@ -21,20 +21,20 @@ func TestNewFuncSimple(t *testing.T) {
 			t.Fatalf("f mustn't return false")
 		}
 	}
-	if n != uint64(2*iterations) {
-		t.Fatalf("Unexpected n: %d. Expecting %d", n, 2*iterations)
+	if got := n.Load(); got != uint64(2*iterations) {
+		t.Fatalf("Unexpected n: %d. Expecting %d", got, 2*iterations)
 	}
 }
 
 func TestNewFuncMulti(t *testing.T) {
 	t.Parallel()
 
-	var n1, n2 uint64
+	var n1, n2 atomic.Uint64
 	f1 := NewFunc(func(ctx any) {
-		atomic.AddUint64(&n1, uint64(ctx.(int)))
+		n1.Add(uint64(ctx.(int)))
 	})
 	f2 := NewFunc(func(ctx any) {
-		atomic.AddUint64(&n2, uint64(ctx.(int)))
+		n2.Add(uint64(ctx.(int)))
 	})
 
 	iterations := 4 * 1024
@@ -81,10 +81,10 @@ func TestNewFuncMulti(t *testing.T) {
 		t.Fatalf("timeout")
 	}
 
-	if n1 != uint64(3*iterations) {
-		t.Fatalf("unexpected n1: %d. Expecting %d", n1, 3*iterations)
+	if got1 := n1.Load(); got1 != uint64(3*iterations) {
+		t.Fatalf("unexpected n1: %d. Expecting %d", got1, 3*iterations)
 	}
-	if n2 != uint64(5*iterations) {
-		t.Fatalf("unexpected n2: %d. Expecting %d", n2, 5*iterations)
+	if got2 := n2.Load(); got2 != uint64(5*iterations) {
+		t.Fatalf("unexpected n2: %d. Expecting %d", got2, 5*iterations)
 	}
 }

--- a/stackless/func_timing_test.go
+++ b/stackless/func_timing_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func BenchmarkFuncOverhead(b *testing.B) {
-	var n uint64
+	var n atomic.Uint64
 	f := NewFunc(func(ctx any) {
-		atomic.AddUint64(&n, *(ctx.(*uint64)))
+		n.Add(*(ctx.(*uint64)))
 	})
 	b.RunParallel(func(pb *testing.PB) {
 		x := uint64(1)
@@ -18,15 +18,15 @@ func BenchmarkFuncOverhead(b *testing.B) {
 			}
 		}
 	})
-	if n != uint64(b.N) {
-		b.Fatalf("unexpected n: %d. Expecting %d", n, b.N)
+	if got := n.Load(); got != uint64(b.N) {
+		b.Fatalf("unexpected n: %d. Expecting %d", got, b.N)
 	}
 }
 
 func BenchmarkFuncPure(b *testing.B) {
-	var n uint64
+	var n atomic.Uint64
 	f := func(x *uint64) {
-		atomic.AddUint64(&n, *x)
+		n.Add(*x)
 	}
 	b.RunParallel(func(pb *testing.PB) {
 		x := uint64(1)
@@ -34,7 +34,7 @@ func BenchmarkFuncPure(b *testing.B) {
 			f(&x)
 		}
 	})
-	if n != uint64(b.N) {
-		b.Fatalf("unexpected n: %d. Expecting %d", n, b.N)
+	if got := n.Load(); got != uint64(b.N) {
+		b.Fatalf("unexpected n: %d. Expecting %d", got, b.N)
 	}
 }


### PR DESCRIPTION
This PR replaces atomic operations with atomic types for more type safety, better semantics, and clearer intent. Changes are done only in tests.

See https://cuonglm.xyz/post/go119_atomic_types/