### PR TITLE
header: reject invalid trailer names

### DIFF
--- a/header.go
+++ b/header.go
@@ -505,20 +505,14 @@ func (h *header) AddTrailerBytes(trailer []byte) (err error) {
 		if i < 0 {
 			i = len(trailer)
 		}
-		key := trailer[:i]
-		for len(key) > 0 && key[0] == ' ' {
-			key = key[1:]
-		}
-		for len(key) > 0 && key[len(key)-1] == ' ' {
-			key = key[:len(key)-1]
-		}
+		key := trim(trailer[:i])
 		// Forbidden by RFC 7230, section 4.1.2
-		if isBadTrailer(key) {
+		if !isValidTrailerKey(key) || isBadTrailer(key) {
 			err = ErrBadTrailer
 			continue
 		}
 		h.bufK = append(h.bufK[:0], key...)
-		normalizeHeaderKey(h.bufK, h.disableNormalizing || bytes.IndexByte(h.bufK, ' ') != -1)
+		normalizeHeaderKeyValidated(h.bufK, h.disableNormalizing)
 		if cap(h.trailer) > len(h.trailer) {
 			h.trailer = h.trailer[:len(h.trailer)+1]
 			h.trailer[len(h.trailer)-1] = append(h.trailer[len(h.trailer)-1][:0], h.bufK...)
@@ -530,6 +524,18 @@ func (h *header) AddTrailerBytes(trailer []byte) (err error) {
 	}
 
 	return err
+}
+
+func isValidTrailerKey(key []byte) bool {
+	if len(key) == 0 {
+		return false
+	}
+	for _, c := range key {
+		if !validHeaderFieldByte(c) {
+			return false
+		}
+	}
+	return true
 }
 
 // validHeaderFieldByte returns true if c valid header field byte

--- a/header_test.go
+++ b/header_test.go
@@ -2017,7 +2017,7 @@ func TestResponseHeaderAddTrailerError(t *testing.T) {
 
 	var h ResponseHeader
 	err := h.AddTrailer("Foo,   Content-Length , bAr,Transfer-Encoding, uSer aGent")
-	expectedTrailer := "Foo, Bar, uSer aGent"
+	expectedTrailer := "Foo, Bar"
 
 	if !errors.Is(err, ErrBadTrailer) {
 		t.Fatalf("unexpected err %q. Expected %q", err, ErrBadTrailer)
@@ -2040,6 +2040,105 @@ func TestRequestHeaderAddTrailerError(t *testing.T) {
 	if trailer := string(h.Peek(HeaderTrailer)); trailer != expectedTrailer {
 		t.Fatalf("unexpected trailer %q. Expected %q", trailer, expectedTrailer)
 	}
+}
+
+func TestResponseHeaderAddTrailerRejectsInvalidNames(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		trailer string
+	}{
+		{"crlf", "X-Ok\r\nInjected: yes"},
+		{"cr", "X-Ok\rInjected"},
+		{"lf", "X-Ok\nInjected"},
+		{"tab_inside", "X\tOk"},
+		{"space_inside", "X Ok"},
+		{"colon", "X-Ok: Injected"},
+		{"non_ascii", "X-\xff"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var h ResponseHeader
+			h.noDefaultDate = true
+			err := h.AddTrailer(tc.trailer)
+			if !errors.Is(err, ErrBadTrailer) {
+				t.Fatalf("unexpected err %q. Expected %q", err, ErrBadTrailer)
+			}
+			if trailer := string(h.Peek(HeaderTrailer)); trailer != "" {
+				t.Fatalf("unexpected trailer %q. Expected empty trailer", trailer)
+			}
+			if header := string(h.Header()); strings.Contains(header, "\r\nInjected") {
+				t.Fatalf("unexpected injected header in %q", header)
+			}
+		})
+	}
+}
+
+func TestRequestHeaderAddTrailerRejectsInvalidNames(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		trailer string
+	}{
+		{"crlf", "X-Ok\r\nInjected: yes"},
+		{"cr", "X-Ok\rInjected"},
+		{"lf", "X-Ok\nInjected"},
+		{"tab_inside", "X\tOk"},
+		{"space_inside", "X Ok"},
+		{"colon", "X-Ok: Injected"},
+		{"non_ascii", "X-\xff"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var h RequestHeader
+			err := h.AddTrailer(tc.trailer)
+			if !errors.Is(err, ErrBadTrailer) {
+				t.Fatalf("unexpected err %q. Expected %q", err, ErrBadTrailer)
+			}
+			if trailer := string(h.Peek(HeaderTrailer)); trailer != "" {
+				t.Fatalf("unexpected trailer %q. Expected empty trailer", trailer)
+			}
+			if header := string(h.Header()); strings.Contains(header, "\r\nInjected") {
+				t.Fatalf("unexpected injected header in %q", header)
+			}
+		})
+	}
+}
+
+func TestHeaderAddTrailerTrimsOWS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ResponseHeader", func(t *testing.T) {
+		t.Parallel()
+
+		var h ResponseHeader
+		if err := h.AddTrailer("\tfoo\t, \tbar \t"); err != nil {
+			t.Fatalf("unexpected err %q", err)
+		}
+		if trailer := string(h.Peek(HeaderTrailer)); trailer != "Foo, Bar" {
+			t.Fatalf("unexpected trailer %q. Expected %q", trailer, "Foo, Bar")
+		}
+	})
+
+	t.Run("RequestHeader", func(t *testing.T) {
+		t.Parallel()
+
+		var h RequestHeader
+		if err := h.AddTrailer("\tfoo\t, \tbar \t"); err != nil {
+			t.Fatalf("unexpected err %q", err)
+		}
+		if trailer := string(h.Peek(HeaderTrailer)); trailer != "Foo, Bar" {
+			t.Fatalf("unexpected trailer %q. Expected %q", trailer, "Foo, Bar")
+		}
+	})
 }
 
 // Security tests for trailer handling vulnerability fix.


### PR DESCRIPTION
Validate trailer names added through AddTrailerBytes before storing them for Trailer header serialization.

Trim OWS around comma-separated trailer names, reject names containing bytes outside the HTTP field-name token set, and keep the existing forbidden-trailer filtering in place. This prevents CRLF injection through dynamic trailer names while preserving valid trailer declarations.

Add request and response regression coverage for invalid trailer names and tab-trimmed OWS.