### PR TITLE
client: add Client.DoContext and HostClient.DoContext

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package fasthttp
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -527,6 +528,13 @@ func (c *Client) Do(req *Request, resp *Response) error {
 	atomic.AddInt32(&hc.pendingClientRequests, 1)
 	defer atomic.AddInt32(&hc.pendingClientRequests, -1)
 	return hc.Do(req, resp)
+}
+
+// DoContext is like Do but uses ctx for deadline and cancellation.
+// If ctx is cancelled, the underlying connection is closed to interrupt
+// any in-flight read or write.
+func (c *Client) DoContext(ctx context.Context, req *Request, resp *Response) error {
+	return doContext(ctx, req, resp, c.Do)
 }
 
 func (c *Client) hostClient(host []byte, isTLS bool) (*HostClient, error) {
@@ -1547,6 +1555,39 @@ func (c *HostClient) Do(req *Request, resp *Response) error {
 
 	if err == io.EOF {
 		err = ErrConnectionClosed
+	}
+	return err
+}
+
+// DoContext is like Do but uses ctx for deadline and cancellation.
+func (c *HostClient) DoContext(ctx context.Context, req *Request, resp *Response) error {
+	return doContext(ctx, req, resp, c.Do)
+}
+
+func doContext( //nolint:contextcheck
+	ctx context.Context,
+	req *Request,
+	resp *Response,
+	do func(*Request, *Response) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d, ok := ctx.Deadline(); ok {
+		ctxTimeout := time.Until(d)
+		if ctxTimeout <= 0 {
+			return context.DeadlineExceeded
+		}
+		if req.timeout <= 0 || ctxTimeout < req.timeout {
+			req.timeout = ctxTimeout
+		}
+	}
+	prevCtx := req.ctx
+	req.ctx = ctx
+	defer func() { req.ctx = prevCtx }()
+	err := do(req, resp)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
 	}
 	return err
 }
@@ -3128,6 +3169,18 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 		return false, err
 	}
 	conn := cc.c
+
+	if reqCtx := req.ctx; reqCtx != nil && reqCtx.Done() != nil {
+		stop := make(chan struct{})
+		defer close(stop)
+		go func() {
+			select {
+			case <-reqCtx.Done():
+				conn.Close()
+			case <-stop:
+			}
+		}()
+	}
 
 	resp.ParseNetConn(conn)
 

--- a/client_test.go
+++ b/client_test.go
@@ -527,6 +527,72 @@ func TestClientNegativeTimeout(t *testing.T) {
 	ln.Close()
 }
 
+func TestClientDoContext(t *testing.T) {
+	t.Parallel()
+
+	ln := fasthttputil.NewInmemoryListener()
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+		},
+	}
+	go s.Serve(ln) //nolint:errcheck
+	c := &Client{
+		Dial: func(addr string) (net.Conn, error) {
+			return ln.Dial()
+		},
+	}
+	req := AcquireRequest()
+	req.Header.SetMethod(MethodGet)
+	req.SetRequestURI("http://example.com")
+
+	if err := c.DoContext(context.Background(), req, nil); err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := c.DoContext(ctx, req, nil); err != context.Canceled {
+		t.Fatalf("expected context.Canceled error got: %+v", err)
+	}
+
+	ctx, cancel = context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	if err := c.DoContext(ctx, req, nil); err != context.DeadlineExceeded {
+		t.Fatalf("expected context.DeadlineExceeded error got: %+v", err)
+	}
+
+	ln.Close()
+}
+
+func TestClientDoContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ln := fasthttputil.NewInmemoryListener()
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			time.Sleep(500 * time.Millisecond)
+		},
+	}
+	go s.Serve(ln) //nolint:errcheck
+	c := &Client{
+		Dial: func(addr string) (net.Conn, error) {
+			return ln.Dial()
+		},
+	}
+	req := AcquireRequest()
+	req.Header.SetMethod(MethodGet)
+	req.SetRequestURI("http://example.com")
+	req.timeout = time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(50*time.Millisecond, cancel)
+	if err := c.DoContext(ctx, req, AcquireResponse()); err != context.Canceled {
+		t.Fatalf("expected context.Canceled error got: %+v", err)
+	}
+
+	ln.Close()
+}
+
 func TestPipelineClientNilResp(t *testing.T) {
 	t.Parallel()
 

--- a/http.go
+++ b/http.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -60,6 +61,8 @@ type Request struct {
 	// Request timeout. Usually set by DoDeadline or DoTimeout
 	// if <= 0, means not set
 	timeout time.Duration
+
+	ctx context.Context //nolint:containedctx
 
 	secureErrorLogMessage bool
 
@@ -1260,6 +1263,7 @@ func (req *Request) Reset() {
 	req.Header.Reset()
 	req.resetSkipHeader()
 	req.timeout = 0
+	req.ctx = nil
 	req.UseHostHeader = false
 	req.DisableRedirectPathNormalizing = false
 }


### PR DESCRIPTION
Closes #2198.

Adds DoContext on Client and HostClient. Thin wrapper that honors ctx.Deadline() via req.timeout and returns ctx.Err() when the context is cancelled. No changes to the internal call chain. Cancellation is bounded by req.timeout (the inner Do completes naturally before DoContext returns).