### PR TITLE
server: apply ReadTimeout before first byte with ReduceMemoryUsage

### DIFF
--- a/server.go
+++ b/server.go
@@ -2290,8 +2290,15 @@ func (s *Server) serveConn(c net.Conn) error {
 	for {
 		connRequestNum++
 
-		// If this is a keep-alive connection set the idle timeout.
-		if connRequestNum > 1 {
+		if connRequestNum == 1 {
+			// Apply ReadTimeout to the first request byte.
+			if s.ReadTimeout > 0 {
+				if err = c.SetReadDeadline(time.Now().Add(s.ReadTimeout)); err != nil {
+					break
+				}
+			}
+		} else {
+			// If this is a keep-alive connection set the idle timeout.
 			if d := s.idleTimeout(); d > 0 {
 				if err = c.SetReadDeadline(time.Now().Add(d)); err != nil {
 					break
@@ -2318,8 +2325,8 @@ func (s *Server) serveConn(c net.Conn) error {
 				}
 			}
 		} else {
-			// If this is a keep-alive connection acquireByteReader will try to peek
-			// a couple of bytes already so the idle timeout will already be used.
+			// On keep-alive connections acquireByteReader will read the first byte
+			// while the idle timeout is active.
 			br, err = acquireByteReader(&ctx)
 		}
 

--- a/server_test.go
+++ b/server_test.go
@@ -1215,6 +1215,53 @@ func TestServerTLSReadTimeout(t *testing.T) {
 	}
 }
 
+func TestServerReduceMemoryUsageReadTimeoutOnFirstByte(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			t.Error("shouldn't reach handler")
+		},
+		ReduceMemoryUsage: true,
+		ReadTimeout:       100 * time.Millisecond,
+		Logger:            &testLogger{},
+	}
+
+	pipe := fasthttputil.NewPipeConns()
+	cc, sc := pipe.Conn1(), pipe.Conn2()
+	defer cc.Close()
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- s.ServeConn(sc)
+	}()
+
+	readErrCh := make(chan error, 1)
+	go func() {
+		var b [1]byte
+		_, err := cc.Read(b[:])
+		readErrCh <- err
+	}()
+
+	select {
+	case err := <-readErrCh:
+		if err == nil {
+			t.Fatal("server didn't close connection after first-byte timeout")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server didn't close connection after first-byte timeout")
+	}
+
+	select {
+	case err := <-serveErrCh:
+		if err != nil {
+			t.Fatalf("unexpected error from ServeConn: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for ServeConn")
+	}
+}
+
 func TestServerServeTLSEmbed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
On new connections with ReduceMemoryUsage enabled, serveConn could reach acquireByteReader before installing a read deadline. That left the first blocking read outside ReadTimeout and allowed silent clients to keep the connection open until some external timeout closed it.

Apply ReadTimeout before the first read on a new connection, while keeping the existing idle-timeout behavior for keep-alive requests. Add a regression test that verifies the server closes a silent ReduceMemoryUsage connection after the first-byte timeout.