### PR TITLE
fix(server): return ErrMissingFile when MultipartForm.File is nil

### DIFF
--- a/server.go
+++ b/server.go
@@ -1145,7 +1145,7 @@ func (ctx *RequestCtx) FormFile(key string) (*multipart.FileHeader, error) {
 		return nil, err
 	}
 	if mf.File == nil {
-		return nil, err
+		return nil, ErrMissingFile
 	}
 	fhh := mf.File[key]
 	if fhh == nil {


### PR DESCRIPTION
RequestCtx.FormFile previously returned (nil, nil) when the parsed multipart form had a nil File map: the code returned the err variable from the preceding successful MultipartForm() call, which is always nil at that point. Callers checking `if err != nil` proceeded with a nil *multipart.FileHeader, causing nil pointer dereferences downstream.

Return ErrMissingFile instead, matching the existing semantics for the missing-key case immediately below. Fixes #2235.