### PR TITLE
Add ConvertNetHttpRequestToFastHttpRequest adaptor function

### DIFF
--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -96,11 +96,7 @@ func ConvertNetHttpRequestToFastHttpRequest(r *http.Request, ctx *fasthttp.Reque
 	}
 
 	if r.Body != nil {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			return err
-		}
-		ctx.Request.SetBody(body)
+		ctx.Request.SetBodyStream(r.Body, int(r.ContentLength))
 	}
 
 	if r.RemoteAddr != "" {

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -71,8 +71,23 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 	return nil
 }
 
-// ConvertNetHttpToFastHttp converts an http.Request to a fasthttp.RequestCtx.
-// The caller is responsible for the lifecycle of the fasthttp.RequestCtx.
+// ConvertNetHttpRequestToFastHttpRequest converts an http.Request to a fasthttp.RequestCtx.
+//
+// The caller is responsible for the lifecycle of the fasthttp.RequestCtx and the
+// underlying fasthttp.Request. The ctx (and its Request) must only be used for
+// the duration that fasthttp considers it valid (typically within a handler),
+// and must not be accessed after the handler has returned.
+//
+// The request body is not copied. If r.Body is non-nil, it is passed directly to
+// ctx.Request via SetBodyStream. This means:
+//   - r.Body must remain readable for as long as ctx may need to read it.
+//   - r.Body should not be read from, written to, or closed by the caller until
+//     fasthttp is done with ctx.
+//   - The same r.Body must not be reused concurrently in other goroutines while
+//     it is attached to ctx.Request.
+//
+// After calling this function, you should treat r.Body as effectively owned by
+// ctx.Request for the lifetime of that context.
 func ConvertNetHttpRequestToFastHttpRequest(r *http.Request, ctx *fasthttp.RequestCtx) {
 	ctx.Request.Header.SetMethod(r.Method)
 
@@ -103,18 +118,21 @@ func ConvertNetHttpRequestToFastHttpRequest(r *http.Request, ctx *fasthttp.Reque
 		addr := parseRemoteAddr(r.RemoteAddr)
 		ctx.SetRemoteAddr(addr)
 	}
-
 }
 
 func parseRemoteAddr(addr string) net.Addr {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return &net.TCPAddr{IP: net.ParseIP(addr)}
+	if tcpAddr, err := net.ResolveTCPAddr("tcp", addr); err == nil {
+		return tcpAddr
 	}
-	return &net.TCPAddr{
-		IP:   net.ParseIP(host),
-		Port: parsePort(port),
+
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		if tcpAddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(addr, "0")); err == nil {
+			return tcpAddr
+		}
 	}
+
+	host := strings.Trim(addr, "[]")
+	return &net.TCPAddr{IP: net.ParseIP(host)}
 }
 
 func parsePort(port string) int {

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -73,7 +73,7 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 
 // ConvertNetHttpToFastHttp converts an http.Request to a fasthttp.RequestCtx.
 // The caller is responsible for the lifecycle of the fasthttp.RequestCtx.
-func ConvertNetHttpRequestToFastHttpRequest(r *http.Request, ctx *fasthttp.RequestCtx) error {
+func ConvertNetHttpRequestToFastHttpRequest(r *http.Request, ctx *fasthttp.RequestCtx) {
 	ctx.Request.Header.SetMethod(r.Method)
 
 	if r.RequestURI != "" {
@@ -104,7 +104,6 @@ func ConvertNetHttpRequestToFastHttpRequest(r *http.Request, ctx *fasthttp.Reque
 		ctx.SetRemoteAddr(addr)
 	}
 
-	return nil
 }
 
 func parseRemoteAddr(addr string) net.Addr {

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -3,10 +3,10 @@ package fasthttpadaptor
 import (
 	"bytes"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/valyala/fasthttp"
@@ -111,7 +111,12 @@ func ConvertNetHttpRequestToFastHttpRequest(r *http.Request, ctx *fasthttp.Reque
 	}
 
 	if r.Body != nil {
-		ctx.Request.SetBodyStream(r.Body, int(r.ContentLength))
+		contentLength := int(r.ContentLength)
+		if r.ContentLength >= int64(math.MaxInt) {
+			contentLength = -1
+		}
+
+		ctx.Request.SetBodyStream(r.Body, contentLength)
 	}
 
 	if r.RemoteAddr != "" {
@@ -133,12 +138,4 @@ func parseRemoteAddr(addr string) net.Addr {
 
 	host := strings.Trim(addr, "[]")
 	return &net.TCPAddr{IP: net.ParseIP(host)}
-}
-
-func parsePort(port string) int {
-	p, err := strconv.Atoi(port)
-	if err != nil {
-		return 0
-	}
-	return p
 }

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -71,7 +71,7 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 	return nil
 }
 
-// ConvertNetHttpRequestToFastHttpRequest converts an http.Request to a fasthttp.RequestCtx.
+// ConvertNetHTTPRequestToFastHTTPRequest converts an http.Request to a fasthttp.RequestCtx.
 //
 // The caller is responsible for the lifecycle of the fasthttp.RequestCtx and the
 // underlying fasthttp.Request. The ctx (and its Request) must only be used for
@@ -88,7 +88,7 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 //
 // After calling this function, you should treat r.Body as effectively owned by
 // ctx.Request for the lifetime of that context.
-func ConvertNetHttpRequestToFastHttpRequest(r *http.Request, ctx *fasthttp.RequestCtx) {
+func ConvertNetHTTPRequestToFastHTTPRequest(r *http.Request, ctx *fasthttp.RequestCtx) {
 	ctx.Request.Header.SetMethod(r.Method)
 
 	if r.RequestURI != "" {

--- a/fasthttpadaptor/request_test.go
+++ b/fasthttpadaptor/request_test.go
@@ -238,6 +238,106 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 	})
 
+	t.Run("IPv6 remote address with port", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			RemoteAddr: "[2001:db8::1]:8080",
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+
+		remoteAddr := ctx.RemoteAddr().String()
+		if remoteAddr != "[2001:db8::1]:8080" {
+			t.Errorf("expected remote addr [2001:db8::1]:8080, got %s", remoteAddr)
+		}
+	})
+
+	t.Run("IPv6 remote address without port", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			RemoteAddr: "2001:db8::1",
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+
+		remoteAddr := ctx.RemoteAddr().String()
+		if remoteAddr != "[2001:db8::1]:0" {
+			t.Errorf("expected remote addr [2001:db8::1]:0, got %s", remoteAddr)
+		}
+	})
+
+	t.Run("IPv6 remote address with zone and port", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			RemoteAddr: "[fe80::1%eth0]:9090",
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+
+		remoteAddr := ctx.RemoteAddr().String()
+		if remoteAddr != "[fe80::1%eth0]:9090" {
+			t.Errorf("expected remote addr [fe80::1%%eth0]:9090, got %s", remoteAddr)
+		}
+	})
+
+	t.Run("IPv6 remote address with zone without port", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			RemoteAddr: "fe80::1%eth0",
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+
+		remoteAddr := ctx.RemoteAddr().String()
+		if remoteAddr != "[fe80::1%eth0]:0" {
+			t.Errorf("expected remote addr [fe80::1%%eth0]:0, got %s", remoteAddr)
+		}
+	})
+
+	t.Run("IPv6 loopback with port", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			RemoteAddr: "[::1]:3000",
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+
+		remoteAddr := ctx.RemoteAddr().String()
+		if remoteAddr != "[::1]:3000" {
+			t.Errorf("expected remote addr [::1]:3000, got %s", remoteAddr)
+		}
+	})
+
 	t.Run("body read error", func(t *testing.T) {
 		t.Parallel()
 		httpReq := &http.Request{

--- a/fasthttpadaptor/request_test.go
+++ b/fasthttpadaptor/request_test.go
@@ -47,7 +47,7 @@ func BenchmarkConvertNetHttpRequestToFastHttpRequest(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ConvertNetHttpRequestToFastHttpRequest(&httpReq, ctx)
+		ConvertNetHttpRequestToFastHttpRequest(&httpReq, ctx)
 	}
 }
 
@@ -72,10 +72,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
 		if string(ctx.Method()) != "POST" {
 			t.Errorf("expected method POST, got %s", ctx.Method())
@@ -106,10 +103,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
 		if string(ctx.RequestURI()) != "/fallback/path?foo=bar" {
 			t.Errorf("expected URI /fallback/path?foo=bar, got %s", ctx.RequestURI())
@@ -129,10 +123,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
 		if string(ctx.Request.Header.Peek("X-Custom-Header")) != "custom-value" {
 			t.Errorf("expected header value custom-value, got %s", ctx.Request.Header.Peek("X-Custom-Header"))
@@ -152,10 +143,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
 		// Check all header values are present
 		var values []string
@@ -184,10 +172,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
 		if !bytes.Equal(ctx.Request.Body(), bodyContent) {
 			t.Errorf("expected body %q, got %q", bodyContent, ctx.Request.Body())
@@ -206,10 +191,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
 		if len(ctx.Request.Body()) != 0 {
 			t.Errorf("expected empty body, got %q", ctx.Request.Body())
@@ -228,10 +210,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "192.168.1.100:8080" {
@@ -251,10 +230,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "192.168.1.100:0" {
@@ -275,12 +251,9 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
-		if err != nil {
-			t.Fatalf("unexpected error during conversion: %v", err)
-		}
+		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
 
-		_, err = io.ReadAll(ctx.RequestBodyStream())
+		_, err := io.ReadAll(ctx.RequestBodyStream())
 		if err == nil {
 			t.Fatal("expected error when reading body stream, got nil")
 		}

--- a/fasthttpadaptor/request_test.go
+++ b/fasthttpadaptor/request_test.go
@@ -32,8 +32,8 @@ func BenchmarkConvertRequest(b *testing.B) {
 	}
 }
 
-func BenchmarkConvertNetHttpRequestToFastHttpRequest(b *testing.B) {
-	var httpReq http.Request = http.Request{
+func BenchmarkConvertNetHTTPRequestToFastHTTPRequest(b *testing.B) {
+	httpReq := http.Request{
 		Method:     "GET",
 		RequestURI: "/test",
 		Host:       "test",
@@ -47,7 +47,7 @@ func BenchmarkConvertNetHttpRequestToFastHttpRequest(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ConvertNetHttpRequestToFastHttpRequest(&httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(&httpReq, ctx)
 	}
 }
 
@@ -58,7 +58,7 @@ func (errReader) Read([]byte) (int, error) {
 	return 0, errors.New("read error")
 }
 
-func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
+func TestConvertNetHTTPRequestToFastHTTPRequest(t *testing.T) {
 	t.Parallel()
 
 	t.Run("basic conversion", func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		if string(ctx.Method()) != "POST" {
 			t.Errorf("expected method POST, got %s", ctx.Method())
@@ -103,7 +103,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		if string(ctx.RequestURI()) != "/fallback/path?foo=bar" {
 			t.Errorf("expected URI /fallback/path?foo=bar, got %s", ctx.RequestURI())
@@ -123,7 +123,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		if string(ctx.Request.Header.Peek("X-Custom-Header")) != "custom-value" {
 			t.Errorf("expected header value custom-value, got %s", ctx.Request.Header.Peek("X-Custom-Header"))
@@ -143,14 +143,15 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		// Check all header values are present
 		var values []string
-		ctx.Request.Header.VisitAll(func(key, value []byte) {
+		ctx.Request.Header.All()(func(key, value []byte) bool {
 			if string(key) == "Accept" {
 				values = append(values, string(value))
 			}
+			return true
 		})
 
 		if len(values) != 3 {
@@ -172,7 +173,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		if !bytes.Equal(ctx.Request.Body(), bodyContent) {
 			t.Errorf("expected body %q, got %q", bodyContent, ctx.Request.Body())
@@ -191,7 +192,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		if len(ctx.Request.Body()) != 0 {
 			t.Errorf("expected empty body, got %q", ctx.Request.Body())
@@ -210,7 +211,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "192.168.1.100:8080" {
@@ -230,7 +231,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "192.168.1.100:0" {
@@ -250,7 +251,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "[2001:db8::1]:8080" {
@@ -270,7 +271,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "[2001:db8::1]:0" {
@@ -290,7 +291,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "[fe80::1%eth0]:9090" {
@@ -310,7 +311,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "[fe80::1%eth0]:0" {
@@ -330,7 +331,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		remoteAddr := ctx.RemoteAddr().String()
 		if remoteAddr != "[::1]:3000" {
@@ -351,7 +352,7 @@ func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
 		}
 
 		ctx := &fasthttp.RequestCtx{}
-		ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		ConvertNetHTTPRequestToFastHTTPRequest(httpReq, ctx)
 
 		_, err := io.ReadAll(ctx.RequestBodyStream())
 		if err == nil {

--- a/fasthttpadaptor/request_test.go
+++ b/fasthttpadaptor/request_test.go
@@ -1,7 +1,11 @@
 package fasthttpadaptor
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/valyala/fasthttp"
@@ -26,4 +30,252 @@ func BenchmarkConvertRequest(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = ConvertRequest(ctx, &httpReq, true)
 	}
+}
+
+func BenchmarkConvertNetHttpRequestToFastHttpRequest(b *testing.B) {
+	var httpReq http.Request = http.Request{
+		Method:     "GET",
+		RequestURI: "/test",
+		Host:       "test",
+		Header: http.Header{
+			"X": []string{"test"},
+			"Y": []string{"test"},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ConvertNetHttpRequestToFastHttpRequest(&httpReq, ctx)
+	}
+}
+
+// errReader is a reader that always returns an error.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("read error")
+}
+
+func TestConvertNetHttpRequestToFastHttpRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic conversion", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "POST",
+			RequestURI: "/test/path?query=1",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if string(ctx.Method()) != "POST" {
+			t.Errorf("expected method POST, got %s", ctx.Method())
+		}
+		if string(ctx.RequestURI()) != "/test/path?query=1" {
+			t.Errorf("expected URI /test/path?query=1, got %s", ctx.RequestURI())
+		}
+		if string(ctx.Request.Header.Protocol()) != "HTTP/1.1" {
+			t.Errorf("expected protocol HTTP/1.1, got %s", ctx.Request.Header.Protocol())
+		}
+		if string(ctx.Host()) != "example.com" {
+			t.Errorf("expected host example.com, got %s", ctx.Host())
+		}
+	})
+
+	t.Run("URL fallback when RequestURI is empty", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "",
+			URL: &url.URL{
+				Path:     "/fallback/path",
+				RawQuery: "foo=bar",
+			},
+			Proto:  "HTTP/1.1",
+			Host:   "fallback.com",
+			Header: http.Header{},
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if string(ctx.RequestURI()) != "/fallback/path?foo=bar" {
+			t.Errorf("expected URI /fallback/path?foo=bar, got %s", ctx.RequestURI())
+		}
+	})
+
+	t.Run("single header", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header: http.Header{
+				"X-Custom-Header": []string{"custom-value"},
+			},
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if string(ctx.Request.Header.Peek("X-Custom-Header")) != "custom-value" {
+			t.Errorf("expected header value custom-value, got %s", ctx.Request.Header.Peek("X-Custom-Header"))
+		}
+	})
+
+	t.Run("multiple header values", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header: http.Header{
+				"Accept": []string{"text/html", "application/json", "text/plain"},
+			},
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check all header values are present
+		var values []string
+		ctx.Request.Header.VisitAll(func(key, value []byte) {
+			if string(key) == "Accept" {
+				values = append(values, string(value))
+			}
+		})
+
+		if len(values) != 3 {
+			t.Errorf("expected 3 Accept header values, got %d", len(values))
+		}
+	})
+
+	t.Run("request body", func(t *testing.T) {
+		t.Parallel()
+		bodyContent := []byte("test body content")
+		httpReq := &http.Request{
+			Method:     "POST",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewReader(bodyContent)),
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !bytes.Equal(ctx.Request.Body(), bodyContent) {
+			t.Errorf("expected body %q, got %q", bodyContent, ctx.Request.Body())
+		}
+	})
+
+	t.Run("nil body", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			Body:       nil,
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(ctx.Request.Body()) != 0 {
+			t.Errorf("expected empty body, got %q", ctx.Request.Body())
+		}
+	})
+
+	t.Run("remote address with port", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			RemoteAddr: "192.168.1.100:8080",
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		remoteAddr := ctx.RemoteAddr().String()
+		if remoteAddr != "192.168.1.100:8080" {
+			t.Errorf("expected remote addr 192.168.1.100:8080, got %s", remoteAddr)
+		}
+	})
+
+	t.Run("remote address without port", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "GET",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			RemoteAddr: "192.168.1.100",
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		remoteAddr := ctx.RemoteAddr().String()
+		if remoteAddr != "192.168.1.100:0" {
+			t.Errorf("expected remote addr 192.168.1.100:0, got %s", remoteAddr)
+		}
+	})
+
+	t.Run("body read error", func(t *testing.T) {
+		t.Parallel()
+		httpReq := &http.Request{
+			Method:     "POST",
+			RequestURI: "/",
+			Proto:      "HTTP/1.1",
+			Host:       "example.com",
+			Header:     http.Header{},
+			Body:       io.NopCloser(errReader{}),
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		err := ConvertNetHttpRequestToFastHttpRequest(httpReq, ctx)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 }


### PR DESCRIPTION
One of my personal project i need to convert net http request to fasthttp request instead of doing it directly in my own project i want to add this functionality to fasthttp for possible future uses and  i also looking for a review if its correct way to convert both request object.