### PR TITLE
fix(fasthttpproxy): propagate GetDialFunc error instead of returning nil DialFunc

### DIFF
--- a/fasthttpproxy/http.go
+++ b/fasthttpproxy/http.go
@@ -1,6 +1,7 @@
 package fasthttpproxy
 
 import (
+	"net"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -30,7 +31,10 @@ func FasthttpHTTPDialer(proxy string) fasthttp.DialFunc {
 //	}
 func FasthttpHTTPDialerTimeout(proxy string, timeout time.Duration) fasthttp.DialFunc {
 	d := Dialer{Config: httpproxy.Config{HTTPProxy: proxy, HTTPSProxy: proxy}, Timeout: timeout, ConnectTimeout: timeout}
-	dialFunc, _ := d.GetDialFunc(false)
+	dialFunc, err := d.GetDialFunc(false)
+	if err != nil {
+		return func(addr string) (net.Conn, error) { return nil, err }
+	}
 	return dialFunc
 }
 
@@ -60,6 +64,9 @@ func FasthttpHTTPDialerDualStackTimeout(proxy string, timeout time.Duration) fas
 		Config: httpproxy.Config{HTTPProxy: proxy, HTTPSProxy: proxy}, Timeout: timeout, ConnectTimeout: timeout,
 		DialDualStack: true,
 	}
-	dialFunc, _ := d.GetDialFunc(false)
+	dialFunc, err := d.GetDialFunc(false)
+	if err != nil {
+		return func(addr string) (net.Conn, error) { return nil, err }
+	}
 	return dialFunc
 }

--- a/fasthttpproxy/proxy_env.go
+++ b/fasthttpproxy/proxy_env.go
@@ -1,6 +1,7 @@
 package fasthttpproxy
 
 import (
+	"net"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -34,6 +35,9 @@ func FasthttpProxyHTTPDialer() fasthttp.DialFunc {
 //	}
 func FasthttpProxyHTTPDialerTimeout(timeout time.Duration) fasthttp.DialFunc {
 	d := Dialer{Timeout: timeout, ConnectTimeout: timeout}
-	dialFunc, _ := d.GetDialFunc(true)
+	dialFunc, err := d.GetDialFunc(true)
+	if err != nil {
+		return func(addr string) (net.Conn, error) { return nil, err }
+	}
 	return dialFunc
 }

--- a/fasthttpproxy/socks5.go
+++ b/fasthttpproxy/socks5.go
@@ -1,6 +1,8 @@
 package fasthttpproxy
 
 import (
+	"net"
+
 	"github.com/valyala/fasthttp"
 	"golang.org/x/net/http/httpproxy"
 )
@@ -15,7 +17,10 @@ import (
 //	}
 func FasthttpSocksDialer(proxyAddr string) fasthttp.DialFunc {
 	d := Dialer{Config: httpproxy.Config{HTTPProxy: proxyAddr, HTTPSProxy: proxyAddr}}
-	dialFunc, _ := d.GetDialFunc(false)
+	dialFunc, err := d.GetDialFunc(false)
+	if err != nil {
+		return func(addr string) (net.Conn, error) { return nil, err }
+	}
 	return dialFunc
 }
 
@@ -29,6 +34,9 @@ func FasthttpSocksDialer(proxyAddr string) fasthttp.DialFunc {
 //	}
 func FasthttpSocksDialerDualStack(proxyAddr string) fasthttp.DialFunc {
 	d := Dialer{Config: httpproxy.Config{HTTPProxy: proxyAddr, HTTPSProxy: proxyAddr}, DialDualStack: true}
-	dialFunc, _ := d.GetDialFunc(false)
+	dialFunc, err := d.GetDialFunc(false)
+	if err != nil {
+		return func(addr string) (net.Conn, error) { return nil, err }
+	}
 	return dialFunc
 }


### PR DESCRIPTION
Fixes #2248.

## Problem

The five public dialer constructors in `fasthttpproxy` all ignore the error returned by `GetDialFunc`:

```go
// http.go, socks5.go, proxy_env.go
dialFunc, _ := d.GetDialFunc(false)
return dialFunc  // nil when GetDialFunc failed
```

`GetDialFunc` returns `(nil, err)` when the proxy URL is malformed or uses an unknown scheme. The silent `_` discard means callers receive a `nil` `fasthttp.DialFunc`, and any subsequent call to `Dial` panics with a nil pointer dereference.

## Fix

Wrap the error in a closure that propagates it on every `Dial` call — the same pattern the standard library uses for similar situations:

```go
dialFunc, err := d.GetDialFunc(false)
if err != nil {
    return func(addr string) (net.Conn, error) { return nil, err }
}
return dialFunc
```

This preserves the existing API (callers still get a non-nil `DialFunc`) while surfacing the configuration error at dial time rather than panicking.

**Affected functions:**
- `FasthttpHTTPDialerTimeout`
- `FasthttpHTTPDialerDualStackTimeout`
- `FasthttpSocksDialer`
- `FasthttpSocksDialerDualStack`
- `FasthttpProxyHTTPDialerTimeout`