### PR TITLE
fix double release of streamed client response body

### DIFF
--- a/client.go
+++ b/client.go
@@ -3205,7 +3205,11 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	closeConn := resetConnection || req.ConnectionClose() || resp.ConnectionClose()
 	if customStreamBody && resp.bodyStream != nil {
 		rbs := resp.bodyStream
+		var closed atomic.Bool
 		resp.bodyStream = newCloseReaderWithError(rbs, func(wErr error) error {
+			if !closed.CompareAndSwap(false, true) {
+				return nil
+			}
 			hc.ReleaseReader(br)
 			if r, ok := rbs.(*requestStream); ok {
 				releaseRequestStream(r)

--- a/http_test.go
+++ b/http_test.go
@@ -3349,6 +3349,73 @@ func TestResponseBodyStream(t *testing.T) {
 			}
 		})
 
+		t.Run("direct close with error releases client stream", func(t *testing.T) {
+			t.Parallel()
+
+			client := Client{StreamResponseBody: true, MaxConnsPerHost: 1}
+			resp := AcquireResponse()
+			defer ReleaseResponse(resp)
+			request := AcquireRequest()
+			defer ReleaseRequest(request)
+			request.SetRequestURI(server.URL + "?chunked=true")
+			if err := client.Do(request, resp); err != nil {
+				t.Fatal(err)
+			}
+			stream, ok := resp.BodyStream().(ReadCloserWithError)
+			if !ok {
+				t.Fatalf("unexpected body stream type %T", resp.BodyStream())
+			}
+			if err := stream.CloseWithError(errors.New("client closed")); err != nil {
+				t.Fatalf("close body stream err: %v", err)
+			}
+			if err := stream.CloseWithError(errors.New("client closed again")); err != nil {
+				t.Fatalf("close body stream twice err: %v", err)
+			}
+
+			resp2 := AcquireResponse()
+			defer ReleaseResponse(resp2)
+			request2 := AcquireRequest()
+			defer ReleaseRequest(request2)
+			request2.SetRequestURI(server.URL)
+			if err := client.Do(request2, resp2); err != nil {
+				t.Fatalf("second request err: %v", err)
+			}
+		})
+
+		t.Run("compressed write releases client stream", func(t *testing.T) {
+			t.Parallel()
+
+			client := Client{StreamResponseBody: true, MaxConnsPerHost: 1}
+
+			resp := AcquireResponse()
+			defer ReleaseResponse(resp)
+			request := AcquireRequest()
+			defer ReleaseRequest(request)
+
+			request.SetRequestURI(server.URL)
+			if err := client.Do(request, resp); err != nil {
+				t.Fatal(err)
+			}
+
+			bw := bufio.NewWriter(io.Discard)
+			if err := resp.WriteGzip(bw); err != nil {
+				t.Fatalf("write gzip response err: %v", err)
+			}
+			if err := bw.Flush(); err != nil {
+				t.Fatalf("flush gzip response err: %v", err)
+			}
+
+			resp2 := AcquireResponse()
+			defer ReleaseResponse(resp2)
+			request2 := AcquireRequest()
+			defer ReleaseRequest(request2)
+
+			request2.SetRequestURI(server.URL)
+			if err := client.Do(request2, resp2); err != nil {
+				t.Fatalf("second request err: %v", err)
+			}
+		})
+
 		t.Run("identity", func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Fix double release of the underlying streamed response body when a client response `BodyStream()` is closed directly.

When `StreamResponseBody` is enabled, the transport wraps `resp.bodyStream` with a  `ReadCloserWithError` that releases the reader, closes or releases the backend connection, and releases the underlying `requestStream`.

If user code passes `resp.BodyStream()` elsewhere and that stream is closed directly with `CloseWithError`, the wrapper already releases the underlying `requestStream`. A later `ReleaseResponse(resp)` calls `Response.Reset()`, sees the same `resp.bodyStream`, and can release the same `requestStream` again.

This change clears `resp.bodyStream` when the wrapper is closed, making subsequent `ReleaseResponse` / `CloseBodyStream` calls no-op for that stream.

This can happen in proxy-style code that forwards `resp.BodyStream()` into another response writer and closes it when the downstream client disconnects.