### PR TITLE
Add flushing support to fasthttpadaptor

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -56,42 +56,166 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 			ctx.Error("Internal Server Error", fasthttp.StatusInternalServerError)
 			return
 		}
-		w := netHTTPResponseWriter{
-			w:   ctx.Response.BodyWriter(),
-			ctx: ctx,
-		}
-		h.ServeHTTP(&w, r.WithContext(ctx))
+		w := newNetHTTPResponseWriter(ctx)
 
-		ctx.SetStatusCode(w.StatusCode())
-		haveContentType := false
-		for k, vv := range w.Header() {
-			if k == fasthttp.HeaderContentType {
-				haveContentType = true
+		// Concurrently serve the net/http handler.
+		doneCh := make(chan struct{})
+		go func() {
+			defer func() {
+				close(doneCh)
+				_ = w.Close()
+			}()
+			h.ServeHTTP(w, r.WithContext(ctx))
+		}()
+
+		select {
+		case <-doneCh:
+			// No flush occured before the handler returned.
+			// Send the data as one chunk.
+			ctx.SetStatusCode(w.StatusCode())
+			haveContentType := false
+			for k, vv := range w.Header() {
+				if k == fasthttp.HeaderContentType {
+					haveContentType = true
+				}
+
+				for _, v := range vv {
+					ctx.Response.Header.Add(k, v)
+				}
 			}
 
-			for _, v := range vv {
-				ctx.Response.Header.Add(k, v)
+			if !haveContentType {
+				// From net/http.ResponseWriter.Write:
+				// If the Header does not contain a Content-Type line, Write adds a Content-Type set
+				// to the result of passing the initial 512 bytes of written data to DetectContentType.
+				l := 512
+				b := w.firstChunk
+				if len(b) < 512 {
+					l = len(b)
+				}
+				ctx.Response.Header.Set(fasthttp.HeaderContentType, http.DetectContentType(b[:l]))
 			}
-		}
-		if !haveContentType {
-			// From net/http.ResponseWriter.Write:
-			// If the Header does not contain a Content-Type line, Write adds a Content-Type set
-			// to the result of passing the initial 512 bytes of written data to DetectContentType.
-			l := 512
-			b := ctx.Response.Body()
-			if len(b) < 512 {
-				l = len(b)
+
+			if len(w.firstChunk) > 0 {
+				ctx.Response.SetBodyRaw(append([]byte(nil), w.firstChunk...))
 			}
-			ctx.Response.Header.Set(fasthttp.HeaderContentType, http.DetectContentType(b[:l]))
+
+		case <-w.flushedCh:
+			// Flush occured before handler returned.
+			// Send the first 512 bytes and start streaming
+			// the rest of the first chunk and new data as it arrives.
+			ctx.SetStatusCode(w.StatusCode())
+			haveContentType := false
+			for k, vv := range w.Header() {
+				// Don't copy Content-Length header when
+				// streaming.
+				if k == fasthttp.HeaderContentLength {
+					continue
+				}
+
+				if k == fasthttp.HeaderContentType {
+					haveContentType = true
+				}
+
+				for _, v := range vv {
+					ctx.Response.Header.Add(k, v)
+				}
+			}
+
+			if !haveContentType {
+				// From net/http.ResponseWriter.Write:
+				// If the Header does not contain a Content-Type line, Write adds a Content-Type set
+				// to the result of passing the initial 512 bytes of written data to DetectContentType.
+				l := 512
+				b := w.firstChunk
+				if len(b) < 512 {
+					l = len(b)
+				}
+				ctx.Response.Header.Set(fasthttp.HeaderContentType, http.DetectContentType(b[:l]))
+			}
+
+			// Start streaming mode on return.
+			ctx.SetBodyStreamWriter(func(bw *bufio.Writer) {
+				// Stream the first chunk.
+				if len(w.firstChunk) > 0 {
+					_, _ = bw.Write(w.firstChunk)
+					_ = bw.Flush()
+					w.firstChunk = nil
+				}
+
+				// Stream the rest of the data that is read
+				// from the net/http handler in 32 KiB chunks.
+				//
+				// Note: Data must be manually copied in chunks
+				// as data comes in.
+				chunk := make([]byte, 32*1024)
+				for {
+					// Read net/http handler chunk.
+					n, err := w.r.Read(chunk)
+					if err != nil {
+						// Handler ended due to an io.EOF
+						// or an error occured.
+						return
+					}
+
+					// Copy chunk to fasthttp response
+					if n > 0 {
+						_, _ = bw.Write(chunk[:n])
+						_ = bw.Flush()
+					}
+				}
+			})
+			close(w.streamingCh)
+
+		case <-w.hijackedCh:
+			// The net/http handler called w.Hijack().
+			// Copy data bidirectionally between the
+			// net/http and fasthttp connections.
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			// Note: It is safe to assume that net.Conn automatically
+			// flushes data while copying.
+			go func() {
+				defer wg.Done()
+				_, _ = io.Copy(ctx.Conn(), w.handlerConn)
+				_ = ctx.Conn().Close()
+			}()
+			go func() {
+				defer wg.Done()
+				_, _ = io.Copy(w.handlerConn, ctx.Conn())
+				_ = w.handlerConn.Close()
+			}()
+
+			wg.Wait()
 		}
 	}
 }
 
 type netHTTPResponseWriter struct {
-	w          io.Writer
-	h          http.Header
-	ctx        *fasthttp.RequestCtx
-	statusCode int
+	handlerConn net.Conn
+	ctx         *fasthttp.RequestCtx
+	h           http.Header
+	r           *io.PipeReader
+	w           *io.PipeWriter
+	flushedCh   chan struct{}
+	streamingCh chan struct{}
+	hijackedCh  chan struct{}
+	firstChunk  []byte
+	statusCode  int
+}
+
+func newNetHTTPResponseWriter(ctx *fasthttp.RequestCtx) *netHTTPResponseWriter {
+	pr, pw := io.Pipe()
+	return &netHTTPResponseWriter{
+		ctx:         ctx,
+		h:           make(http.Header),
+		r:           pr,
+		w:           pw,
+		flushedCh:   make(chan struct{}),
+		streamingCh: make(chan struct{}),
+		hijackedCh:  make(chan struct{}),
+	}
 }
 
 func (w *netHTTPResponseWriter) StatusCode() int {
@@ -102,9 +226,6 @@ func (w *netHTTPResponseWriter) StatusCode() int {
 }
 
 func (w *netHTTPResponseWriter) Header() http.Header {
-	if w.h == nil {
-		w.h = make(http.Header)
-	}
 	return w.h
 }
 
@@ -113,24 +234,29 @@ func (w *netHTTPResponseWriter) WriteHeader(statusCode int) {
 }
 
 func (w *netHTTPResponseWriter) Write(p []byte) (int, error) {
-	return w.w.Write(p)
+	select {
+	case <-w.streamingCh:
+		// Streaming mode is on.
+		// Stream directly to the conn writer.
+		return w.w.Write(p)
+	default:
+		// Streaming mode is off.
+		// Write to the first chunk for flushing later.
+		w.firstChunk = append(w.firstChunk, p...)
+		return len(p), nil
+	}
 }
 
-func (w *netHTTPResponseWriter) Flush() {}
+func (w *netHTTPResponseWriter) Flush() {
+	// Trigger streaming mode setup.
+	select {
+	case <-w.flushedCh:
+	default:
+		close(w.flushedCh)
+	}
 
-type wrappedConn struct {
-	net.Conn
-
-	wg   sync.WaitGroup
-	once sync.Once
-}
-
-func (c *wrappedConn) Close() (err error) {
-	c.once.Do(func() {
-		err = c.Conn.Close()
-		c.wg.Done()
-	})
-	return
+	// Wait for streaming mode.
+	<-w.streamingCh
 }
 
 func (w *netHTTPResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
@@ -138,22 +264,26 @@ func (w *netHTTPResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	// doing anything else with it.
 	w.ctx.HijackSetNoResponse(true)
 
-	conn := &wrappedConn{Conn: w.ctx.Conn()}
-	conn.wg.Add(1)
-	w.ctx.Hijack(func(net.Conn) {
-		conn.wg.Wait()
-	})
+	netHTTPConn, fasthttpConn := net.Pipe()
+	w.handlerConn = fasthttpConn
 
-	bufW := bufio.NewWriter(conn)
-
-	// Write any unflushed body to the hijacked connection buffer.
-	unflushedBody := w.ctx.Response.Body()
-	if len(unflushedBody) > 0 {
-		if _, err := bufW.Write(unflushedBody); err != nil {
-			conn.Close()
-			return nil, nil, err
-		}
+	// Trigger hijacked mode.
+	select {
+	case <-w.hijackedCh:
+	default:
+		close(w.hijackedCh)
 	}
 
-	return conn, &bufio.ReadWriter{Reader: bufio.NewReader(conn), Writer: bufW}, nil
+	bufW := bufio.NewReadWriter(bufio.NewReader(netHTTPConn), bufio.NewWriter(netHTTPConn))
+
+	// Write any unflushed body to the hijacked connection buffer.
+	if len(w.firstChunk) > 0 {
+		_, _ = bufW.Write(w.firstChunk)
+		w.firstChunk = nil
+	}
+	return netHTTPConn, bufW, nil
+}
+
+func (w *netHTTPResponseWriter) Close() error {
+	return w.w.Close()
 }


### PR DESCRIPTION
### Description

Currently, `fasthttpadaptor` runs the net/http handler fully first, then copies the response to a fasthttp response object and returns. This makes it incompatible with net/http handlers that may rely on instantly flushing to the client (e.g. Live Data Streams, SSE events).

This PR adds support flushing by concurrently handling the net/http handler and copy chunks of data to the fasthttp response after a flush occurs. If the response is never flushed, the `fasthttpadaptor` can follow its old behavior and send the data as a single chunk for efficiency.

The PR also adds a few new test cases to ensure that flushed data is received if the client connection closes before the full response is sent.

Fixes: #2053 
Related: https://github.com/gofiber/fiber/issues/3421

### Additional Comments

This feature will help close a major gap in fasthttp's `net/http` support, which is a main barrier of adoption for `fasthttp`. Flushing support would enable more `net/http` handlers to work with minimal overhead.