### PR TITLE
header: match net/http CL+TE handling

### DIFF
--- a/header.go
+++ b/header.go
@@ -206,14 +206,15 @@ func (h *ResponseHeader) ContentLength() int {
 // -2 means Transfer-Encoding: identity.
 func (h *RequestHeader) ContentLength() int {
 	if h.disableSpecialHeader {
-		// Parse Content-Length from raw headers when special headers are disabled
+		// Parse framing headers from raw headers when special headers are disabled.
+		// Transfer-Encoding takes precedence over Content-Length, matching
+		// the normal parser path.
+		te := peekArgBytes(h.h, strTransferEncoding)
+		if caseInsensitiveCompare(te, strChunked) {
+			return -1 // chunked
+		}
 		v := peekArgBytes(h.h, strContentLength)
 		if len(v) == 0 {
-			// Check for Transfer-Encoding: chunked
-			te := peekArgBytes(h.h, strTransferEncoding)
-			if bytes.Equal(te, strChunked) {
-				return -1 // chunked
-			}
 			return -2 // identity
 		}
 		n, err := parseContentLength(v)
@@ -3037,14 +3038,15 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 				continue
 			}
 			if caseInsensitiveCompare(s.key, strContentLength) {
+				var err error
+				contentLength, err := parseContentLength(s.value)
+				if err != nil {
+					h.contentLength = -2
+					h.connectionClose = true
+					return 0, err
+				}
 				if h.contentLength != -1 {
-					var err error
-					h.contentLength, err = parseContentLength(s.value)
-					if err != nil {
-						h.contentLength = -2
-						h.connectionClose = true
-						return 0, err
-					}
+					h.contentLength = contentLength
 					h.contentLengthBytes = append(h.contentLengthBytes[:0], s.value...)
 				}
 				continue
@@ -3172,6 +3174,32 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 			}
 		}
 
+		isContentLength := false
+		isTransferEncoding := false
+		contentLength := 0
+		switch s.key[0] | 0x20 {
+		case 'c':
+			if caseInsensitiveCompare(s.key, strContentLength) {
+				isContentLength = true
+				if contentLengthSeen {
+					h.connectionClose = true
+					return 0, ErrDuplicateContentLength
+				}
+				contentLengthSeen = true
+				var err error
+				contentLength, err = parseContentLength(s.value)
+				if err != nil {
+					h.contentLength = -2
+					h.connectionClose = true
+					return 0, err
+				}
+			}
+		case 't':
+			if caseInsensitiveCompare(s.key, strTransferEncoding) {
+				isTransferEncoding = true
+			}
+		}
+
 		if h.disableSpecialHeader {
 			h.h = appendArgBytes(h.h, s.key, s.value, argsHasValue)
 			continue
@@ -3198,21 +3226,9 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 				h.contentType = append(h.contentType[:0], s.value...)
 				continue
 			}
-			if caseInsensitiveCompare(s.key, strContentLength) {
-				if contentLengthSeen {
-					h.connectionClose = true
-					return 0, ErrDuplicateContentLength
-				}
-				contentLengthSeen = true
-
+			if isContentLength {
 				if h.contentLength != -1 {
-					var err error
-					h.contentLength, err = parseContentLength(s.value)
-					if err != nil {
-						h.contentLength = -2
-						h.connectionClose = true
-						return 0, err
-					}
+					h.contentLength = contentLength
 					h.contentLengthBytes = append(h.contentLengthBytes[:0], s.value...)
 				}
 				continue
@@ -3227,7 +3243,7 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 				continue
 			}
 		case 't':
-			if caseInsensitiveCompare(s.key, strTransferEncoding) {
+			if isTransferEncoding {
 				isIdentity := caseInsensitiveCompare(s.value, strIdentity)
 				isChunked := caseInsensitiveCompare(s.value, strChunked)
 

--- a/header_test.go
+++ b/header_test.go
@@ -507,6 +507,16 @@ func TestRequestDisableSpecialHeaders(t *testing.T) {
 		t.Fatalf("body content incorrect with DisableSpecialHeader: got %q, expected %q",
 			string(req.Body()), testBody)
 	}
+
+	var ambiguous Request
+	ambiguous.Header.DisableSpecialHeader()
+	br3 := bufio.NewReader(bytes.NewBufferString("POST /test HTTP/1.1\r\nHost: example.com\r\nContent-Length: 1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\n\r\n"))
+	if err := ambiguous.ReadLimitBody(br3, 0); err != nil {
+		t.Fatalf("unexpected error reading ambiguous request: %v", err)
+	}
+	if body := string(ambiguous.Body()); body != "test" {
+		t.Fatalf("body content incorrect with ambiguous framing: got %q, expected %q", body, "test")
+	}
 }
 
 func TestRequestDisableSpecialHeadersChunked(t *testing.T) {
@@ -3370,6 +3380,9 @@ func TestResponseHeaderReadError(t *testing.T) {
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked, gzip\r\n\r\n")
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n")
 
+	// invalid Content-Length with Transfer-Encoding
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: nope\r\n\r\n")
+
 	// no protocol in the first line
 	testResponseHeaderReadError(t, h, "GET /foo/bar\r\nHost: google.com\r\n\r\nisdD")
 
@@ -3430,6 +3443,10 @@ func TestRequestHeaderReadError(t *testing.T) {
 
 	// post with duplicate content-length
 	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nContent-Type: s\r\nContent-Length: 13\r\nContent-Length: 1\r\n\r\n")
+
+	// invalid Content-Length with Transfer-Encoding
+	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nContent-Length: nope\r\nTransfer-Encoding: chunked\r\n\r\n")
+	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nTransfer-Encoding: chunked\r\nContent-Length: nope\r\n\r\n")
 
 	// Zero-length header
 	testRequestHeaderReadError(t, h, "GET /foo/bar HTTP/1.1\r\n: zero-key\r\n\r\n")

--- a/http_test.go
+++ b/http_test.go
@@ -1788,6 +1788,36 @@ func TestRequestReadLimitBody(t *testing.T) {
 	testRequestReadLimitBodySuccess(t, "GET /foo HTTP/1.0\r\n\r\n", 0)
 }
 
+func TestRequestReadLimitBodyContentLengthAndTransferEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"POST /foo HTTP/1.1\r\nHost: aaa.com\r\nContent-Length: 1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\n\r\nNEXT",
+		"POST /foo HTTP/1.1\r\nHost: aaa.com\r\nTransfer-Encoding: chunked\r\nContent-Length: 1\r\n\r\n4\r\ntest\r\n0\r\n\r\nNEXT",
+	}
+
+	for _, s := range tests {
+		var req Request
+		br := bufio.NewReader(bytes.NewBufferString(s))
+		if err := req.ReadLimitBody(br, 0); err != nil {
+			t.Fatalf("unexpected error: %v. s=%q", err, s)
+		}
+		if body := string(req.Body()); body != "test" {
+			t.Fatalf("unexpected body %q. Expecting %q. s=%q", body, "test", s)
+		}
+		b, err := br.Peek(4)
+		if err != nil {
+			t.Fatalf("unexpected error reading remaining bytes: %v. s=%q", err, s)
+		}
+		if string(b) != "NEXT" {
+			t.Fatalf("unexpected remaining bytes %q. Expecting %q. s=%q", b, "NEXT", s)
+		}
+	}
+
+	testRequestReadLimitBodyError(t, "POST /foo HTTP/1.1\r\nHost: aaa.com\r\nContent-Length: 1nope\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n", 0, ErrNonNumericChars)
+	testRequestReadLimitBodyError(t, "POST /foo HTTP/1.1\r\nHost: aaa.com\r\nTransfer-Encoding: chunked\r\nContent-Length: 1nope\r\n\r\n0\r\n\r\n", 0, ErrNonNumericChars)
+}
+
 func TestRequestReadLimitBodyRejectWhitespaceBeforeColonFramingHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -2565,6 +2595,8 @@ func TestResponseReadError(t *testing.T) {
 	testResponseReadError(t, resp, "HTTP/1.1 200 OK\r\nContent-Type: aaa\r\nTransfer-Encoding: chunked\r\n\r\nfoo")
 
 	testResponseReadError(t, resp, "HTTP/1.1 200 OK\r\nContent-Type: aaa\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nfoo")
+
+	testResponseReadError(t, resp, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: nope\r\n\r\n0\r\n\r\n")
 }
 
 func testResponseReadError(t *testing.T, resp *Response, response string) {

--- a/server_test.go
+++ b/server_test.go
@@ -2078,6 +2078,39 @@ func TestServerRejectsMissingHostHTTP11(t *testing.T) {
 	}
 }
 
+func TestServerRejectsInvalidContentLengthWithTransferEncoding(t *testing.T) {
+	t.Parallel()
+
+	var handlerCalled atomic.Bool
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			handlerCalled.Store(true)
+			ctx.Success("text/plain", []byte("ok"))
+		},
+		Logger: &testLogger{},
+	}
+
+	rw := &readWriter{}
+	rw.r.WriteString("POST / HTTP/1.1\r\nHost: a\r\nContent-Length: nope\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
+
+	_ = s.ServeConn(rw)
+
+	br := bufio.NewReader(&rw.w)
+	verifyResponse(t, br, StatusBadRequest, string(defaultContentType), "Error when parsing request")
+
+	if handlerCalled.Load() {
+		t.Fatal("handler should not run for request with invalid Content-Length")
+	}
+
+	data, err := io.ReadAll(br)
+	if err != nil {
+		t.Fatalf("Unexpected error when reading remaining data: %v", err)
+	}
+	if len(data) > 0 {
+		t.Fatalf("unexpected remaining data %q", data)
+	}
+}
+
 func TestServerContinueHandler(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Match net/http behavior when requests or responses contain both Content-Length and Transfer-Encoding.

Parse and validate Content-Length even when Transfer-Encoding is present, so invalid lengths are rejected. For valid Content-Length with chunked Transfer-Encoding, keep chunked framing as authoritative. Also apply the same precedence when RequestHeader.DisableSpecialHeader is used.