### PR TITLE
Replace mustDiscard panic with error return (#1442)

### DIFF
--- a/header.go
+++ b/header.go
@@ -2170,7 +2170,9 @@ func (h *ResponseHeader) tryRead(r *bufio.Reader, n int) error {
 	if errParse != nil {
 		return headerError("response", err, errParse, b, h.secureErrorLogMessage)
 	}
-	mustDiscard(r, headersLen)
+	if err := discardHeader(r, headersLen); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2226,7 +2228,9 @@ func (h *header) tryReadTrailer(r *bufio.Reader, n int) error {
 		}
 		return headerError("response", err, errParse, b, h.secureErrorLogMessage)
 	}
-	mustDiscard(r, headersLen)
+	if err := discardHeader(r, headersLen); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2316,7 +2320,9 @@ func (h *RequestHeader) tryRead(r *bufio.Reader, n int) error {
 	if errParse != nil {
 		return headerError("request", err, errParse, b, h.secureErrorLogMessage)
 	}
-	mustDiscard(r, headersLen)
+	if err := discardHeader(r, headersLen); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3433,8 +3439,9 @@ func mustPeekBuffered(r *bufio.Reader) []byte {
 	return buf
 }
 
-func mustDiscard(r *bufio.Reader, n int) {
+func discardHeader(r *bufio.Reader, n int) error {
 	if _, err := r.Discard(n); err != nil {
-		panic(fmt.Sprintf("bufio.Reader.Discard(%d) failed: %v", n, err))
+		return fmt.Errorf("bufio.Reader.Discard(%d) failed: %w", n, err)
 	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Replace `mustDiscard()` which panics on `bufio.Reader.Discard()` failure with `discardHeader()` that returns an error, preventing server crashes under high concurrency.

## Problem

Under high concurrency, `mustDiscard()` in `header.go` panics when a connection times out during header reading:

```
panic: bufio.Reader.Discard(517) failed: read tcp4 ...: i/o timeout
```

This panic occurs in the worker goroutine and cannot be recovered by any middleware (RouterPanic, Recovery, etc.), causing the entire server to crash.

## Fix

- Rename `mustDiscard()` to `discardHeader()` and return an `error` instead of panicking
- Update all three call sites in `header.go` to propagate the error
- All call sites already return `error`, so the change is straightforward

## Testing

```bash
go test -run TestResponseHeader -count=1  # PASS
go test -run TestRequestHeader -count=1   # PASS
```

Fixes #1442