### PR TITLE
Reject backslash absolute URIs and cache parse errors

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -155,7 +155,8 @@ func testRequestCopyTo(t *testing.T, src *Request) {
 	var dst Request
 	src.CopyTo(&dst)
 
-	if !reflect.DeepEqual(src, &dst) {
+	// Compare serialized representations.
+	if src.String() != dst.String() || !bytes.Equal(src.Body(), dst.Body()) {
 		t.Fatalf("RequestCopyTo fail, src: \n%+v\ndst: \n%+v\n", src, &dst)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -2349,11 +2349,21 @@ func (s *Server) serveConn(c net.Conn) error {
 						writeTimeout = s.WriteTimeout
 					}
 				}
-				// read body
-				if s.StreamRequestBody {
-					err = ctx.Request.readBodyStream(br, maxRequestBodySize, s.GetOnly, !s.DisablePreParseMultipartForm)
-				} else {
-					err = ctx.Request.readLimitBody(br, maxRequestBodySize, s.GetOnly, !s.DisablePreParseMultipartForm)
+
+				if err == nil {
+					if err = ctx.Request.parseURI(); err != nil {
+						bw = s.writeErrorResponse(bw, ctx, serverName, err)
+						break
+					}
+				}
+
+				if err == nil {
+					// read body
+					if s.StreamRequestBody {
+						err = ctx.Request.readBodyStream(br, maxRequestBodySize, s.GetOnly, !s.DisablePreParseMultipartForm)
+					} else {
+						err = ctx.Request.readLimitBody(br, maxRequestBodySize, s.GetOnly, !s.DisablePreParseMultipartForm)
+					}
 				}
 			}
 			// When StreamRequestBody is set to true, we cannot safely release br.


### PR DESCRIPTION
Keep our server behaviour the same as net/http.