### PR TITLE
fix(pprofhandler): use exact path matching to prevent prefix-based route confusion

### DIFF
--- a/pprofhandler/pprof.go
+++ b/pprofhandler/pprof.go
@@ -23,19 +23,22 @@ var (
 // See https://pkg.go.dev/net/http/pprof for details.
 func PprofHandler(ctx *fasthttp.RequestCtx) {
 	ctx.Response.Header.Set("Content-Type", "text/html")
+	path := ctx.Path()
 	switch {
-	case bytes.HasPrefix(ctx.Path(), []byte("/debug/pprof/cmdline")):
+	case bytes.Equal(path, []byte("/debug/pprof/cmdline")):
 		cmdline(ctx)
-	case bytes.HasPrefix(ctx.Path(), []byte("/debug/pprof/profile")):
+	case bytes.Equal(path, []byte("/debug/pprof/profile")):
 		profile(ctx)
-	case bytes.HasPrefix(ctx.Path(), []byte("/debug/pprof/symbol")):
+	case bytes.Equal(path, []byte("/debug/pprof/symbol")):
 		symbol(ctx)
-	case bytes.HasPrefix(ctx.Path(), []byte("/debug/pprof/trace")):
+	case bytes.Equal(path, []byte("/debug/pprof/trace")):
 		trace(ctx)
 	default:
 		for _, v := range rtp.Profiles() {
 			ppName := v.Name()
-			if bytes.HasPrefix(ctx.Path(), []byte("/debug/pprof/"+ppName)) {
+			ppPath := "/debug/pprof/" + ppName
+			if bytes.Equal(path, []byte(ppPath)) ||
+				bytes.HasPrefix(path, []byte(ppPath+"/")) {
 				namedHandler := fasthttpadaptor.NewFastHTTPHandlerFunc(pprof.Handler(ppName).ServeHTTP)
 				namedHandler(ctx)
 				return

--- a/pprofhandler/pprof_test.go
+++ b/pprofhandler/pprof_test.go
@@ -1,0 +1,71 @@
+package pprofhandler
+
+import (
+	"net"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
+)
+
+func TestPprofHandler_PathMatching(t *testing.T) {
+	ln := fasthttputil.NewInmemoryListener()
+	defer ln.Close()
+
+	s := &fasthttp.Server{
+		Handler: PprofHandler,
+	}
+	go func() {
+		_ = s.Serve(ln)
+	}()
+
+	client := &fasthttp.Client{
+		Dial: func(addr string) (net.Conn, error) {
+			return ln.Dial()
+		},
+	}
+
+	doReq := func(path string) (int, []byte) {
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+		req.SetRequestURI("http://localhost" + path)
+		if err := client.Do(req, resp); err != nil {
+			t.Fatalf("request to %s failed: %v", path, err)
+		}
+		return resp.StatusCode(), resp.Body()
+	}
+
+	// Exact paths should work
+	tests := []struct {
+		path       string
+		wantStatus int
+	}{
+		{"/debug/pprof/", fasthttp.StatusOK},
+		{"/debug/pprof/cmdline", fasthttp.StatusOK},
+		{"/debug/pprof/symbol", fasthttp.StatusOK},
+		{"/debug/pprof/heap", fasthttp.StatusOK},
+	}
+	for _, tt := range tests {
+		status, _ := doReq(tt.path)
+		if status != tt.wantStatus {
+			t.Errorf("path %s: got status %d, want %d", tt.path, status, tt.wantStatus)
+		}
+	}
+
+	// Malformed paths with extra suffixes should NOT return cmdline/profile/symbol/trace data.
+	// The key test: compare response body of exact path vs. prefixed path.
+	// If prefix matching were used, they'd return the same content.
+	_, exactBody := doReq("/debug/pprof/cmdline")
+	_, prefixBody := doReq("/debug/pprof/cmdlineEvil")
+	if string(exactBody) == string(prefixBody) && len(exactBody) > 0 {
+		t.Error("/debug/pprof/cmdlineEvil should not return the same content as /debug/pprof/cmdline")
+	}
+
+	_, exactBody = doReq("/debug/pprof/symbol")
+	_, prefixBody = doReq("/debug/pprof/symbolEvil")
+	if string(exactBody) == string(prefixBody) && len(exactBody) > 0 {
+		t.Error("/debug/pprof/symbolEvil should not return the same content as /debug/pprof/symbol")
+	}
+}


### PR DESCRIPTION
## Problem

PprofHandler uses  for matching pprof endpoint paths. This means paths like  incorrectly match the  handler,  matches , etc.

Fixes #2258

## Fix

Switch from  to  for the four named handlers (cmdline, profile, symbol, trace). For runtime profile names in the default case, check that the path either exactly matches or has a trailing slash boundary.

Changes:
- : Replace  with  for exact path matching
- : Add tests verifying that malformed paths with extra suffixes don't match specific handlers

## Testing

All existing functionality preserved — exact paths still resolve correctly. Malicious/malformed paths with extra suffixes no longer match specific handlers.