### PR TITLE
fix: prevent zombie connsCleaner goroutine on dial failure

### DIFF
--- a/client.go
+++ b/client.go
@@ -1731,16 +1731,26 @@ func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool)
 		}
 	}
 
-	if startCleaner {
-		go c.connsCleaner()
-	}
-
 	conn, err := c.dialHostHard(reqTimeout)
 	if err != nil {
 		c.decConnsCount()
+		// Reset cleaner flag if connsCount dropped to 0, allowing the next
+		// connection attempt to start the cleaner. This prevents zombie
+		// goroutines when dial fails. See issue #2171.
+		if startCleaner {
+			c.connsLock.Lock()
+			if c.connsCount == 0 {
+				c.connsCleanerRun = false
+			}
+			c.connsLock.Unlock()
+		}
 		return nil, err
 	}
 	cc = acquireClientConn(conn)
+
+	if startCleaner {
+		go c.connsCleaner()
+	}
 
 	return cc, nil
 }


### PR DESCRIPTION
## Summary

When `dialHostHard()` fails, the `connsCleaner` goroutine (started before dial) becomes a zombie — it sleeps for `MaxIdleConnDuration` before checking if it should stop. With a large `MaxIdleConnDuration` (e.g., 5 minutes), each failed dial attempt leaves a zombie goroutine for that duration.

## Root Cause

In `AcquireConn()`, the cleaner goroutine is started at line 1735 *before* `dialHostHard()`:

```go
if startCleaner {
    go c.connsCleaner()  // started before dial
}

conn, err := c.dialHostHard(reqTimeout)
if err != nil {
    c.decConnsCount()  // connsCount drops, but cleaner is already sleeping
    return nil, err
}
```

The cleaner's loop checks `mustStop := c.connsCount == 0` only after waking from `time.Sleep(sleepFor)`, where `sleepFor` can be up to `MaxIdleConnDuration`.

## Fix

1. Move the `go c.connsCleaner()` start to **after** a successful dial
2. On dial failure, reset `connsCleanerRun = false` if `connsCount` drops to 0, so the next connection attempt can start the cleaner

```go
conn, err := c.dialHostHard(reqTimeout)
if err != nil {
    c.decConnsCount()
    if startCleaner {
        c.connsLock.Lock()
        if c.connsCount == 0 {
            c.connsCleanerRun = false
        }
        c.connsLock.Unlock()
    }
    return nil, err
}
cc = acquireClientConn(conn)

if startCleaner {
    go c.connsCleaner()
}
```

This handles concurrent scenarios correctly: if dial fails and count drops to 0, the next goroutine that needs a connection will see `connsCleanerRun = false` and start the cleaner itself.

## Testing

All existing client tests pass.

Fixes #2171