### PR TITLE
Sanitize cookie setters to prevent CRLF injection

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -162,12 +162,14 @@ func (c *Cookie) Path() []byte {
 func (c *Cookie) SetPath(path string) {
 	c.bufK = append(c.bufK[:0], path...)
 	c.path = normalizePath(c.path, c.bufK)
+	c.path = removeNewLines(c.path)
 }
 
 // SetPathBytes sets cookie path.
 func (c *Cookie) SetPathBytes(path []byte) {
 	c.bufK = append(c.bufK[:0], path...)
 	c.path = normalizePath(c.path, c.bufK)
+	c.path = removeNewLines(c.path)
 }
 
 // Domain returns cookie domain.
@@ -180,12 +182,12 @@ func (c *Cookie) Domain() []byte {
 
 // SetDomain sets cookie domain.
 func (c *Cookie) SetDomain(domain string) {
-	c.domain = append(c.domain[:0], domain...)
+	c.domain = initHeaderValueString(c.domain, domain)
 }
 
 // SetDomainBytes sets cookie domain.
 func (c *Cookie) SetDomainBytes(domain []byte) {
-	c.domain = append(c.domain[:0], domain...)
+	c.domain = initHeaderValueBytes(c.domain, domain)
 }
 
 // MaxAge returns the seconds until the cookie is meant to expire or 0
@@ -236,12 +238,12 @@ func (c *Cookie) Value() []byte {
 
 // SetValue sets cookie value.
 func (c *Cookie) SetValue(value string) {
-	c.value = append(c.value[:0], value...)
+	c.value = initHeaderValueString(c.value, value)
 }
 
 // SetValueBytes sets cookie value.
 func (c *Cookie) SetValueBytes(value []byte) {
-	c.value = append(c.value[:0], value...)
+	c.value = initHeaderValueBytes(c.value, value)
 }
 
 // Key returns cookie name.
@@ -254,12 +256,12 @@ func (c *Cookie) Key() []byte {
 
 // SetKey sets cookie name.
 func (c *Cookie) SetKey(key string) {
-	c.key = append(c.key[:0], key...)
+	c.key = initHeaderValueString(c.key, key)
 }
 
 // SetKeyBytes sets cookie name.
 func (c *Cookie) SetKeyBytes(key []byte) {
-	c.key = append(c.key[:0], key...)
+	c.key = initHeaderValueBytes(c.key, key)
 }
 
 // Reset clears the cookie.
@@ -385,8 +387,8 @@ func (c *Cookie) ParseBytes(src []byte) error {
 		return errNoCookies
 	}
 
-	c.key = append(c.key, k...)
-	c.value = append(c.value, v...)
+	c.key = initHeaderValueBytes(c.key, k)
+	c.value = initHeaderValueBytes(c.value, v)
 
 	for s.nextRaw(&k, &v) {
 		if len(k) != 0 {
@@ -412,12 +414,12 @@ func (c *Cookie) ParseBytes(src []byte) error {
 
 			case 'd': // "domain"
 				if caseInsensitiveCompare(strCookieDomain, k) {
-					c.domain = append(c.domain, v...)
+					c.domain = initHeaderValueBytes(c.domain, v)
 				}
 
 			case 'p': // "path"
 				if caseInsensitiveCompare(strCookiePath, k) {
-					c.path = append(c.path, v...)
+					c.path = initHeaderValueBytes(c.path, v)
 				}
 
 			case 's': // "samesite"

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -15,6 +15,84 @@ func TestCookiePanic(t *testing.T) {
 	}
 }
 
+func TestCookieSettersSanitizeNewLines(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		set  func(c *Cookie)
+	}{
+		{
+			name: "SetKey",
+			set:  func(c *Cookie) { c.SetKey("sid\r\nSet-Cookie: admin=1") },
+		},
+		{
+			name: "SetKeyBytes",
+			set:  func(c *Cookie) { c.SetKeyBytes([]byte("sid\r\nSet-Cookie: admin=1")) },
+		},
+		{
+			name: "SetValue",
+			set:  func(c *Cookie) { c.SetValue("abc\r\nSet-Cookie: admin=1") },
+		},
+		{
+			name: "SetValueBytes",
+			set:  func(c *Cookie) { c.SetValueBytes([]byte("abc\r\nSet-Cookie: admin=1")) },
+		},
+		{
+			name: "SetDomain",
+			set:  func(c *Cookie) { c.SetDomain("example.com\r\nSet-Cookie: admin=1") },
+		},
+		{
+			name: "SetDomainBytes",
+			set:  func(c *Cookie) { c.SetDomainBytes([]byte("example.com\r\nSet-Cookie: admin=1")) },
+		},
+		{
+			name: "SetPath",
+			set:  func(c *Cookie) { c.SetPath("/account\r\nSet-Cookie: admin=1") },
+		},
+		{
+			name: "SetPathBytes",
+			set:  func(c *Cookie) { c.SetPathBytes([]byte("/account\r\nSet-Cookie: admin=1")) },
+		},
+		{
+			name: "SetPathEncodedNewLine",
+			set:  func(c *Cookie) { c.SetPath("/account%0d%0aSet-Cookie:%20admin=1") },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c Cookie
+			c.SetKey("sid")
+			c.SetValue("abc")
+			c.SetDomain("example.com")
+			c.SetPath("/")
+
+			tc.set(&c)
+
+			s := c.String()
+			if strings.ContainsAny(s, "\r\n") {
+				t.Fatalf("unexpected newline in cookie %q", s)
+			}
+		})
+	}
+}
+
+func TestCookieParseSanitizesNewLines(t *testing.T) {
+	t.Parallel()
+
+	var c Cookie
+	err := c.Parse("sid=abc\r\nSet-Cookie: admin=1; Domain=example.com\r\nSet-Cookie: admin=1; Path=/account\r\nSet-Cookie: admin=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := c.String()
+	if strings.ContainsAny(s, "\r\n") {
+		t.Fatalf("unexpected newline in cookie %q", s)
+	}
+}
+
 func TestCookieValueWithEqualAndSpaceChars(t *testing.T) {
 	t.Parallel()
 

--- a/header.go
+++ b/header.go
@@ -1655,13 +1655,17 @@ func (h *ResponseHeader) SetCanonical(key, value []byte) {
 //
 // It is safe re-using the cookie after the function returns.
 func (h *ResponseHeader) SetCookie(cookie *Cookie) {
-	h.cookies = setArgBytes(h.cookies, cookie.Key(), cookie.Cookie(), argsHasValue)
+	h.bufK = initHeaderValueBytes(h.bufK, cookie.Key())
+	h.bufV = initHeaderValueBytes(h.bufV, cookie.Cookie())
+	h.cookies = setArgBytes(h.cookies, h.bufK, h.bufV, argsHasValue)
 }
 
 // SetCookie sets 'key: value' cookies.
 func (h *RequestHeader) SetCookie(key, value string) {
 	h.collectCookies()
-	h.cookies = setArg(h.cookies, key, value, argsHasValue)
+	h.bufK = initHeaderValueString(h.bufK, key)
+	h.bufV = initHeaderValueString(h.bufV, value)
+	h.cookies = setArgBytes(h.cookies, h.bufK, h.bufV, argsHasValue)
 }
 
 // SetCookieBytesK sets 'key: value' cookies.

--- a/header_test.go
+++ b/header_test.go
@@ -2398,6 +2398,64 @@ func TestRequestHeaderCookie(t *testing.T) {
 	}
 }
 
+func TestRequestHeaderSetCookieSanitizesNewLines(t *testing.T) {
+	t.Parallel()
+
+	var h RequestHeader
+	h.SetRequestURI("/")
+	h.SetHost("example.com")
+	h.SetCookie("sid\r\nX-Injected-Key: 1", "abc\r\nX-Injected-Value: 1")
+
+	header := string(h.Header())
+	if strings.Contains(header, "\r\nX-Injected") {
+		t.Fatalf("unexpected injected header in %q", header)
+	}
+	if n := strings.Count(header, "\r\nCookie: "); n != 1 {
+		t.Fatalf("unexpected Cookie header count %d in %q", n, header)
+	}
+}
+
+func TestResponseHeaderSetCookieSanitizesNewLines(t *testing.T) {
+	t.Parallel()
+
+	var c Cookie
+	c.SetKey("sid")
+	c.SetValue("abc\r\nSet-Cookie: admin=1; Path=/; HttpOnly")
+
+	var h ResponseHeader
+	h.SetStatusCode(StatusOK)
+	h.SetCookie(&c)
+
+	header := string(h.Header())
+	if strings.Contains(header, "\r\nSet-Cookie: admin=1") {
+		t.Fatalf("unexpected injected Set-Cookie header in %q", header)
+	}
+	if n := strings.Count(header, "\r\nSet-Cookie: "); n != 1 {
+		t.Fatalf("unexpected Set-Cookie header count %d in %q", n, header)
+	}
+}
+
+func TestResponseHeaderSetParsedCookieSanitizesNewLines(t *testing.T) {
+	t.Parallel()
+
+	var c Cookie
+	err := c.Parse("sid=abc\r\nSet-Cookie: admin=1; Path=/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var h ResponseHeader
+	h.SetCookie(&c)
+
+	header := string(h.Header())
+	if strings.Contains(header, "\r\nSet-Cookie: admin=1") {
+		t.Fatalf("unexpected injected Set-Cookie header in %q", header)
+	}
+	if n := strings.Count(header, "\r\nSet-Cookie: "); n != 1 {
+		t.Fatalf("unexpected Set-Cookie header count %d in %q", n, header)
+	}
+}
+
 func TestResponseHeaderCookieIssue4(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Prevent cookie APIs from serializing embedded CR or LF bytes into Cookie and Set-Cookie header lines.

Route Cookie key, value, domain, and path setters, parsed cookie fields, and RequestHeader/ResponseHeader SetCookie paths through the existing newline sanitization. Sanitize paths after normalization so percent-decoded CR/LF bytes cannot bypass the guard.

Thanks to @vnykmshr for reporting this issue.