### PR TITLE
header: reject unsupported response Transfer-Encoding

### DIFF
--- a/header.go
+++ b/header.go
@@ -2991,6 +2991,7 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 	var s headerScanner
 	s.b = buf
 	var kv *argsKV
+	transferEncodingSeen := false
 
 	for s.next() {
 		// Trim trailing whitespace before the colon to normalize headers
@@ -3070,10 +3071,26 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 			}
 		case 't':
 			if caseInsensitiveCompare(s.key, strTransferEncoding) {
-				if len(s.value) > 0 && !bytes.Equal(s.value, strIdentity) {
-					h.contentLength = -1
-					h.h = setArgBytes(h.h, strTransferEncoding, strChunked, argsHasValue)
+				if h.noHTTP11 {
+					continue
 				}
+				if transferEncodingSeen {
+					h.connectionClose = true
+					if h.secureErrorLogMessage {
+						return 0, ErrUnsupportedTransferEncoding
+					}
+					return 0, errors.New("too many Transfer-Encoding headers")
+				}
+				transferEncodingSeen = true
+				if !caseInsensitiveCompare(s.value, strChunked) {
+					h.connectionClose = true
+					if h.secureErrorLogMessage {
+						return 0, ErrUnsupportedTransferEncoding
+					}
+					return 0, fmt.Errorf("unsupported Transfer-Encoding: %q", s.value)
+				}
+				h.contentLength = -1
+				h.h = setArgBytes(h.h, strTransferEncoding, strChunked, argsHasValue)
 				continue
 			}
 			if caseInsensitiveCompare(s.key, strTrailer) {

--- a/header_test.go
+++ b/header_test.go
@@ -3113,9 +3113,9 @@ func TestResponseHeaderReadSuccess(t *testing.T) {
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 300 OK\r\nContent-Type: foo/barr\r\nTransfer-Encoding: chunked\r\nContent-Length: 354\r\n\r\n",
 		300, -1, "foo/barr")
 
-	// duplicate transfer-encoding: chunked
-	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n",
-		200, -1, "text/html")
+	// HTTP/1.0 ignores Transfer-Encoding.
+	testResponseHeaderReadSuccess(t, h, "HTTP/1.0 200 OK\r\nTransfer-Encoding: deflate\r\nContent-Length: 5\r\n\r\n",
+		200, 5, string(defaultContentType))
 
 	// no reason string in the first line
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 456\r\nContent-Type: xxx/yyy\r\nContent-Length: 134\r\n\r\naaaxxx",
@@ -3363,6 +3363,13 @@ func TestResponseHeaderReadError(t *testing.T) {
 	// forbidden trailer
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: -1\r\nTrailer: Foo, Content-Length\r\n\r\n")
 
+	// unsupported transfer-encoding
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: deflate\r\nContent-Length: 5\r\n\r\n")
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: identity\r\nContent-Length: 5\r\n\r\n")
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: \r\nContent-Length: 5\r\n\r\n")
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked, gzip\r\n\r\n")
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n")
+
 	// no protocol in the first line
 	testResponseHeaderReadError(t, h, "GET /foo/bar\r\nHost: google.com\r\n\r\nisdD")
 
@@ -3396,6 +3403,9 @@ func TestResponseHeaderReadErrorSecureLog(t *testing.T) {
 
 	// no trailing crlf
 	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n")
+
+	// unsupported transfer-encoding
+	testResponseHeaderReadSecuredError(t, h, "HTTP/1.1 200 OK\r\nTransfer-Encoding: deflate\r\nContent-Length: 5\r\n\r\n")
 }
 
 func TestRequestHeaderReadError(t *testing.T) {

--- a/http_test.go
+++ b/http_test.go
@@ -32,19 +32,30 @@ func TestInvalidTrailers(t *testing.T) {
 	}
 }
 
-func TestResponseEmptyTransferEncoding(t *testing.T) {
+func TestResponseEmptyTransferEncodingError(t *testing.T) {
 	t.Parallel()
 
 	var r Response
 
-	body := "Some body"
-	br := bufio.NewReader(bytes.NewBufferString("HTTP/1.1 200 OK\r\nContent-Type: aaa\r\nTransfer-Encoding: \r\nContent-Length: 9\r\n\r\n" + body))
-	err := r.Read(br)
-	if err != nil {
-		t.Fatal(err)
+	response := "HTTP/1.1 200 OK\r\nContent-Type: aaa\r\nTransfer-Encoding: \r\nContent-Length: 9\r\n\r\nSome body"
+	br := bufio.NewReader(bytes.NewBufferString(response))
+	if err := r.Read(br); err == nil {
+		t.Fatal("expected an error")
 	}
-	if got := string(r.Body()); got != body {
-		t.Fatalf("expected %q got %q", body, got)
+	expectNetHTTPReadResponseError(t, response, "net/http accepted response with empty Transfer-Encoding")
+}
+
+func expectNetHTTPReadResponseError(t *testing.T, response, msg string) {
+	t.Helper()
+
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(response)), nil)
+	if resp != nil && resp.Body != nil {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("cannot close response body: %v", closeErr)
+		}
+	}
+	if err == nil {
+		t.Fatal(msg)
 	}
 }
 
@@ -2422,10 +2433,6 @@ func TestResponseReadSuccess(t *testing.T) {
 	testResponseReadSuccess(t, resp, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nqwer\r\n2\r\nty\r\n0\r\nFoo2: bar2\r\n\r\n",
 		200, -1, "text/html", "qwerty", map[string]string{"Foo2": "bar2"})
 
-	// chunked response with non-chunked Transfer-Encoding.
-	testResponseReadSuccess(t, resp, "HTTP/1.1 230 OK\r\nContent-Type: text\r\nTransfer-Encoding: aaabbb\r\n\r\n2\r\ner\r\n2\r\nty\r\n0\r\nFoo3: bar3\r\n\r\n",
-		230, -1, "text", "erty", map[string]string{"Foo3": "bar3"})
-
 	// chunked response with content-length
 	testResponseReadSuccess(t, resp, "HTTP/1.1 200 OK\r\nContent-Type: foo/bar\r\nContent-Length: 123\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\nFoo4:bar4\r\n\r\n",
 		200, -1, "foo/bar", "test", map[string]string{"Foo4": "bar4"})
@@ -2437,6 +2444,42 @@ func TestResponseReadSuccess(t *testing.T) {
 	// chunked response with chunk extension
 	testResponseReadSuccess(t, resp, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n3;ext\r\naaa\r\n0\r\nFoo6: bar6\r\n\r\n",
 		200, -1, "text/html", "aaa", map[string]string{"Foo6": "bar6"})
+}
+
+func TestResponseReadUnsupportedTransferEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{
+			name:     "deflate",
+			response: "HTTP/1.1 200 OK\r\nTransfer-Encoding: deflate\r\nContent-Length: 5\r\n\r\nABCDE",
+		},
+		{
+			name:     "identity",
+			response: "HTTP/1.1 200 OK\r\nTransfer-Encoding: identity\r\nContent-Length: 5\r\n\r\nABCDE",
+		},
+		{
+			name:     "compound",
+			response: "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked, gzip\r\n\r\n0\r\n\r\n",
+		},
+		{
+			name:     "duplicate",
+			response: "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resp Response
+			if err := resp.Read(bufio.NewReader(strings.NewReader(tt.response))); err == nil {
+				t.Fatal("expected an error")
+			}
+			expectNetHTTPReadResponseError(t, tt.response, "net/http accepted response")
+		})
+	}
 }
 
 func TestResponseReadError(t *testing.T) {


### PR DESCRIPTION
Reject HTTP/1.1 response Transfer-Encoding values unless they are a single chunked header, matching net/http's strict transfer parser behavior.

This prevents arbitrary or compound response Transfer-Encoding values from being silently normalized to chunked and avoids desync/body parsing ambiguity when parsing upstream responses.