### PR TITLE
feat: add ExpectHandler for richer Expect: 100-continue handling

### DIFF
--- a/server.go
+++ b/server.go
@@ -205,8 +205,7 @@ type Server struct {
 	// client may have already started sending the request body.
 	//
 	// The ctx provides access to request headers and connection metadata (e.g.
-	// RemoteAddr for IP-based filtering). The response must not be modified —
-	// only the returned status code is used.
+	// RemoteAddr for IP-based filtering). The response must not be modified.
 	//
 	// If both ExpectHandler and ContinueHandler are set, ExpectHandler
 	// takes precedence.

--- a/server.go
+++ b/server.go
@@ -194,6 +194,25 @@ type Server struct {
 	// like they are normal requests.
 	ContinueHandler func(header *RequestHeader) bool
 
+	// ExpectHandler is called after receiving the Expect 100 Continue Header.
+	//
+	// https://www.rfc-editor.org/rfc/rfc9110.html#field.expect
+	//
+	// ExpectHandler provides more control than ContinueHandler by allowing
+	// the server to respond with any final status code. The handler should return
+	// StatusContinue (100) to accept the request and proceed to read the body,
+	// or any other status code to reject it. If StatusExpectationFailed (417) is
+	// returned, the response is sent and the connection is closed. For any other
+	// non-100 status code, the response is also sent and the connection is closed,
+	// since the client may have already started sending the request body.
+	//
+	// If both ExpectHandler and ContinueHandler are set, ExpectHandler
+	// takes precedence.
+	//
+	// The default behavior (when neither handler is set) is to automatically accept
+	// the request body.
+	ExpectHandler func(header *RequestHeader) int
+
 	// ConnState specifies an optional callback function that is
 	// called when a client connection changes state. See the
 	// ConnState type and associated constants for details.
@@ -2445,10 +2464,20 @@ func (s *Server) serveConn(c net.Conn) error {
 		}
 
 		// 'Expect: 100-continue' request handling.
-		// See https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html#sec8.2.3 for details.
+		// See https://www.rfc-editor.org/rfc/rfc9110.html#field.expect for details.
 		if ctx.Request.MayContinue() {
-			// Allow the ability to deny reading the incoming request body
-			if s.ContinueHandler != nil {
+			// Allow the ability to deny reading the incoming request body.
+			if s.ExpectHandler != nil {
+				if expectStatus := s.ExpectHandler(&ctx.Request.Header); expectStatus != StatusContinue {
+					continueReadingRequest = false
+					if br != nil {
+						br.Reset(ctx.c)
+					}
+					ctx.SetStatusCode(expectStatus)
+					// Close connection since client may have already started sending body data.
+					connectionClose = true
+				}
+			} else if s.ContinueHandler != nil {
 				if continueReadingRequest = s.ContinueHandler(&ctx.Request.Header); !continueReadingRequest {
 					if br != nil {
 						br.Reset(ctx.c)
@@ -2498,8 +2527,9 @@ func (s *Server) serveConn(c net.Conn) error {
 			}
 		}
 
-		// store req.ConnectionClose so even if it was changed inside of handler
-		connectionClose = s.DisableKeepalive || ctx.Request.Header.ConnectionClose()
+		// store req.ConnectionClose so even if it was changed inside of handler.
+		// Preserve connectionClose if already set (e.g., by ExpectHandler).
+		connectionClose = connectionClose || s.DisableKeepalive || ctx.Request.Header.ConnectionClose()
 
 		if serverName != "" {
 			ctx.Response.Header.SetServer(serverName)

--- a/server.go
+++ b/server.go
@@ -206,12 +206,16 @@ type Server struct {
 	// non-100 status code, the response is also sent and the connection is closed,
 	// since the client may have already started sending the request body.
 	//
+	// The ctx provides access to request headers and connection metadata (e.g.
+	// RemoteAddr for IP-based filtering). The response must not be modified —
+	// only the returned status code is used.
+	//
 	// If both ExpectHandler and ContinueHandler are set, ExpectHandler
 	// takes precedence.
 	//
 	// The default behavior (when neither handler is set) is to automatically accept
 	// the request body.
-	ExpectHandler func(header *RequestHeader) int
+	ExpectHandler func(ctx *RequestCtx) int
 
 	// ConnState specifies an optional callback function that is
 	// called when a client connection changes state. See the
@@ -2468,7 +2472,7 @@ func (s *Server) serveConn(c net.Conn) error {
 		if ctx.Request.MayContinue() {
 			// Allow the ability to deny reading the incoming request body.
 			if s.ExpectHandler != nil {
-				if expectStatus := s.ExpectHandler(&ctx.Request.Header); expectStatus != StatusContinue {
+				if expectStatus := s.ExpectHandler(ctx); expectStatus != StatusContinue {
 					continueReadingRequest = false
 					if br != nil {
 						br.Reset(ctx.c)

--- a/server.go
+++ b/server.go
@@ -201,10 +201,8 @@ type Server struct {
 	// ExpectHandler provides more control than ContinueHandler by allowing
 	// the server to respond with any final status code. The handler should return
 	// StatusContinue (100) to accept the request and proceed to read the body,
-	// or any other status code to reject it. If StatusExpectationFailed (417) is
-	// returned, the response is sent and the connection is closed. For any other
-	// non-100 status code, the response is also sent and the connection is closed,
-	// since the client may have already started sending the request body.
+	// or any other status code to reject it and close the connection since the
+	// client may have already started sending the request body.
 	//
 	// The ctx provides access to request headers and connection metadata (e.g.
 	// RemoteAddr for IP-based filtering). The response must not be modified —

--- a/server_test.go
+++ b/server_test.go
@@ -2102,6 +2102,199 @@ func TestServerContinueHandler(t *testing.T) {
 	}
 }
 
+func TestServerExpectHandler(t *testing.T) {
+	t.Parallel()
+
+	acceptContentLength := 5
+	s := &Server{
+		ExpectHandler: func(headers *RequestHeader) int {
+			if !headers.IsPost() {
+				t.Errorf("unexpected method %q. Expecting POST", headers.Method())
+			}
+
+			ct := headers.ContentType()
+			if string(ct) != "a/b" {
+				t.Errorf("unexpected content-type: %q. Expecting %q", ct, "a/b")
+			}
+
+			if headers.contentLength == acceptContentLength {
+				return StatusContinue
+			}
+			return StatusExpectationFailed
+		},
+		Handler: func(ctx *RequestCtx) {
+			if ctx.Request.Header.contentLength != acceptContentLength {
+				t.Errorf("all requests with content-length other than %d should be denied", acceptContentLength)
+			}
+			if !ctx.IsPost() {
+				t.Errorf("unexpected method %q. Expecting POST", ctx.Method())
+			}
+			if string(ctx.Path()) != "/foo" {
+				t.Errorf("unexpected path %q. Expecting %q", ctx.Path(), "/foo")
+			}
+			ct := ctx.Request.Header.ContentType()
+			if string(ct) != "a/b" {
+				t.Errorf("unexpected content-type: %q. Expecting %q", ct, "a/b")
+			}
+			if string(ctx.PostBody()) != "12345" {
+				t.Errorf("unexpected body: %q. Expecting %q", ctx.PostBody(), "12345")
+			}
+			ctx.WriteString("foobar") //nolint:errcheck
+		},
+	}
+
+	sendRequest := func(rw *readWriter, expectedStatusCode int, expectedResponse string) {
+		if err := s.ServeConn(rw); err != nil {
+			t.Fatalf("Unexpected error from serveConn: %v", err)
+		}
+
+		br := bufio.NewReader(&rw.w)
+		verifyResponse(t, br, expectedStatusCode, string(defaultContentType), expectedResponse)
+
+		data, err := io.ReadAll(br)
+		if err != nil {
+			t.Fatalf("Unexpected error when reading remaining data: %v", err)
+		}
+		if len(data) > 0 {
+			t.Fatalf("unexpected remaining data %q", data)
+		}
+	}
+
+	rw := &readWriter{}
+	for range 25 {
+		// Regular requests without Expect header
+		rw.r.Reset()
+		rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")
+		sendRequest(rw, StatusOK, "foobar")
+
+		// Expect 100-continue requests that are accepted
+		rw.r.Reset()
+		rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")
+		sendRequest(rw, StatusOK, "foobar")
+
+		// Requests rejected with 417
+		rw.r.Reset()
+		rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 6\r\nContent-Type: a/b\r\n\r\n123456")
+		sendRequest(rw, StatusExpectationFailed, "")
+	}
+}
+
+func TestServerExpectHandlerCustomStatusCode(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		ExpectHandler: func(headers *RequestHeader) int {
+			// Reject with 413 Request Entity Too Large for large bodies
+			if headers.ContentLength() > 5 {
+				return StatusRequestEntityTooLarge
+			}
+			return StatusContinue
+		},
+		Handler: func(ctx *RequestCtx) {
+			ctx.WriteString("ok") //nolint:errcheck
+		},
+	}
+
+	// Accepted request
+	rw := &readWriter{}
+	rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from serveConn: %v", err)
+	}
+	br := bufio.NewReader(&rw.w)
+	verifyResponse(t, br, StatusOK, string(defaultContentType), "ok")
+
+	// Rejected request with 413 — connection should be closed
+	rw = &readWriter{}
+	rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 6\r\nContent-Type: a/b\r\n\r\n123456")
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from serveConn: %v", err)
+	}
+	br = bufio.NewReader(&rw.w)
+	verifyResponse(t, br, StatusRequestEntityTooLarge, string(defaultContentType), "")
+}
+
+func TestServerExpectHandlerConnectionClose(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		ExpectHandler: func(headers *RequestHeader) int {
+			if headers.ContentLength() > 5 {
+				return StatusExpectationFailed
+			}
+			return StatusContinue
+		},
+		Handler: func(ctx *RequestCtx) {
+			ctx.WriteString("ok") //nolint:errcheck
+		},
+	}
+
+	// When rejected, the response should have Connection: close and
+	// subsequent pipelined requests should NOT be processed.
+	rw := &readWriter{}
+	// Send two pipelined requests: one rejected, one that should never be processed.
+	rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 6\r\nContent-Type: a/b\r\n\r\n123456")
+	rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")
+
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from serveConn: %v", err)
+	}
+
+	br := bufio.NewReader(&rw.w)
+	var resp Response
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("Unexpected error when reading response: %v", err)
+	}
+	if resp.StatusCode() != StatusExpectationFailed {
+		t.Fatalf("unexpected status code: %d. Expecting %d", resp.StatusCode(), StatusExpectationFailed)
+	}
+	if !resp.Header.ConnectionClose() {
+		t.Fatal("response should have Connection: close header")
+	}
+
+	// Verify no second response was sent (connection was closed after first rejection).
+	data, err := io.ReadAll(br)
+	if err != nil {
+		t.Fatalf("Unexpected error when reading remaining data: %v", err)
+	}
+	if len(data) > 0 {
+		t.Fatalf("unexpected remaining data %q. Connection should have been closed", data)
+	}
+}
+
+func TestServerExpectHandlerPrecedence(t *testing.T) {
+	t.Parallel()
+
+	// When both ExpectHandler and ContinueHandler are set,
+	// ExpectHandler should take precedence.
+	continueHandlerCalled := false
+	s := &Server{
+		ContinueHandler: func(headers *RequestHeader) bool {
+			continueHandlerCalled = true
+			return true
+		},
+		ExpectHandler: func(headers *RequestHeader) int {
+			return StatusRequestEntityTooLarge
+		},
+		Handler: func(ctx *RequestCtx) {
+			t.Error("handler should not be called when ExpectHandler rejects")
+		},
+	}
+
+	rw := &readWriter{}
+	rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from serveConn: %v", err)
+	}
+
+	br := bufio.NewReader(&rw.w)
+	verifyResponse(t, br, StatusRequestEntityTooLarge, string(defaultContentType), "")
+
+	if continueHandlerCalled {
+		t.Fatal("ContinueHandler should not be called when ExpectHandler is set")
+	}
+}
+
 func TestCompressHandler(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -2107,17 +2107,17 @@ func TestServerExpectHandler(t *testing.T) {
 
 	acceptContentLength := 5
 	s := &Server{
-		ExpectHandler: func(headers *RequestHeader) int {
-			if !headers.IsPost() {
-				t.Errorf("unexpected method %q. Expecting POST", headers.Method())
+		ExpectHandler: func(ctx *RequestCtx) int {
+			if !ctx.IsPost() {
+				t.Errorf("unexpected method %q. Expecting POST", ctx.Method())
 			}
 
-			ct := headers.ContentType()
+			ct := ctx.Request.Header.ContentType()
 			if string(ct) != "a/b" {
 				t.Errorf("unexpected content-type: %q. Expecting %q", ct, "a/b")
 			}
 
-			if headers.contentLength == acceptContentLength {
+			if ctx.Request.Header.contentLength == acceptContentLength {
 				return StatusContinue
 			}
 			return StatusExpectationFailed
@@ -2183,9 +2183,9 @@ func TestServerExpectHandlerCustomStatusCode(t *testing.T) {
 	t.Parallel()
 
 	s := &Server{
-		ExpectHandler: func(headers *RequestHeader) int {
+		ExpectHandler: func(ctx *RequestCtx) int {
 			// Reject with 413 Request Entity Too Large for large bodies
-			if headers.ContentLength() > 5 {
+			if ctx.Request.Header.ContentLength() > 5 {
 				return StatusRequestEntityTooLarge
 			}
 			return StatusContinue
@@ -2218,8 +2218,8 @@ func TestServerExpectHandlerConnectionClose(t *testing.T) {
 	t.Parallel()
 
 	s := &Server{
-		ExpectHandler: func(headers *RequestHeader) int {
-			if headers.ContentLength() > 5 {
+		ExpectHandler: func(ctx *RequestCtx) int {
+			if ctx.Request.Header.ContentLength() > 5 {
 				return StatusExpectationFailed
 			}
 			return StatusContinue
@@ -2273,7 +2273,7 @@ func TestServerExpectHandlerPrecedence(t *testing.T) {
 			continueHandlerCalled = true
 			return true
 		},
-		ExpectHandler: func(headers *RequestHeader) int {
+		ExpectHandler: func(ctx *RequestCtx) int {
 			return StatusRequestEntityTooLarge
 		},
 		Handler: func(ctx *RequestCtx) {
@@ -2293,6 +2293,32 @@ func TestServerExpectHandlerPrecedence(t *testing.T) {
 	if continueHandlerCalled {
 		t.Fatal("ContinueHandler should not be called when ExpectHandler is set")
 	}
+}
+
+func TestServerExpectHandlerRemoteAddr(t *testing.T) {
+	t.Parallel()
+
+	// ExpectHandler can use ctx.RemoteAddr() for IP-based filtering.
+	// readWriter returns zeroTCPAddr (0.0.0.0:0) as the remote address.
+	s := &Server{
+		ExpectHandler: func(ctx *RequestCtx) int {
+			if ctx.RemoteAddr().String() == "0.0.0.0:0" {
+				return StatusForbidden
+			}
+			return StatusContinue
+		},
+		Handler: func(ctx *RequestCtx) {
+			ctx.WriteString("ok") //nolint:errcheck
+		},
+	}
+
+	rw := &readWriter{}
+	rw.r.WriteString("POST /foo HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 5\r\nContent-Type: a/b\r\n\r\n12345")
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from serveConn: %v", err)
+	}
+	br := bufio.NewReader(&rw.w)
+	verifyResponse(t, br, StatusForbidden, string(defaultContentType), "")
 }
 
 func TestCompressHandler(t *testing.T) {


### PR DESCRIPTION
ContinueHandler only returns a bool, limiting the server to either accepting (100) or rejecting with 417. ExpectHandler allows returning any HTTP status code, and closes the connection on rejection since the client may have already started sending body data per RFC 9110.

ExpectHandler takes precedence when both handlers are set.