### PR TITLE
client: add aggregate connection count metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -606,6 +606,36 @@ func (c *Client) CloseIdleConnections() {
 	c.mLock.RUnlock()
 }
 
+// ConnsCount returns total connection count across all HostClients managed by Client.
+func (c *Client) ConnsCount() int {
+	c.mLock.RLock()
+	defer c.mLock.RUnlock()
+
+	n := 0
+	for _, v := range c.m {
+		n += v.ConnsCount()
+	}
+	for _, v := range c.ms {
+		n += v.ConnsCount()
+	}
+	return n
+}
+
+// IdleConnsCount returns total idle connection count across all HostClients managed by Client.
+func (c *Client) IdleConnsCount() int {
+	c.mLock.RLock()
+	defer c.mLock.RUnlock()
+
+	n := 0
+	for _, v := range c.m {
+		n += v.IdleConnsCount()
+	}
+	for _, v := range c.ms {
+		n += v.IdleConnsCount()
+	}
+	return n
+}
+
 func (c *Client) mCleaner(m map[string]*HostClient) {
 	mustStop := false
 
@@ -1885,6 +1915,14 @@ func (c *HostClient) ConnsCount() int {
 	defer c.connsLock.Unlock()
 
 	return c.connsCount
+}
+
+// IdleConnsCount returns idle connection count of HostClient.
+func (c *HostClient) IdleConnsCount() int {
+	c.connsLock.Lock()
+	defer c.connsLock.Unlock()
+
+	return len(c.conns)
 }
 
 func acquireClientConn(conn net.Conn) *clientConn {

--- a/client_test.go
+++ b/client_test.go
@@ -74,6 +74,64 @@ func TestCloseIdleConnections(t *testing.T) {
 	}
 }
 
+func TestClientConnectionCounts(t *testing.T) {
+	t.Parallel()
+
+	ln := fasthttputil.NewInmemoryListener()
+
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+		},
+	}
+	go func() {
+		if err := s.Serve(ln); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	c := &Client{
+		Dial: func(addr string) (net.Conn, error) {
+			return ln.Dial()
+		},
+	}
+
+	if n := c.ConnsCount(); n != 0 {
+		t.Errorf("unexpected connection count %d. Expecting %d", n, 0)
+	}
+	if n := c.IdleConnsCount(); n != 0 {
+		t.Errorf("unexpected idle connection count %d. Expecting %d", n, 0)
+	}
+
+	if _, _, err := c.Get(nil, "http://google.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := c.ConnsCount(); n != 1 {
+		t.Errorf("unexpected connection count %d. Expecting %d", n, 1)
+	}
+	if n := c.IdleConnsCount(); n != 1 {
+		t.Errorf("unexpected idle connection count %d. Expecting %d", n, 1)
+	}
+
+	c.CloseIdleConnections()
+
+	if n := c.IdleConnsCount(); n != 0 {
+		t.Errorf("unexpected idle connection count %d. Expecting %d", n, 0)
+	}
+}
+
+func TestClientConnectionCountsEmpty(t *testing.T) {
+	t.Parallel()
+
+	var c Client
+	if n := c.ConnsCount(); n != 0 {
+		t.Fatalf("unexpected connection count %d. Expecting %d", n, 0)
+	}
+	if n := c.IdleConnsCount(); n != 0 {
+		t.Fatalf("unexpected idle connection count %d. Expecting %d", n, 0)
+	}
+}
+
 func TestPipelineClientSetUserAgent(t *testing.T) {
 	t.Parallel()
 

--- a/client_test.go
+++ b/client_test.go
@@ -120,18 +120,6 @@ func TestClientConnectionCounts(t *testing.T) {
 	}
 }
 
-func TestClientConnectionCountsEmpty(t *testing.T) {
-	t.Parallel()
-
-	var c Client
-	if n := c.ConnsCount(); n != 0 {
-		t.Fatalf("unexpected connection count %d. Expecting %d", n, 0)
-	}
-	if n := c.IdleConnsCount(); n != 0 {
-		t.Fatalf("unexpected idle connection count %d. Expecting %d", n, 0)
-	}
-}
-
 func TestPipelineClientSetUserAgent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds Client.ConnsCount() and Client.IdleConnsCount(), aggregating across all managed HostClients (both http and https   maps). Also adds HostClient.IdleConnsCount() since there was no public accessor for per-host idle count.

Closes #2200