### PR TITLE
header: reject duplicate Content-Length in responses

### DIFF
--- a/header.go
+++ b/header.go
@@ -2989,6 +2989,8 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 	// 'identity' content-length by default
 	h.contentLength = -2
 
+	contentLengthSeen := false
+
 	var s headerScanner
 	s.b = buf
 	var kv *argsKV
@@ -3037,6 +3039,12 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 				continue
 			}
 			if caseInsensitiveCompare(s.key, strContentLength) {
+				if contentLengthSeen {
+					h.connectionClose = true
+					return 0, ErrDuplicateContentLength
+				}
+				contentLengthSeen = true
+
 				var err error
 				contentLength, err := parseContentLength(s.value)
 				if err != nil {

--- a/header_test.go
+++ b/header_test.go
@@ -3112,10 +3112,6 @@ func TestResponseHeaderReadSuccess(t *testing.T) {
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 400 OK\nconTEnt-leNGTH: 123\nConTENT-TYPE: ass\r\n\r\n",
 		400, 123, "ass")
 
-	// duplicate content-length
-	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 456\r\nContent-Type: foo/bar\r\nContent-Length: 321\r\n\r\n",
-		200, 321, "foo/bar")
-
 	// duplicate content-type
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 234\r\nContent-Type: foo/bar\r\nContent-Type: baz/bar\r\n\r\n",
 		200, 234, "baz/bar")
@@ -3363,6 +3359,11 @@ func TestResponseHeaderReadError(t *testing.T) {
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: faaa\r\nContent-Type: text/html\r\n\r\nfoobar")
 	testResponseHeaderReadError(t, h, "HTTP/1.1 201 OK\r\nContent-Length: 123aa\r\nContent-Type: text/ht\r\n\r\naaa")
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: aa124\r\nContent-Type: html\r\n\r\nxx")
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 5, 5\r\nContent-Type: html\r\n\r\n")
+
+	// duplicate content-length
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 456\r\nContent-Type: foo/bar\r\nContent-Length: 321\r\n\r\n")
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 456\r\nContent-Type: foo/bar\r\nContent-Length: 456\r\n\r\n")
 
 	// no headers
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\n")
@@ -3384,6 +3385,16 @@ func TestResponseHeaderReadError(t *testing.T) {
 
 	// Space before header name
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\n foo: bar\r\n\r\n")
+}
+
+func TestResponseHeaderReadDuplicateContentLengthError(t *testing.T) {
+	t.Parallel()
+
+	h := &ResponseHeader{}
+	err := h.Read(bufio.NewReader(strings.NewReader("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 7\r\n\r\n")))
+	if !errors.Is(err, ErrDuplicateContentLength) {
+		t.Fatalf("unexpected error %v. Expecting ErrDuplicateContentLength", err)
+	}
 }
 
 func TestResponseHeaderReadErrorSecureLog(t *testing.T) {

--- a/http_test.go
+++ b/http_test.go
@@ -2486,6 +2486,9 @@ func TestResponseReadError(t *testing.T) {
 	// invalid chunked body
 	testResponseReadError(t, resp, "HTTP/1.1 200 OK\r\nContent-Type: aaa\r\nContent-Length: 1234\r\n\r\nshort")
 
+	// duplicate content-length
+	testResponseReadError(t, resp, "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 7\r\n\r\nABCDEFG")
+
 	// chunked body without end chunk
 	testResponseReadError(t, resp, "HTTP/1.1 200 OK\r\nContent-Type: aaa\r\nTransfer-Encoding: chunked\r\n\r\nfoo")
 


### PR DESCRIPTION
Reject duplicate Content-Length headers when parsing response headers instead of accepting the last value.

This prevents response framing disagreements with other HTTP/1.x parsers on reused connections. Add regression coverage for ResponseHeader.Read and Response.Read, including identical duplicate values and the already-rejected comma-separated form.