### PR TITLE
Go 1.26 and golangci-lint updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,10 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: 1.24.x
+        go-version: 1.26.x
     - run: go version
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@v9.2.0
       with:
-        version: v2.5.0
+        version: v2.10.1
         args: --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.24.x, 1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:

--- a/args.go
+++ b/args.go
@@ -396,7 +396,7 @@ func copyArgs(dst, src []argsKV) []argsKV {
 	}
 	n := len(src)
 	dst = dst[:n]
-	for i := 0; i < n; i++ {
+	for i := range n {
 		dstKV := &dst[i]
 		srcKV := &src[i]
 		dstKV.key = append(dstKV.key[:0], srcKV.key...)
@@ -443,7 +443,7 @@ func setArgBytes(h []argsKV, key, value []byte, noValue bool) []argsKV {
 
 func setArg(h []argsKV, key, value string, noValue bool) []argsKV {
 	n := len(h)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		kv := &h[i]
 		if key == string(kv.key) {
 			if noValue {

--- a/args_test.go
+++ b/args_test.go
@@ -123,13 +123,13 @@ func TestArgsAcquireReleaseSequential(t *testing.T) {
 
 func TestArgsAcquireReleaseConcurrent(t *testing.T) {
 	ch := make(chan struct{}, 10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			testArgsAcquireRelease(t)
 			ch <- struct{}{}
 		}()
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		select {
 		case <-ch:
 		case <-time.After(time.Second):
@@ -141,7 +141,7 @@ func TestArgsAcquireReleaseConcurrent(t *testing.T) {
 func testArgsAcquireRelease(t *testing.T) {
 	a := AcquireArgs()
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		k := fmt.Sprintf("key_%d", i)
 		v := fmt.Sprintf("value_%d", i*3+123)
 		a.Set(k, v)
@@ -151,7 +151,7 @@ func testArgsAcquireRelease(t *testing.T) {
 	a.Reset()
 	a.Parse(s)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		k := fmt.Sprintf("key_%d", i)
 		expectedV := fmt.Sprintf("value_%d", i*3+123)
 		v := a.Peek(k)
@@ -199,7 +199,7 @@ func TestArgsEscape(t *testing.T) {
 	// Test all characters
 	k := "f.o,1:2/4"
 	v := make([]byte, 256)
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		v[i] = byte(i)
 	}
 	u := url.Values{}
@@ -227,7 +227,7 @@ func TestPathEscape(t *testing.T) {
 
 	// Test all characters
 	pathSegment := make([]byte, 256)
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		pathSegment[i] = byte(i)
 	}
 	testPathEscape(t, "/foo/"+string(pathSegment))
@@ -442,8 +442,8 @@ func TestArgsSetGetDel(t *testing.T) {
 	}
 	a.Del("xxx")
 
-	for j := 0; j < 3; j++ {
-		for i := 0; i < 10; i++ {
+	for range 3 {
+		for i := range 10 {
 			k := fmt.Sprintf("foo%d", i)
 			v := fmt.Sprintf("bar_%d", i)
 			a.Set(k, v)
@@ -452,7 +452,7 @@ func TestArgsSetGetDel(t *testing.T) {
 			}
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		k := fmt.Sprintf("foo%d", i)
 		v := fmt.Sprintf("bar_%d", i)
 		if string(a.Peek(k)) != v {
@@ -475,7 +475,7 @@ func TestArgsSetGetDel(t *testing.T) {
 		t.Fatalf("Unexpected value %q. Expected %q", a.Peek("bb"), "aa")
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		k := fmt.Sprintf("xx%d", i)
 		v := fmt.Sprintf("yy%d", i)
 		a.Set(k, v)

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -80,7 +80,7 @@ func ParseIPv4(dst net.IP, ipStr []byte) (net.IP, error) {
 	dst = dst.To4() // dst is always non-nil here
 
 	b := ipStr
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		n := bytes.IndexByte(b, '.')
 		if n < 0 {
 			return dst, fmt.Errorf("cannot find dot in ipStr %q", ipStr)
@@ -152,7 +152,7 @@ func parseUintBuf(b []byte) (int, int, error) {
 		return -1, 0, errEmptyInt
 	}
 	v := 0
-	for i := 0; i < n; i++ {
+	for i := range n {
 		c := b[i]
 		k := c - '0'
 		if k > 9 {
@@ -252,7 +252,7 @@ const (
 )
 
 func lowercaseBytes(b []byte) {
-	for i := 0; i < len(b); i++ {
+	for i := range b {
 		p := &b[i]
 		*p = toLowerTable[*p]
 	}

--- a/bytesconv_64_test.go
+++ b/bytesconv_64_test.go
@@ -22,7 +22,7 @@ func TestAppendUint(t *testing.T) {
 	testAppendUint(t, 123)
 	testAppendUint(t, 0x7fffffffffffffff)
 
-	for i := 0; i < 2345; i++ {
+	for i := range 2345 {
 		testAppendUint(t, i)
 	}
 }

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -18,7 +18,7 @@ func TestAppendQuotedArg(t *testing.T) {
 
 	// Sync with url.QueryEscape
 	allcases := make([]byte, 256)
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		allcases[i] = byte(i)
 	}
 	res := string(AppendQuotedArg(nil, allcases))
@@ -33,7 +33,7 @@ func TestAppendHTMLEscape(t *testing.T) {
 
 	// Sync with html.EscapeString
 	allcases := make([]byte, 256)
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		allcases[i] = byte(i)
 	}
 	res := string(AppendHTMLEscape(nil, string(allcases)))

--- a/bytesconv_timing_test.go
+++ b/bytesconv_timing_test.go
@@ -15,7 +15,7 @@ func BenchmarkAppendHTMLEscape(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var buf []byte
 		for pb.Next() {
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				buf = AppendHTMLEscape(buf[:0], sOrig)
 				if string(buf) != sExpected {
 					b.Fatalf("unexpected escaped string: %q. Expecting %q", buf, sExpected)
@@ -31,7 +31,7 @@ func BenchmarkHTMLEscapeString(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var s string
 		for pb.Next() {
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				s = html.EscapeString(sOrig)
 				if s != sExpected {
 					b.Fatalf("unexpected escaped string: %q. Expecting %q", s, sExpected)

--- a/client_test.go
+++ b/client_test.go
@@ -217,7 +217,7 @@ func TestPipelineClientIssue832(t *testing.T) {
 
 	attempts := 10
 	go func() {
-		for i := 0; i < attempts; i++ {
+		for range attempts {
 			c, err := ln.Accept()
 			if err != nil {
 				t.Error(err)
@@ -235,7 +235,7 @@ func TestPipelineClientIssue832(t *testing.T) {
 	go func() {
 		defer close(done)
 
-		for i := 0; i < attempts; i++ {
+		for range attempts {
 			if err := client.Do(req, res); err == nil {
 				t.Error("error expected")
 			}
@@ -1045,14 +1045,14 @@ func testPipelineClientDoConcurrent(t *testing.T, concurrency int, maxBatchDelay
 	}
 
 	clientStopCh := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
 			testPipelineClientDo(t, c)
 			clientStopCh <- struct{}{}
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-clientStopCh:
 		case <-time.After(3 * time.Second):
@@ -1079,7 +1079,7 @@ func testPipelineClientDo(t *testing.T, c *PipelineClient) {
 	req := AcquireRequest()
 	req.SetRequestURI("http://foobar/baz")
 	resp := AcquireResponse()
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if i&1 == 0 {
 			err = c.DoTimeout(req, resp, time.Second)
 		} else {
@@ -1149,7 +1149,7 @@ func testPipelineClientDisableHeaderNamesNormalizing(t *testing.T, timeout time.
 	var req Request
 	req.SetRequestURI("http://aaaai.com/bsdf?sddfsd")
 	var resp Response
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		if timeout > 0 {
 			if err := c.DoTimeout(&req, &resp, timeout); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -1209,7 +1209,7 @@ func TestClientDoTimeoutDisableHeaderNamesNormalizing(t *testing.T) {
 	var req Request
 	req.SetRequestURI("http://aaaai.com/bsdf?sddfsd")
 	var resp Response
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		if err := c.DoTimeout(&req, &resp, time.Second); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1266,7 +1266,7 @@ func TestClientDoTimeoutDisablePathNormalizing(t *testing.T) {
 	var req Request
 	req.SetRequestURI(urlWithEncodedPath)
 	var resp Response
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		if err := c.DoTimeout(&req, &resp, time.Second); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1320,7 +1320,7 @@ func TestHostClientPendingRequests(t *testing.T) {
 	}
 
 	resultCh := make(chan error, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
 			req := AcquireRequest()
 			req.SetRequestURI("http://foobar/baz")
@@ -1340,7 +1340,7 @@ func TestHostClientPendingRequests(t *testing.T) {
 	}
 
 	// wait while all the requests reach server
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-readyCh:
 		case <-time.After(time.Second):
@@ -1355,7 +1355,7 @@ func TestHostClientPendingRequests(t *testing.T) {
 
 	// unblock request handlers on the server and wait until all the requests are finished.
 	close(doneCh)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case err := <-resultCh:
 			if err != nil {
@@ -1417,11 +1417,10 @@ func TestHostClientMaxConnsWithDeadline(t *testing.T) {
 		MaxConns: 1,
 	}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-
 			req := AcquireRequest()
 			req.SetRequestURI("http://foobar/baz")
 			req.Header.SetMethod(MethodPost)
@@ -1496,7 +1495,7 @@ func TestHostClientMaxConnDuration(t *testing.T) {
 		MaxConnDuration: 10 * time.Millisecond,
 	}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		statusCode, body, err := c.Get(nil, "http://aaaa.com/bbb/cc")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -1552,7 +1551,7 @@ func TestHostClientMultipleAddrs(t *testing.T) {
 		},
 	}
 
-	for i := 0; i < 9; i++ {
+	for range 9 {
 		statusCode, body, err := c.Get(nil, "http://foobar/baz/aaa?bbb=ddd")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -1624,7 +1623,7 @@ func TestClientFollowRedirects(t *testing.T) {
 		},
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		statusCode, body, err := c.GetTimeout(nil, "http://xxx/foo", time.Second)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -1637,7 +1636,7 @@ func TestClientFollowRedirects(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		statusCode, body, err := c.Get(nil, "http://xxx/aaab/sss")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -1650,7 +1649,7 @@ func TestClientFollowRedirects(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		req := AcquireRequest()
 		resp := AcquireResponse()
 
@@ -1673,7 +1672,7 @@ func TestClientFollowRedirects(t *testing.T) {
 		ReleaseResponse(resp)
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		req := AcquireRequest()
 		resp := AcquireResponse()
 
@@ -1697,7 +1696,7 @@ func TestClientFollowRedirects(t *testing.T) {
 		ReleaseResponse(resp)
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		req := AcquireRequest()
 		resp := AcquireResponse()
 
@@ -1723,7 +1722,7 @@ func TestClientFollowRedirects(t *testing.T) {
 		ReleaseResponse(resp)
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		req := AcquireRequest()
 		resp := AcquireResponse()
 
@@ -1778,7 +1777,7 @@ func TestClientGetTimeoutSuccessConcurrent(t *testing.T) {
 	defer s.Stop()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1805,7 +1804,7 @@ func TestClientDoTimeoutSuccessConcurrent(t *testing.T) {
 	defer s.Stop()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1847,7 +1846,7 @@ func TestClientGetTimeoutErrorConcurrent(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1889,7 +1888,7 @@ func TestClientDoTimeoutErrorConcurrent(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1903,7 +1902,7 @@ func testClientDoTimeoutError(t *testing.T, c *Client, n int) {
 	var req Request
 	var resp Response
 	req.SetRequestURI("http://foobar.com/baz")
-	for i := 0; i < n; i++ {
+	for range n {
 		err := c.DoTimeout(&req, &resp, time.Millisecond)
 		if err == nil {
 			t.Errorf("expecting error")
@@ -1916,7 +1915,7 @@ func testClientDoTimeoutError(t *testing.T, c *Client, n int) {
 
 func testClientGetTimeoutError(t *testing.T, c *Client, n int) {
 	buf := make([]byte, 10)
-	for i := 0; i < n; i++ {
+	for range n {
 		statusCode, _, err := c.GetTimeout(buf, "http://foobar.com/baz", time.Millisecond)
 		if err == nil {
 			t.Errorf("expecting error")
@@ -1934,7 +1933,7 @@ func testClientRequestSetTimeoutError(t *testing.T, c *Client, n int) {
 	var req Request
 	var resp Response
 	req.SetRequestURI("http://foobar.com/baz")
-	for i := 0; i < n; i++ {
+	for range n {
 		req.SetTimeout(time.Millisecond)
 		err := c.Do(&req, &resp)
 		if err == nil {
@@ -2182,7 +2181,7 @@ func TestHostClientTransport(t *testing.T) {
 		}(),
 	}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		statusCode, body, err := c.Get(nil, "http://aaaa.com/bbb/cc")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -2388,7 +2387,7 @@ func TestClientHTTPSInvalidServerName(t *testing.T) {
 
 	var c Client
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		_, _, err := c.GetTimeout(nil, "https://"+sHTTPS.Addr(), time.Second)
 		if err == nil {
 			t.Fatalf("expecting TLS error")
@@ -2412,7 +2411,7 @@ func TestClientHTTPSConcurrent(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		wg.Add(1)
 		addr := "http://" + sHTTP.Addr()
 		if i&1 != 0 {
@@ -2430,15 +2429,15 @@ func TestClientHTTPSConcurrent(t *testing.T) {
 func TestClientManyServers(t *testing.T) {
 	t.Parallel()
 
-	var addrs []string
-	for i := 0; i < 10; i++ {
+	addrs := make([]string, 0, 10)
+	for range 10 {
 		s := startEchoServer(t, "tcp", "127.0.0.1:")
 		defer s.Stop()
 		addrs = append(addrs, s.Addr())
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		wg.Add(1)
 		addr := "http://" + addrs[i]
 		go func() {
@@ -2476,7 +2475,7 @@ func TestClientConcurrent(t *testing.T) {
 
 	addr := "http://" + s.Addr()
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -2531,7 +2530,7 @@ func TestHostClientConcurrent(t *testing.T) {
 	c := createEchoClient("unix", addr)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -2544,7 +2543,7 @@ func TestHostClientConcurrent(t *testing.T) {
 
 func testClientGet(t *testing.T, c clientGetter, addr string, n int) {
 	var buf []byte
-	for i := 0; i < n; i++ {
+	for i := range n {
 		uri := fmt.Sprintf("%s/foo/%d?bar=baz", addr, i)
 		statusCode, body, err := c.Get(buf, uri)
 		buf = body
@@ -2565,7 +2564,7 @@ func testClientDoTimeoutSuccess(t *testing.T, c *Client, addr string, n int) {
 	var req Request
 	var resp Response
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		uri := fmt.Sprintf("%s/foo/%d?bar=baz", addr, i)
 		req.SetRequestURI(uri)
 		if err := c.DoTimeout(&req, &resp, time.Second); err != nil {
@@ -2588,7 +2587,7 @@ func testClientRequestSetTimeoutSuccess(t *testing.T, c *Client, addr string, n 
 	var req Request
 	var resp Response
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		uri := fmt.Sprintf("%s/foo/%d?bar=baz", addr, i)
 		req.SetRequestURI(uri)
 		req.SetTimeout(time.Second)
@@ -2610,7 +2609,7 @@ func testClientRequestSetTimeoutSuccess(t *testing.T, c *Client, addr string, n 
 
 func testClientGetTimeoutSuccess(t *testing.T, c *Client, addr string, n int) {
 	var buf []byte
-	for i := 0; i < n; i++ {
+	for i := range n {
 		uri := fmt.Sprintf("%s/foo/%d?bar=baz", addr, i)
 		statusCode, body, err := c.GetTimeout(buf, uri, time.Second)
 		buf = body
@@ -2633,7 +2632,7 @@ func testClientGetTimeoutSuccess(t *testing.T, c *Client, addr string, n int) {
 func testClientPost(t *testing.T, c clientPoster, addr string, n int) {
 	var buf []byte
 	var args Args
-	for i := 0; i < n; i++ {
+	for i := range n {
 		uri := fmt.Sprintf("%s/foo/%d?bar=baz", addr, i)
 		args.Set("xx", fmt.Sprintf("yy%d", i))
 		args.Set("zzz", fmt.Sprintf("qwe_%d", i))
@@ -2863,11 +2862,10 @@ func TestHostClientMaxConnWaitTimeoutSuccess(t *testing.T) {
 		MaxConnWaitTimeout: time.Second * 2,
 	}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-
 			req := AcquireRequest()
 			req.SetRequestURI("http://foobar/baz")
 			req.Header.SetMethod(MethodPost)
@@ -2941,11 +2939,10 @@ func TestHostClientMaxConnWaitTimeoutError(t *testing.T) {
 	}
 
 	var errNoFreeConnsCount atomic.Uint32
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-
 			req := AcquireRequest()
 			req.SetRequestURI("http://foobar/baz")
 			req.Header.SetMethod(MethodPost)
@@ -3038,11 +3035,10 @@ func TestHostClientMaxConnWaitTimeoutWithEarlierDeadline(t *testing.T) {
 	}
 
 	var errTimeoutCount atomic.Uint32
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-
 			req := AcquireRequest()
 			req.SetRequestURI("http://foobar/baz")
 			req.Header.SetMethod(MethodPost)
@@ -3281,7 +3277,7 @@ func TestClientTransportEx(t *testing.T) {
 	const loopCount = 4
 	const getCount = 20
 	const postCount = 10
-	for i := 0; i < loopCount; i++ {
+	for i := range loopCount {
 		addr := "http://" + sHTTP.Addr()
 		if i&1 != 0 {
 			addr = "https://" + sHTTPS.Addr()

--- a/client_timing_test.go
+++ b/client_timing_test.go
@@ -95,7 +95,7 @@ var fakeClientConnPool sync.Pool
 
 func BenchmarkClientGetTimeoutFastServer(b *testing.B) {
 	body := []byte("123456789099")
-	s := []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s", len(body), body))
+	s := fmt.Appendf(nil, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s", len(body), body)
 	c := &Client{
 		Dial: func(addr string) (net.Conn, error) {
 			return acquireFakeServerConn(s), nil

--- a/compress.go
+++ b/compress.go
@@ -439,8 +439,8 @@ func newCompressWriterPoolMap() []*sync.Pool {
 	// in https://pkg.go.dev/compress/flate#pkg-constants .
 	// Compression levels are normalized with normalizeCompressLevel,
 	// so the fit [0..11].
-	var m []*sync.Pool
-	for i := 0; i < 12; i++ {
+	m := make([]*sync.Pool, 0, 12)
+	for range 12 {
 		m = append(m, &sync.Pool{})
 	}
 	return m

--- a/compress_test.go
+++ b/compress_test.go
@@ -10,11 +10,12 @@ import (
 )
 
 var compressTestcases = func() []string {
-	a := []string{
+	a := make([]string, 0, 4)
+	a = append(a,
 		"",
 		"foobar",
 		"выфаодлодл одлфываыв sd2 k34",
-	}
+	)
 	bigS := createFixedBody(1e4)
 	a = append(a, string(bigS))
 	return a
@@ -210,7 +211,7 @@ func testFlateCompressSingleCase(s string) error {
 
 func testConcurrent(concurrency int, f func() error) error {
 	ch := make(chan error, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for i := range concurrency {
 		go func(idx int) {
 			err := f()
 			if err != nil {
@@ -219,7 +220,7 @@ func testConcurrent(concurrency int, f func() error) error {
 			ch <- nil
 		}(i)
 	}
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case err := <-ch:
 			if err != nil {

--- a/cookie.go
+++ b/cookie.go
@@ -584,7 +584,7 @@ func caseInsensitiveCompare(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for i := 0; i < len(a); i++ {
+	for i := range a {
 		if a[i]|0x20 != b[i]|0x20 {
 			return false
 		}

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -289,13 +289,13 @@ func TestCookieAcquireReleaseConcurrent(t *testing.T) {
 	t.Parallel()
 
 	ch := make(chan struct{}, 10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			testCookieAcquireRelease(t)
 			ch <- struct{}{}
 		}()
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		select {
 		case <-ch:
 		case <-time.After(time.Second):

--- a/fasthttpproxy/dialer_test.go
+++ b/fasthttpproxy/dialer_test.go
@@ -233,7 +233,7 @@ func TestDialer_GetDialFunc(t *testing.T) {
 				t.Errorf("GetDialFunc() counts = %v, want %v", getCounts(counts), tt.wantCounts)
 			}
 		})
-		for i := 0; i < len(counts); i++ {
+		for i := range counts {
 			counts[i].Store(0)
 		}
 	}
@@ -287,7 +287,7 @@ func getDialer(httpProxy, httpsProxy, noProxy string) *Dialer {
 }
 
 func getCounts(counts []atomic.Int64) (r []int64) {
-	for i := 0; i < len(counts); i++ {
+	for i := range counts {
 		r = append(r, counts[i].Load())
 	}
 	return r

--- a/fasthttputil/inmemory_listener_test.go
+++ b/fasthttputil/inmemory_listener_test.go
@@ -16,7 +16,7 @@ func TestInmemoryListener(t *testing.T) {
 	ln := NewInmemoryListener()
 
 	ch := make(chan struct{})
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(n int) {
 			conn, err := ln.Dial()
 			if err != nil {
@@ -77,7 +77,7 @@ func TestInmemoryListener(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		select {
 		case <-ch:
 		case <-time.After(time.Second):
@@ -163,7 +163,7 @@ func TestInmemoryListenerHTTPSingle(t *testing.T) {
 
 func TestInmemoryListenerHTTPSerial(t *testing.T) {
 	testInmemoryListenerHTTP(t, func(t *testing.T, client *http.Client) {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			testInmemoryListenerHTTPSingle(t, client, fmt.Sprintf("request_%d", i))
 		}
 	})
@@ -172,7 +172,7 @@ func TestInmemoryListenerHTTPSerial(t *testing.T) {
 func TestInmemoryListenerHTTPConcurrent(t *testing.T) {
 	testInmemoryListenerHTTP(t, func(t *testing.T, client *http.Client) {
 		var wg sync.WaitGroup
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()

--- a/fasthttputil/pipeconns_test.go
+++ b/fasthttputil/pipeconns_test.go
@@ -31,7 +31,7 @@ func TestPipeConnsWriteTimeout(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		_, err := c1.Write(data)
 		if err == nil {
 			t.Fatalf("expecting error")
@@ -56,7 +56,7 @@ func TestPipeConnsWriteTimeout(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		_, err := c2.Read(data)
 		if err == nil {
 			t.Fatalf("expecting error")
@@ -91,7 +91,7 @@ func testPipeConnsReadTimeout(t *testing.T, timeout time.Duration) {
 	}
 
 	var buf [1]byte
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		_, err := c1.Read(buf[:])
 		if err == nil {
 			t.Fatalf("expecting error on iteration %d", i)
@@ -125,14 +125,14 @@ func TestPipeConnsCloseWhileReadWriteConcurrent(t *testing.T) {
 
 	concurrency := 4
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
 			testPipeConnsCloseWhileReadWriteSerial(t)
 			ch <- struct{}{}
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-ch:
 		case <-time.After(5 * time.Second):
@@ -148,7 +148,7 @@ func TestPipeConnsCloseWhileReadWriteSerial(t *testing.T) {
 }
 
 func testPipeConnsCloseWhileReadWriteSerial(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		testPipeConnsCloseWhileReadWrite(t)
 	}
 }
@@ -238,7 +238,7 @@ func testPipeConnsReadWrite(t *testing.T, c1, c2 net.Conn) {
 	defer c2.Close()
 
 	var buf [32]byte
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		// The first write
 		s1 := fmt.Sprintf("foo_%d", i)
 		n, err := c1.Write([]byte(s1))
@@ -301,7 +301,7 @@ func testPipeConnsClose(t *testing.T, c1, c2 net.Conn) {
 	var buf [10]byte
 
 	// attempt writing to closed conn
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		n, err := c1.Write(buf[:])
 		if err == nil {
 			t.Fatalf("expecting error")
@@ -312,7 +312,7 @@ func testPipeConnsClose(t *testing.T, c1, c2 net.Conn) {
 	}
 
 	// attempt reading from closed conn
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		n, err := c2.Read(buf[:])
 		if err == nil {
 			t.Fatalf("expecting error")
@@ -330,7 +330,7 @@ func testPipeConnsClose(t *testing.T, c1, c2 net.Conn) {
 	}
 
 	// attempt closing already closed conns
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		if err := c1.Close(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -342,14 +342,14 @@ func testPipeConnsClose(t *testing.T, c1, c2 net.Conn) {
 
 func testConcurrency(t *testing.T, concurrency int, f func(*testing.T)) {
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
 			f(t)
 			ch <- struct{}{}
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-ch:
 		case <-time.After(time.Second):

--- a/fs.go
+++ b/fs.go
@@ -7,6 +7,7 @@ import (
 	"html"
 	"io"
 	"io/fs"
+	"maps"
 	"mime"
 	"net/http"
 	"os"
@@ -477,9 +478,7 @@ func (fs *FS) initRequestHandler() {
 		compressedFileSuffixes["gzip"] == compressedFileSuffixes["zstd"] {
 		// Copy global map
 		compressedFileSuffixes = make(map[string]string, len(FSCompressedFileSuffixes))
-		for k, v := range FSCompressedFileSuffixes {
-			compressedFileSuffixes[k] = v
-		}
+		maps.Copy(compressedFileSuffixes, FSCompressedFileSuffixes)
 	}
 
 	if fs.CompressedFileSuffix != "" {
@@ -1232,10 +1231,7 @@ func ParseByteRange(byteRange []byte, contentLength int) (startPos, endPos int, 
 		if err != nil {
 			return 0, 0, err
 		}
-		startPos := contentLength - v
-		if startPos < 0 {
-			startPos = 0
-		}
+		startPos := max(contentLength-v, 0)
 		return startPos, contentLength - 1, nil
 	}
 

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -223,9 +223,9 @@ func TestFSFSByteRangeConcurrent(t *testing.T) {
 
 	concurrency := 10
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
-			for j := 0; j < 5; j++ {
+			for range 5 {
 				testFSByteRange(t, h, "/fs.go")
 				testFSByteRange(t, h, "/README.md")
 			}
@@ -233,7 +233,7 @@ func TestFSFSByteRangeConcurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-time.After(time.Second):
 			t.Fatalf("timeout")
@@ -283,9 +283,9 @@ func TestFSFSCompressConcurrent(t *testing.T) {
 
 	concurrency := 4
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
-			for j := 0; j < 5; j++ {
+			for range 5 {
 				testFSFSCompress(t, h, "/fs.go")
 				testFSFSCompress(t, h, "/examples/")
 				testFSFSCompress(t, h, "/README.md")
@@ -294,7 +294,7 @@ func TestFSFSCompressConcurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-ch:
 		case <-time.After(time.Second * 4):
@@ -679,9 +679,9 @@ func TestDirFSFSByteRangeConcurrent(t *testing.T) {
 
 	concurrency := 10
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
-			for j := 0; j < 5; j++ {
+			for range 5 {
 				testFSByteRange(t, h, "/fs.go")
 				testFSByteRange(t, h, "/README.md")
 			}
@@ -689,7 +689,7 @@ func TestDirFSFSByteRangeConcurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-time.After(time.Second):
 			t.Fatalf("timeout")
@@ -735,9 +735,9 @@ func TestDirFSFSCompressConcurrent(t *testing.T) {
 
 	concurrency := 4
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
-			for j := 0; j < 5; j++ {
+			for range 5 {
 				testFSFSCompress(t, h, "/fs.go")
 				testFSFSCompress(t, h, "/examples/")
 				testFSFSCompress(t, h, "/README.md")
@@ -746,7 +746,7 @@ func TestDirFSFSCompressConcurrent(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-ch:
 		case <-time.After(time.Second * 2):

--- a/fs_test.go
+++ b/fs_test.go
@@ -388,9 +388,9 @@ func runFSByteRangeConcurrent(t *testing.T, fs *FS) {
 
 	concurrency := 10
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
-			for j := 0; j < 5; j++ {
+			for range 5 {
 				testFSByteRange(t, h, "/fs.go")
 				testFSByteRange(t, h, "/README.md")
 			}
@@ -398,7 +398,7 @@ func runFSByteRangeConcurrent(t *testing.T, fs *FS) {
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-time.After(time.Second):
 			t.Fatalf("timeout")
@@ -623,9 +623,9 @@ func runFSCompressConcurrent(t *testing.T, fs *FS) {
 
 	concurrency := 4
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
-			for j := 0; j < 5; j++ {
+			for range 5 {
 				testFSCompress(t, h, "/fs.go")
 				testFSCompress(t, h, "/examples/")
 				testFSCompress(t, h, "/README.md")
@@ -634,7 +634,7 @@ func runFSCompressConcurrent(t *testing.T, fs *FS) {
 		}()
 	}
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-ch:
 		case <-time.After(time.Second * 2):
@@ -841,7 +841,7 @@ func TestFSHandlerSingleThread(t *testing.T) {
 	}
 	sort.Strings(filenames)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		fsHandlerTest(t, requestHandler, filenames)
 	}
 }
@@ -865,16 +865,16 @@ func TestFSHandlerConcurrent(t *testing.T) {
 
 	concurrency := 10
 	ch := make(chan struct{}, concurrency)
-	for j := 0; j < concurrency; j++ {
+	for range concurrency {
 		go func() {
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				fsHandlerTest(t, requestHandler, filenames)
 			}
 			ch <- struct{}{}
 		}()
 	}
 
-	for j := 0; j < concurrency; j++ {
+	for range concurrency {
 		select {
 		case <-ch:
 		case <-time.After(time.Second):

--- a/header.go
+++ b/header.go
@@ -2483,7 +2483,7 @@ func (h *ResponseHeader) AppendBytes(dst []byte) []byte {
 
 	n := len(h.cookies)
 	if n > 0 {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			kv := &h.cookies[i]
 			dst = appendHeaderLine(dst, strSetCookie, kv.value)
 		}
@@ -3232,14 +3232,14 @@ func (s *headerValueScanner) next() bool {
 	if len(b) == 0 {
 		return false
 	}
-	n := bytes.IndexByte(b, ',')
-	if n < 0 {
+	before, after, ok := bytes.Cut(b, []byte{','})
+	if !ok {
 		s.value = stripSpace(b)
 		s.b = b[len(b):]
 		return true
 	}
-	s.value = stripSpace(b[:n])
-	s.b = b[n+1:]
+	s.value = stripSpace(before)
+	s.b = after
 	return true
 }
 

--- a/header_test.go
+++ b/header_test.go
@@ -576,7 +576,7 @@ func TestResponseHeaderAdd(t *testing.T) {
 	h.Add("content-type", "xxx")
 	m["bbb"] = struct{}{}
 	m["xxx"] = struct{}{}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := strconv.Itoa(i)
 		h.Add("Foo-Bar", v)
 		m[v] = struct{}{}
@@ -629,7 +629,7 @@ func TestRequestHeaderAdd(t *testing.T) {
 	h.Add("user-agent", "xxx")
 	m["bbb"] = struct{}{}
 	m["xxx"] = struct{}{}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := strconv.Itoa(i)
 		h.Add("Foo-Bar", v)
 		m[v] = struct{}{}
@@ -939,7 +939,7 @@ func TestBufferSnippet(t *testing.T) {
 	b := string(createFixedBody(199))
 	bExpected := fmt.Sprintf("%q", b)
 	testBufferSnippet(t, b, bExpected)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		b += "foobar"
 		bExpected = fmt.Sprintf("%q", b)
 		testBufferSnippet(t, b, bExpected)
@@ -948,7 +948,7 @@ func TestBufferSnippet(t *testing.T) {
 	b = string(createFixedBody(400))
 	bExpected = fmt.Sprintf("%q", b)
 	testBufferSnippet(t, b, bExpected)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		b += "sadfqwer"
 		bExpected = fmt.Sprintf("%q...%q", b[:200], b[len(b)-200:])
 		testBufferSnippet(t, b, bExpected)
@@ -2637,10 +2637,7 @@ func (r *bufioPeekReader) Read(b []byte) (int, error) {
 	}
 
 	r.n++
-	n := r.n
-	if len(r.s) < n {
-		n = len(r.s)
-	}
+	n := min(len(r.s), r.n)
 	src := []byte(r.s[:n])
 	r.s = r.s[n:]
 	n = copy(b, src)
@@ -2676,8 +2673,8 @@ func TestResponseHeaderBufioPeek(t *testing.T) {
 }
 
 func getHeaders(n int) string {
-	var h []string
-	for i := 0; i < n; i++ {
+	h := make([]string, 0, n)
+	for i := range n {
 		h = append(h, fmt.Sprintf("Header_%d: Value_%d\r\n", i, i))
 	}
 	return strings.Join(h, "")

--- a/http.go
+++ b/http.go
@@ -2481,13 +2481,8 @@ func readBodyWithStreaming(r *bufio.Reader, contentLength, maxBodySize int, dst 
 
 	dst = dst[:0]
 
-	readN := maxBodySize
-	if readN > contentLength {
-		readN = contentLength
-	}
-	if readN > 8*1024 {
-		readN = 8 * 1024
-	}
+	readN := min(maxBodySize, contentLength)
+	readN = min(readN, 8*1024)
 
 	// A fixed-length pre-read function should be used here; otherwise,
 	// it may read content beyond the request body into areas outside

--- a/lbclient_example_test.go
+++ b/lbclient_example_test.go
@@ -27,7 +27,7 @@ func ExampleLBClient() {
 	// Send requests to load-balanced servers
 	var req fasthttp.Request
 	var resp fasthttp.Response
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		url := fmt.Sprintf("http://abcedfg/foo/bar/%d", i)
 		req.SetRequestURI(url)
 		if err := lbc.Do(&req, &resp); err != nil {

--- a/peripconn.go
+++ b/peripconn.go
@@ -31,10 +31,7 @@ func (cc *perIPConnCounter) Unregister(ip uint32) {
 		// developer safeguard
 		panic("BUG: perIPConnCounter.Register() wasn't called")
 	}
-	n := cc.m[ip] - 1
-	if n < 0 {
-		n = 0
-	}
+	n := max(cc.m[ip]-1, 0)
 	cc.m[ip] = n
 }
 

--- a/prefork/prefork.go
+++ b/prefork/prefork.go
@@ -180,7 +180,7 @@ func (p *Prefork) prefork(addr string) (err error) {
 		}
 	}()
 
-	for i := 0; i < goMaxProcs; i++ {
+	for range goMaxProcs {
 		var cmd *exec.Cmd
 		if cmd, err = p.doCommand(); err != nil {
 			p.logger().Printf("failed to start a child prefork process, error: %v\n", err)

--- a/requestctx_setbodystreamwriter_example_test.go
+++ b/requestctx_setbodystreamwriter_example_test.go
@@ -19,7 +19,7 @@ func ExampleRequestCtx_SetBodyStreamWriter() {
 func responseStreamHandler(ctx *fasthttp.RequestCtx) {
 	// Send the response in chunks and wait for a second between each chunk.
 	ctx.SetBodyStreamWriter(func(w *bufio.Writer) {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			fmt.Fprintf(w, "this is a message number %d", i)
 
 			// Do not forget flushing streamed data to the client.

--- a/server.go
+++ b/server.go
@@ -20,6 +20,7 @@ import (
 var errNoCertOrKeyProvided = errors.New("cert or key has not provided")
 
 // ErrAlreadyServing is deprecated.
+//
 // Deprecated: ErrAlreadyServing is never returned from Serve. See issue #633.
 var ErrAlreadyServing = errors.New("Server is already serving connections")
 
@@ -287,6 +288,7 @@ type Server struct {
 	MaxRequestsPerConn int
 
 	// MaxKeepaliveDuration is a no-op and only left here for backwards compatibility.
+	//
 	// Deprecated: Use IdleTimeout instead.
 	MaxKeepaliveDuration time.Duration
 

--- a/server_timing_test.go
+++ b/server_timing_test.go
@@ -275,10 +275,7 @@ func (ln *fakeListener) Accept() (net.Conn, error) {
 		ln.lock.Unlock()
 		return nil, io.EOF
 	}
-	requestsCount := ln.requestsPerConn
-	if requestsCount > ln.requestsCount {
-		requestsCount = ln.requestsCount
-	}
+	requestsCount := min(ln.requestsPerConn, ln.requestsCount)
 	ln.requestsCount -= requestsCount
 	ln.lock.Unlock()
 
@@ -306,7 +303,7 @@ func newFakeListener(requestsCount, clientsCount, requestsPerConn int, request s
 		ch:              make(chan *fakeServerConn, clientsCount),
 		done:            make(chan struct{}),
 	}
-	for i := 0; i < clientsCount; i++ {
+	for range clientsCount {
 		ln.ch <- &fakeServerConn{
 			ln: ln,
 		}

--- a/stackless/func.go
+++ b/stackless/func.go
@@ -27,7 +27,7 @@ func NewFunc(f func(ctx any)) func(ctx any) bool {
 	funcWorkCh := make(chan *funcWork, runtime.GOMAXPROCS(-1)*2048)
 	onceInit := func() {
 		n := runtime.GOMAXPROCS(-1)
-		for i := 0; i < n; i++ {
+		for range n {
 			go funcWorker(funcWorkCh, f)
 		}
 	}

--- a/stackless/func_test.go
+++ b/stackless/func_test.go
@@ -16,7 +16,7 @@ func TestNewFuncSimple(t *testing.T) {
 	})
 
 	iterations := 4 * 1024
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		if !f(2) {
 			t.Fatalf("f mustn't return false")
 		}
@@ -42,7 +42,7 @@ func TestNewFuncMulti(t *testing.T) {
 	f1Done := make(chan error, 1)
 	go func() {
 		var err error
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			if !f1(3) {
 				err = errors.New("f1 mustn't return false")
 				break
@@ -54,7 +54,7 @@ func TestNewFuncMulti(t *testing.T) {
 	f2Done := make(chan error, 1)
 	go func() {
 		var err error
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			if !f2(5) {
 				err = errors.New("f2 mustn't return false")
 				break

--- a/stackless/writer_test.go
+++ b/stackless/writer_test.go
@@ -70,7 +70,7 @@ func testWriter(newWriter NewWriterFunc, newReader func(io.Reader) io.Reader) er
 	dstW := &bytes.Buffer{}
 	w := NewWriter(dstW, newWriter)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if err := testWriterReuse(w, dstW, newReader); err != nil {
 			return fmt.Errorf("unexpected error when re-using writer on iteration %d: %w", i, err)
 		}
@@ -84,7 +84,7 @@ func testWriter(newWriter NewWriterFunc, newReader func(io.Reader) io.Reader) er
 func testWriterReuse(w Writer, r io.Reader, newReader func(io.Reader) io.Reader) error {
 	wantW := &bytes.Buffer{}
 	mw := io.MultiWriter(w, wantW)
-	for i := 0; i < 30; i++ {
+	for i := range 30 {
 		fmt.Fprintf(mw, "foobar %d\n", i)
 		if i%13 == 0 {
 			if err := w.Flush(); err != nil {
@@ -110,12 +110,12 @@ func testWriterReuse(w Writer, r io.Reader, newReader func(io.Reader) io.Reader)
 
 func testConcurrent(testFunc func() error, concurrency int) error {
 	ch := make(chan error, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
 			ch <- testFunc()
 		}()
 	}
-	for i := 0; i < concurrency; i++ {
+	for i := range concurrency {
 		select {
 		case err := <-ch:
 			if err != nil {

--- a/stream_test.go
+++ b/stream_test.go
@@ -52,7 +52,7 @@ func TestStreamReaderClose(t *testing.T) {
 		}
 
 		data := createFixedBody(4000)
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			w.Write(data) //nolint:errcheck
 		}
 		if err := w.Flush(); err == nil {

--- a/streaming.go
+++ b/streaming.go
@@ -42,10 +42,7 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 			}
 			rs.chunkLeft = chunkSize
 		}
-		bytesToRead := len(p)
-		if rs.chunkLeft < len(p) {
-			bytesToRead = rs.chunkLeft
-		}
+		bytesToRead := min(rs.chunkLeft, len(p))
 		n, err = rs.reader.Read(p[:bytesToRead])
 		rs.totalBytesRead += n
 		rs.chunkLeft -= n

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -240,7 +240,7 @@ func BenchmarkRequestStreamE2E(b *testing.B) {
 
 	wg := &sync.WaitGroup{}
 	wg.Add(4)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		go func(wg *sync.WaitGroup) {
 			for i := 0; i < b.N/4; i++ {
 				c, err := ln.Dial()

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -499,7 +499,7 @@ func resolveTCPAddrs(addr string, dualStack bool, resolver Resolver, deadline ti
 
 	n := len(ipaddrs)
 	addrs := make([]net.TCPAddr, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ip := ipaddrs[i]
 		if !dualStack && ip.IP.To4() == nil {
 			continue

--- a/tcplisten/tcplisten_test.go
+++ b/tcplisten/tcplisten_test.go
@@ -76,7 +76,7 @@ func testConfigV(t *testing.T, cfg Config, network, addr string) {
 		lns = append(lns, ln)
 	}
 
-	for i := 0; i < requestsCount; i++ {
+	for i := range requestsCount {
 		c, err := net.Dial(network, addr)
 		if err != nil {
 			t.Fatalf("%d. unexpected error when dialing: %s", i, err)

--- a/uri.go
+++ b/uri.go
@@ -308,9 +308,9 @@ func (u *URI) parse(host, uri []byte, isTLS bool) error {
 		}
 		host = host[n+1:]
 
-		if n := bytes.IndexByte(auth, ':'); n >= 0 {
-			u.username = append(u.username[:0], auth[:n]...)
-			u.password = append(u.password[:0], auth[n+1:]...)
+		if before, after, ok := bytes.Cut(auth, []byte{':'}); ok {
+			u.username = append(u.username[:0], before...)
+			u.password = append(u.password[:0], after...)
 		} else {
 			u.username = append(u.username[:0], auth...)
 			u.password = u.password[:0]
@@ -659,10 +659,7 @@ func normalizePath(dst, src []byte) []byte {
 		if n < 0 {
 			break
 		}
-		nn := bytes.LastIndexByte(b[:n], '/')
-		if nn < 0 {
-			nn = 0
-		}
+		nn := max(bytes.LastIndexByte(b[:n], '/'), 0)
 		n += len(strSlashDotDotSlash) - 1
 		copy(b[nn:], b[n:])
 		b = b[:len(b)-n+nn]
@@ -696,10 +693,7 @@ func normalizePath(dst, src []byte) []byte {
 			if n < 0 {
 				break
 			}
-			nn := bytes.LastIndexByte(b[:n], '/')
-			if nn < 0 {
-				nn = 0
-			}
+			nn := max(bytes.LastIndexByte(b[:n], '/'), 0)
 			nn++
 			n += len(strSlashDotDotBackSlash)
 			copy(b[nn:], b[n:])
@@ -712,10 +706,7 @@ func normalizePath(dst, src []byte) []byte {
 			if n < 0 {
 				break
 			}
-			nn := bytes.LastIndexByte(b[:n], '/')
-			if nn < 0 {
-				nn = 0
-			}
+			nn := max(bytes.LastIndexByte(b[:n], '/'), 0)
 			n += len(strBackSlashDotDotBackSlash) - 1
 			copy(b[nn:], b[n:])
 			b = b[:len(b)-n+nn]
@@ -951,7 +942,7 @@ func (u *URI) parseQueryArgs() {
 
 // stringContainsCTLByte reports whether s contains any ASCII control character.
 func stringContainsCTLByte(s []byte) bool {
-	for i := 0; i < len(s); i++ {
+	for i := range s {
 		b := s[i]
 		if b < ' ' || b == 0x7f {
 			return true

--- a/uri_test.go
+++ b/uri_test.go
@@ -35,14 +35,14 @@ func TestURIAcquireReleaseConcurrent(t *testing.T) {
 	t.Parallel()
 
 	ch := make(chan struct{}, 10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			testURIAcquireRelease(t)
 			ch <- struct{}{}
 		}()
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		select {
 		case <-ch:
 		case <-time.After(time.Second):
@@ -52,7 +52,7 @@ func TestURIAcquireReleaseConcurrent(t *testing.T) {
 }
 
 func testURIAcquireRelease(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		u := AcquireURI()
 		host := fmt.Sprintf("host.%d.com", i*23)
 		path := fmt.Sprintf("/foo/%d/bar", i*17)

--- a/userdata.go
+++ b/userdata.go
@@ -17,7 +17,7 @@ func (d *userData) Set(key, value any) {
 	}
 	args := *d
 	n := len(args)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		kv := &args[i]
 		if kv.key == key {
 			kv.value = value
@@ -56,7 +56,7 @@ func (d *userData) Get(key any) any {
 	}
 	args := *d
 	n := len(args)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		kv := &args[i]
 		if kv.key == key {
 			return kv.value
@@ -72,7 +72,7 @@ func (d *userData) GetBytes(key []byte) any {
 func (d *userData) Reset() {
 	args := *d
 	n := len(args)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		v := args[i].value
 		if vc, ok := v.(io.Closer); ok {
 			vc.Close()

--- a/userdata_test.go
+++ b/userdata_test.go
@@ -13,23 +13,23 @@ func TestUserData(t *testing.T) {
 
 	var u userData
 
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("key_%d", i))
+	for i := range 10 {
+		key := fmt.Appendf(nil, "key_%d", i)
 		u.SetBytes(key, i+5)
 		testUserDataGet(t, &u, key, i+5)
 		u.SetBytes(key, i)
 		testUserDataGet(t, &u, key, i)
 	}
 
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("key_%d", i))
+	for i := range 10 {
+		key := fmt.Appendf(nil, "key_%d", i)
 		testUserDataGet(t, &u, key, i)
 	}
 
 	u.Reset()
 
-	for i := 0; i < 10; i++ {
-		key := []byte(fmt.Sprintf("key_%d", i))
+	for i := range 10 {
+		key := fmt.Appendf(nil, "key_%d", i)
 		testUserDataGet(t, &u, key, nil)
 	}
 }
@@ -52,13 +52,13 @@ func TestUserDataValueClose(t *testing.T) {
 	closeCalls := 0
 
 	// store values implementing io.Closer
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		key := fmt.Sprintf("key_%d", i)
 		u.Set(key, &closerValue{closeCalls: &closeCalls})
 	}
 
 	// store values without io.Closer
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		key := fmt.Sprintf("key_noclose_%d", i)
 		u.Set(key, i)
 	}
@@ -84,7 +84,7 @@ func TestUserDataDelete(t *testing.T) {
 
 	var u userData
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		key := fmt.Sprintf("key_%d", i)
 		u.Set(key, i)
 		testUserDataGet(t, &u, []byte(key), i)
@@ -99,7 +99,7 @@ func TestUserDataDelete(t *testing.T) {
 		kk := fmt.Sprintf("key_%d", i+1)
 		testUserDataGet(t, &u, []byte(kk), i+1)
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		key := fmt.Sprintf("key_new_%d", i)
 		u.Set(key, i)
 		testUserDataGet(t, &u, []byte(key), i)

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -20,13 +20,13 @@ func TestWorkerPoolStartStopConcurrent(t *testing.T) {
 
 	concurrency := 10
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
 			testWorkerPoolStartStop()
 			ch <- struct{}{}
 		}()
 	}
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-ch:
 		case <-time.After(time.Second):
@@ -41,7 +41,7 @@ func testWorkerPoolStartStop() {
 		MaxWorkersCount: 10,
 		Logger:          defaultLogger,
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wp.Start()
 		wp.Stop()
 	}
@@ -58,13 +58,13 @@ func TestWorkerPoolMaxWorkersCountConcurrent(t *testing.T) {
 
 	concurrency := 4
 	ch := make(chan struct{}, concurrency)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		go func() {
 			testWorkerPoolMaxWorkersCountMulti(t)
 			ch <- struct{}{}
 		}()
 	}
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		select {
 		case <-ch:
 		case <-time.After(time.Second * 2):
@@ -74,7 +74,7 @@ func TestWorkerPoolMaxWorkersCountConcurrent(t *testing.T) {
 }
 
 func testWorkerPoolMaxWorkersCountMulti(t *testing.T) {
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		testWorkerPoolMaxWorkersCount(t)
 	}
 }
@@ -151,7 +151,7 @@ func testWorkerPoolMaxWorkersCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		if wp.Serve(conn) {
 			t.Fatalf("worker pool must be full")
 		}


### PR DESCRIPTION
Keep Go 1.24 compatibility for now (by not using `wg.Go()`).