### PR TITLE
Add Body() warnings for streaming bodies in server context

### DIFF
--- a/server.go
+++ b/server.go
@@ -2768,6 +2768,10 @@ func (s *Server) acquireCtx(c net.Conn) (ctx *RequestCtx) {
 	}
 	ctx.c = c
 
+	// Inject server logger for Body() warning messages
+	ctx.Request.serverLogger = s.Logger
+	ctx.Response.serverLogger = s.Logger
+
 	return ctx
 }
 


### PR DESCRIPTION
Addresses issue #1765 by logging warnings when Request.Body() or Response.Body() methods read from bodyStream in server context, which can cause OOM attacks by reading unlimited stream data into memory via copyZeroAlloc().

Changes:
- Add private serverLogger field to Request and Response structs
- Inject server logger reference in Server.acquireCtx() for context detection
- Add warnings in Response.Body() and Request.bodyBytes() when bodyStream != nil
- Clear logger references in Reset() methods for proper cleanup
- Add TestServerBodyWarning test to verify streaming body warnings

The warnings only appear when:
1. Body() is called in server context (serverLogger reference exists)
2. Body() attempts to read entire stream into memory (bodyStream != nil + copyZeroAlloc)

Normal body usage and client-side calls remain unaffected. This encourages safer BodyStream() usage without breaking compatibility.