### PR TITLE
fix(fs): bound memory of filesLockMap via fixed-size shards

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"html"
 	"io"
 	"io/fs"
@@ -1926,12 +1927,18 @@ func fsModTime(t time.Time) time.Time {
 	return t.In(time.UTC).Truncate(time.Second)
 }
 
-var filesLockMap sync.Map
+// filesLockShards is a fixed-size pool of mutexes that serializes
+// concurrent generation of the same compressed file. Sharding by path
+// hash keeps memory bounded; distinct paths that happen to share a
+// mutex only contend briefly on the cache-miss path.
+const filesLockShardsCount = 1024
+
+var filesLockShards [filesLockShardsCount]sync.Mutex
 
 func getFileLock(absPath string) *sync.Mutex {
-	v, _ := filesLockMap.LoadOrStore(absPath, &sync.Mutex{})
-	filelock := v.(*sync.Mutex)
-	return filelock
+	h := fnv.New64a()
+	_, _ = h.Write(s2b(absPath))
+	return &filesLockShards[h.Sum64()&(filesLockShardsCount-1)]
 }
 
 var _ fs.FS = (*osFS)(nil)

--- a/fs_test.go
+++ b/fs_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -1204,5 +1205,82 @@ func TestFileCacheForZstd(t *testing.T) {
 	}
 	if !bytes.Equal(ctx.Response.Body(), changedData) {
 		t.Fatalf("Unexpected response body %q. Expecting %q", ctx.Response.Body(), data)
+	}
+}
+
+func TestGetFileLockSamePath(t *testing.T) {
+	t.Parallel()
+
+	const path = "/var/www/static/index.html.gz"
+	a := getFileLock(path)
+	b := getFileLock(path)
+	if a != b {
+		t.Fatalf("getFileLock(%q) returned different mutex instances on repeat calls", path)
+	}
+}
+
+func TestGetFileLockBounded(t *testing.T) {
+	t.Parallel()
+
+	// Acquire locks for many distinct paths and verify the number of
+	// unique mutex instances never exceeds the shard pool size. This is
+	// the regression guard for #2256 (unbounded growth of filesLockMap).
+	seen := make(map[*sync.Mutex]struct{})
+	for i := range 100 * filesLockShardsCount {
+		seen[getFileLock(fmt.Sprintf("/var/www/static/file-%d.html.gz", i))] = struct{}{}
+	}
+	if len(seen) > filesLockShardsCount {
+		t.Fatalf("unique mutex count %d exceeds shard pool size %d", len(seen), filesLockShardsCount)
+	}
+}
+
+func TestGetFileLockDistribution(t *testing.T) {
+	t.Parallel()
+
+	// Verify the hash distributes across shards rather than collapsing to
+	// a tiny subset. With N >> shardCount distinct paths we expect close
+	// to full shard coverage; allow a generous lower bound so the test is
+	// not flaky on edge-case hash behavior.
+	const n = 50 * filesLockShardsCount
+	seen := make(map[*sync.Mutex]struct{})
+	for i := range n {
+		seen[getFileLock(fmt.Sprintf("/srv/cache/asset-%d.br", i))] = struct{}{}
+	}
+	if len(seen) < filesLockShardsCount/2 {
+		t.Fatalf("hash distribution too narrow: only %d/%d shards used", len(seen), filesLockShardsCount)
+	}
+}
+
+func TestGetFileLockConcurrent(t *testing.T) {
+	t.Parallel()
+
+	// Same path across goroutines must serialize: the mutex returned by
+	// getFileLock is the actual synchronization primitive used by the
+	// compression slow path.
+	const (
+		path        = "/tmp/concurrent-getfilelock.gz"
+		goroutines  = 32
+		incsPerG    = 500
+		expectedSum = goroutines * incsPerG
+	)
+	var (
+		counter int
+		wg      sync.WaitGroup
+	)
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range incsPerG {
+				mu := getFileLock(path)
+				mu.Lock()
+				counter++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if counter != expectedSum {
+		t.Fatalf("counter race: got %d, want %d", counter, expectedSum)
 	}
 }


### PR DESCRIPTION
Replaces the unbounded sync.Map keyed by absolute file path with a fixed-size pool of 1024 mutexes selected by FNV-1a hash of the path. This guards against long-running fasthttp servers leaking memory proportional to the number of unique compressed file paths ever served.

Distinct paths may share a mutex (1 in 1024), but contention only occurs on the cache-miss / compression-generation slow path, so the practical impact is negligible. Fixes #2256.