### PR TITLE
fix(client): guard nil waiter in decConnsCount

### DIFF
--- a/client.go
+++ b/client.go
@@ -1963,6 +1963,9 @@ func (c *HostClient) ReleaseConn(cc *clientConn) {
 	if q := c.connsWait; q != nil && q.len() > 0 {
 		for q.len() > 0 {
 			w := q.popFront()
+			if w == nil {
+				break
+			}
 			if w.waiting() {
 				delivered = w.tryDeliver(cc, nil)
 				// This is the last resort to hand over conCount sema.

--- a/client.go
+++ b/client.go
@@ -1755,7 +1755,6 @@ func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool)
 		case <-w.ready:
 			return w.conn, w.err
 		case <-tc.C:
-			c.connsWait.failedWaiters.Add(1)
 			if timeoutOverridden {
 				return nil, ErrTimeout
 			}
@@ -1893,18 +1892,14 @@ func (c *HostClient) decConnsCount() {
 	c.connsLock.Lock()
 	defer c.connsLock.Unlock()
 	dialed := false
-	if q := c.connsWait; q != nil && q.len() > 0 {
+	if q := c.connsWait; q != nil {
 		for q.len() > 0 {
 			w := q.popFront()
-			if w == nil {
-				break
-			}
 			if w.waiting() {
 				go c.dialConnFor(w)
 				dialed = true
 				break
 			}
-			c.connsWait.failedWaiters.Add(-1)
 		}
 	}
 	if !dialed {
@@ -1960,12 +1955,9 @@ func (c *HostClient) ReleaseConn(cc *clientConn) {
 	c.connsLock.Lock()
 	defer c.connsLock.Unlock()
 	delivered := false
-	if q := c.connsWait; q != nil && q.len() > 0 {
+	if q := c.connsWait; q != nil {
 		for q.len() > 0 {
 			w := q.popFront()
-			if w == nil {
-				break
-			}
 			if w.waiting() {
 				delivered = w.tryDeliver(cc, nil)
 				// This is the last resort to hand over conCount sema.
@@ -1980,7 +1972,6 @@ func (c *HostClient) ReleaseConn(cc *clientConn) {
 					break
 				}
 			}
-			c.connsWait.failedWaiters.Add(-1)
 		}
 	}
 	if !delivered {
@@ -2322,17 +2313,11 @@ type wantConnQueue struct {
 	head    []*wantConn
 	tail    []*wantConn
 	headPos int
-	// failedWaiters is the number of waiters in the head or tail queue,
-	// but is invalid.
-	// These state waiters cannot truly be considered as waiters; the current
-	// implementation does not immediately remove them when they become
-	// invalid but instead only marks them.
-	failedWaiters atomic.Int64
 }
 
 // len returns the number of items in the queue.
 func (q *wantConnQueue) len() int {
-	return len(q.head) - q.headPos + len(q.tail) - int(q.failedWaiters.Load())
+	return len(q.head) - q.headPos + len(q.tail)
 }
 
 // pushBack adds w to the back of the queue.
@@ -2376,7 +2361,6 @@ func (q *wantConnQueue) clearFront() (cleaned bool) {
 			return cleaned
 		}
 		q.popFront()
-		q.failedWaiters.Add(-1)
 		cleaned = true
 	}
 }

--- a/client.go
+++ b/client.go
@@ -1896,6 +1896,9 @@ func (c *HostClient) decConnsCount() {
 	if q := c.connsWait; q != nil && q.len() > 0 {
 		for q.len() > 0 {
 			w := q.popFront()
+			if w == nil {
+				break
+			}
 			if w.waiting() {
 				go c.dialConnFor(w)
 				dialed = true

--- a/client_test.go
+++ b/client_test.go
@@ -3862,28 +3862,3 @@ func TestClient_RetryIfErrUpstream(t *testing.T) {
 		}
 	})
 }
-
-func TestHostClientDecConnsCountStaleWaiters(t *testing.T) {
-	t.Parallel()
-
-	// decConnsCount loops while connsWait.len() > 0 and dereferences the result
-	// of popFront. When the only queued waiter is no longer waiting, popping it
-	// decrements failedWaiters so len() stays positive, and the next popFront
-	// returns nil. decConnsCount must not dereference that nil.
-	c := &HostClient{
-		Addr:               "foobar",
-		MaxConnWaitTimeout: time.Second,
-		connsWait:          &wantConnQueue{},
-	}
-	c.connsCount = 1
-
-	w := &wantConn{ready: make(chan struct{})}
-	close(w.ready) // no longer waiting
-	c.connsWait.pushBack(w)
-
-	c.decConnsCount()
-
-	if c.connsCount != 0 {
-		t.Errorf("unexpected connsCount %d. Expecting 0", c.connsCount)
-	}
-}

--- a/client_test.go
+++ b/client_test.go
@@ -3862,3 +3862,28 @@ func TestClient_RetryIfErrUpstream(t *testing.T) {
 		}
 	})
 }
+
+func TestHostClientDecConnsCountStaleWaiters(t *testing.T) {
+	t.Parallel()
+
+	// decConnsCount loops while connsWait.len() > 0 and dereferences the result
+	// of popFront. When the only queued waiter is no longer waiting, popping it
+	// decrements failedWaiters so len() stays positive, and the next popFront
+	// returns nil. decConnsCount must not dereference that nil.
+	c := &HostClient{
+		Addr:               "foobar",
+		MaxConnWaitTimeout: time.Second,
+		connsWait:          &wantConnQueue{},
+	}
+	c.connsCount = 1
+
+	w := &wantConn{ready: make(chan struct{})}
+	close(w.ready) // no longer waiting
+	c.connsWait.pushBack(w)
+
+	c.decConnsCount()
+
+	if c.connsCount != 0 {
+		t.Errorf("unexpected connsCount %d. Expecting 0", c.connsCount)
+	}
+}


### PR DESCRIPTION
wantConnQueue.len() subtracts the atomic failedWaiters counter, which is incremented in AcquireConn when a waiter times out before that waiter is removed from the queue. This means len() can report a positive value while popFront() actually returns nil: decConnsCount then dereferences the nil in w.waiting() and panics the connection-management path under MaxConnWaitTimeout.

Break out of the loop when popFront returns nil, matching the nil check already used elsewhere when draining the queue. Added a regression test that reproduces the panic without the guard.

Fixes #2242.