### PR TITLE
docs: add fasthttp-auth to related projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ This is an **unsafe** way, the result string and `[]byte` buffer share the same 
 - [http2](https://github.com/dgrr/http2) - HTTP/2 implementation for fasthttp.
 - [router](https://github.com/fasthttp/router) - a high
   performance fasthttp request router that scales well.
+- [fasthttp-auth](https://github.com/casbin/fasthttp-auth) - Authorization middleware for fasthttp using Casbin.
 - [fastws](https://github.com/fasthttp/fastws) - Bloatless WebSocket package made for fasthttp
   to handle Read/Write operations concurrently.
 - [gramework](https://github.com/gramework/gramework) - a web framework made by one of fasthttp maintainers.


### PR DESCRIPTION
# docs: add fasthttp-auth to related projects section

## Description

Adds [fasthttp-auth](https://github.com/casbin/fasthttp-auth) to the Related projects section in README.md.

## About Casbin

[Casbin](https://github.com/casbin/casbin) is the most popular authorization library for Go with 400+ integrations across different frameworks and platforms.

## About fasthttp-auth

[fasthttp-auth](https://github.com/casbin/fasthttp-auth) provides authorization middleware for fasthttp using Casbin, enabling developers to easily implement access control in their fasthttp applications.


## Type

Documentation update - no functional changes
