### PR TITLE
Reduce allocations in copyTrailer (saves ~43% time)

### DIFF
--- a/header.go
+++ b/header.go
@@ -3359,9 +3359,18 @@ func copyTrailer(dst, src [][]byte) [][]byte {
 		dst = append(dst[:0], src...)
 	}
 
+	var totalSrcLen int
 	for i := range dst {
-		dst[i] = make([]byte, len(src[i]))
-		copy(dst[i], src[i])
+		totalSrcLen += len(src[i])
+	}
+
+	// allocating single buffer for all trailer values
+	buf := make([]byte, totalSrcLen)
+	bufPos := 0
+	for i := range dst {
+		n := copy(buf[bufPos:], src[i])
+		dst[i] = buf[bufPos : bufPos+n : bufPos+n]
+		bufPos += n
 	}
 	return dst
 }


### PR DESCRIPTION
```bash
 benchstat old.txt new.txt 
goos: darwin
goarch: arm64
pkg: github.com/valyala/fasthttp
cpu: Apple M3 Max
               │   old.txt   │               new.txt               │
               │   sec/op    │   sec/op     vs base                │
CopyTrailer-16   260.6n ± 1%   147.5n ± 0%  -43.42% (p=0.000 n=20)

               │   old.txt    │               new.txt               │
               │     B/op     │     B/op      vs base               │
CopyTrailer-16   1.109Ki ± 0%   1.125Ki ± 0%  +1.41% (p=0.000 n=20)

               │   old.txt   │              new.txt               │
               │  allocs/op  │ allocs/op   vs base                │
CopyTrailer-16   16.000 ± 0%   1.000 ± 0%  -93.75% (p=0.000 n=20)
```