### PR TITLE
Match net/http sensitive header redirect policy

### DIFF
--- a/client.go
+++ b/client.go
@@ -1143,6 +1143,7 @@ func doRequestFollowRedirects(
 	req *Request, resp *Response, url string, maxRedirectsCount int, c clientDoer,
 ) (statusCode int, body []byte, err error) {
 	redirectsCount := 0
+	initialHost := hostnameFromURLString(url)
 
 	for {
 		req.SetRequestURI(url)
@@ -1168,7 +1169,10 @@ func doRequestFollowRedirects(
 			err = ErrMissingLocation
 			break
 		}
-		url = getRedirectURL(url, location, req.DisableRedirectPathNormalizing)
+		redirectURI := AcquireURI()
+		url = getRedirectURL(url, location, req.DisableRedirectPathNormalizing, redirectURI)
+		stripSensitiveHeadersOnRedirect(req, initialHost, redirectURI)
+		ReleaseURI(redirectURI)
 
 		if string(req.Header.Method()) == "POST" && (statusCode == 301 || statusCode == 302) {
 			req.Header.SetMethod(MethodGet)
@@ -1178,14 +1182,89 @@ func doRequestFollowRedirects(
 	return statusCode, body, err
 }
 
-func getRedirectURL(baseURL string, location []byte, disablePathNormalizing bool) string {
-	u := AcquireURI()
-	u.Update(baseURL)
-	u.UpdateBytes(location)
-	u.DisablePathNormalizing = disablePathNormalizing
-	redirectURL := u.String()
-	ReleaseURI(u)
-	return redirectURL
+func getRedirectURL(baseURL string, location []byte, disablePathNormalizing bool, dst *URI) string {
+	dst.Update(baseURL)
+	dst.UpdateBytes(location)
+	dst.DisablePathNormalizing = disablePathNormalizing
+	return dst.String()
+}
+
+// Redirect handling reuses the original Request, so sensitive request
+// headers must be cleared before following redirects that net/http treats
+// as untrusted.
+func stripSensitiveHeadersOnRedirect(req *Request, initialHost []byte, redirectURI *URI) {
+	if !shouldStripSensitiveHeadersOnRedirect(initialHost, redirectURI.Host()) {
+		return
+	}
+
+	req.Header.Del(HeaderAuthorization)
+	req.Header.Del(HeaderCookie)
+	req.Header.Del(HeaderCookie2) // Match net/http behavior.
+	req.Header.Del(HeaderProxyAuthorization)
+}
+
+// shouldStripSensitiveHeadersOnRedirect defines the trust boundary for
+// caller-supplied credentials during redirect handling.
+//
+// net/http forwards sensitive headers only to trusted redirect targets and
+// documents that policy in the Client redirect handling:
+// https://github.com/golang/go/blob/go1.24.1/src/net/http/client.go#L41-L49
+// https://github.com/golang/go/blob/go1.24.1/src/net/http/client.go#L1005-L1021
+//
+// Match that behavior here by anchoring the trust decision to the initial
+// request host, ignoring ports and scheme, and allowing exact-host or
+// subdomain redirects to keep caller-supplied credentials.
+func shouldStripSensitiveHeadersOnRedirect(initialHost, redirectHostPort []byte) bool {
+	return !isDomainOrSubdomainBytes(hostnameFromHostPortBytes(redirectHostPort), initialHost)
+}
+
+func hostnameFromURLString(url string) []byte {
+	_, host, _ := splitHostURI(nil, s2b(url))
+	if n := bytes.LastIndexByte(host, '@'); n >= 0 {
+		host = host[n+1:]
+	}
+	return hostnameFromHostPortBytes(host)
+}
+
+func hostnameFromHostPortBytes(hostPort []byte) []byte {
+	host, _ := splitHostPortBytes(hostPort)
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		return host[1 : len(host)-1]
+	}
+	return host
+}
+
+func isDomainOrSubdomainBytes(sub, parent []byte) bool {
+	if bytes.EqualFold(sub, parent) {
+		return true
+	}
+	if len(sub) <= len(parent) || bytes.IndexByte(sub, ':') >= 0 || bytes.IndexByte(sub, '%') >= 0 {
+		return false
+	}
+	if !bytes.EqualFold(sub[len(sub)-len(parent):], parent) {
+		return false
+	}
+	return sub[len(sub)-len(parent)-1] == '.'
+}
+
+func splitHostPortBytes(hostPort []byte) ([]byte, []byte) {
+	if len(hostPort) == 0 {
+		return hostPort, nil
+	}
+
+	if hostPort[0] == '[' {
+		n := bytes.LastIndexByte(hostPort, ']')
+		if n >= 0 && n+1 < len(hostPort) && hostPort[n+1] == ':' {
+			return hostPort[:n+1], hostPort[n+2:]
+		}
+		return hostPort, nil
+	}
+
+	n := bytes.LastIndexByte(hostPort, ':')
+	if n < 0 || bytes.IndexByte(hostPort[:n], ':') >= 0 {
+		return hostPort, nil
+	}
+	return hostPort[:n], hostPort[n+1:]
 }
 
 // StatusCodeIsRedirect returns true if the status code indicates a redirect.

--- a/client.go
+++ b/client.go
@@ -1200,7 +1200,9 @@ func stripSensitiveHeadersOnRedirect(req *Request, initialHost []byte, redirectU
 	req.Header.Del(HeaderAuthorization)
 	req.Header.Del(HeaderCookie)
 	req.Header.Del(HeaderCookie2) // Match net/http behavior.
+	req.Header.Del(HeaderProxyAuthenticate)
 	req.Header.Del(HeaderProxyAuthorization)
+	req.Header.Del(HeaderWWWAuthenticate)
 }
 
 // shouldStripSensitiveHeadersOnRedirect defines the trust boundary for

--- a/client_test.go
+++ b/client_test.go
@@ -1761,6 +1761,73 @@ func TestClientFollowRedirects(t *testing.T) {
 	ReleaseResponse(resp)
 }
 
+func TestShouldStripSensitiveHeadersOnRedirect(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		initialURL  string
+		redirectURL string
+		want        bool
+	}{
+		{
+			name:        "same host keeps headers",
+			initialURL:  "http://example.com/foo",
+			redirectURL: "http://example.com/bar",
+			want:        false,
+		},
+		{
+			name:        "subdomain keeps headers",
+			initialURL:  "http://example.com/foo",
+			redirectURL: "https://sub.example.com:8443/bar",
+			want:        false,
+		},
+		{
+			name:        "same host different port keeps headers",
+			initialURL:  "http://example.com/foo",
+			redirectURL: "http://example.com:8080/bar",
+			want:        false,
+		},
+		{
+			name:        "http upgrade keeps headers",
+			initialURL:  "http://example.com/foo",
+			redirectURL: "https://example.com/bar",
+			want:        false,
+		},
+		{
+			name:        "https downgrade keeps headers",
+			initialURL:  "https://example.com/foo",
+			redirectURL: "http://example.com/bar",
+			want:        false,
+		},
+		{
+			name:        "parent domain strips when initial host is subdomain",
+			initialURL:  "http://sub.example.com/foo",
+			redirectURL: "http://example.com/bar",
+			want:        true,
+		},
+		{
+			name:        "unrelated host strips headers",
+			initialURL:  "http://example.com/foo",
+			redirectURL: "http://example.net/bar",
+			want:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			initialHost := hostnameFromURLString(tc.initialURL)
+
+			var redirectURI URI
+			redirectURI.Update(tc.redirectURL)
+
+			if got := shouldStripSensitiveHeadersOnRedirect(initialHost, redirectURI.Host()); got != tc.want {
+				t.Fatalf("unexpected redirect stripping decision: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestClientGetTimeoutSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -3343,7 +3410,10 @@ func Test_getRedirectURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getRedirectURL(tt.args.baseURL, tt.args.location, tt.args.disablePathNormalizing); got != tt.want {
+			redirectURI := AcquireURI()
+			got := getRedirectURL(tt.args.baseURL, tt.args.location, tt.args.disablePathNormalizing, redirectURI)
+			ReleaseURI(redirectURI)
+			if got != tt.want {
 				t.Errorf("getRedirectURL() = %v, want %v", got, tt.want)
 			}
 		})

--- a/headers.go
+++ b/headers.go
@@ -37,6 +37,7 @@ const (
 	HeaderContentSecurityPolicyReportOnly = "Content-Security-Policy-Report-Only"
 	HeaderContentType                     = "Content-Type"
 	HeaderCookie                          = "Cookie"
+	HeaderCookie2                         = "Cookie2"
 	HeaderCrossOriginResourcePolicy       = "Cross-Origin-Resource-Policy"
 	HeaderDate                            = "Date"
 	HeaderDNT                             = "DNT"


### PR DESCRIPTION
Strip sensitive headers in DoRedirects matching net/http's redirect policy.

Reported by @vnykmshr