### PR TITLE
 Issue #1699

### DIFF
--- a/examples/conn_user_value/main.go
+++ b/examples/conn_user_value/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync/atomic"
+
+	"github.com/valyala/fasthttp"
+)
+
+// Rate limiter using connection-level user value
+func rateLimitHandler(ctx *fasthttp.RequestCtx) {
+	// Get current request count for this connection
+	currentCount := ctx.ConnUserValueUint64()
+	
+	// Increment counter atomically
+	newCount := atomic.AddUint64(&currentCount, 1)
+	ctx.SetConnUserValueUint64(newCount)
+	
+	// Rate limit: max 10 requests per connection
+	if newCount > 10 {
+		ctx.SetStatusCode(fasthttp.StatusTooManyRequests)
+		ctx.SetBodyString("Rate limit exceeded: max 10 requests per connection")
+		return
+	}
+	
+	// Normal response
+	ctx.SetContentType("text/plain")
+	fmt.Fprintf(ctx, "Request #%d from connection %d\n", newCount, ctx.ConnID())
+}
+
+func main() {
+	log.Println("Starting server on :9999")
+	log.Println("Try: curl -H 'Connection: keep-alive' localhost:9999 multiple times")
+	
+	if err := fasthttp.ListenAndServe(":9999", rateLimitHandler); err != nil {
+		log.Fatalf("Error in ListenAndServe: %s", err)
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -4514,3 +4514,48 @@ func TestRequestCtxInitShouldNotBeCanceledIssue1879(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRequestCtxConnUserValue(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		var ctx RequestCtx
+		
+		if val := ctx.ConnUserValue(); val != nil {
+			t.Fatalf("expected nil, got %v", val)
+		}
+		
+		testStr := "test-value"
+		ctx.SetConnUserValue(testStr)
+		if val := ctx.ConnUserValue(); val != testStr {
+			t.Fatalf("expected %q, got %v", testStr, val)
+		}
+		
+		if val := ctx.ConnUserValueUint64(); val != 0 {
+			t.Fatalf("expected 0 for non-uint64 value, got %d", val)
+		}
+	})
+	
+	// Test uint64 values 
+	t.Run("uint64", func(t *testing.T) {
+		var ctx RequestCtx
+		
+		var testUint uint64 = 42
+		ctx.SetConnUserValueUint64(testUint)
+		if val := ctx.ConnUserValueUint64(); val != testUint {
+			t.Fatalf("expected %d, got %d", testUint, val)
+		}
+		
+		if val := ctx.ConnUserValue(); val != testUint {
+			t.Fatalf("expected %d, got %v", testUint, val)
+		}
+	})
+	
+	// Test reset functionality
+	t.Run("reset", func(t *testing.T) {
+		var ctx RequestCtx
+		ctx.SetConnUserValue("test")
+		ctx.reset()
+		if val := ctx.ConnUserValue(); val != nil {
+			t.Fatalf("expected nil after reset, got %v", val)
+		}
+	})
+}


### PR DESCRIPTION
Implement connection-level user value management in RequestCtx

- Added methods to set and retrieve connection-level user values, including support for uint64 values.
- Implemented reset functionality to clear connection user values.
- Introduced a new example demonstrating rate limiting using connection-level user values.