### PR TITLE
Fix POST redirects after 303 responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -1221,8 +1221,11 @@ func doRequestFollowRedirects(
 		stripSensitiveHeadersOnRedirect(req, initialHost, redirectURI)
 		ReleaseURI(redirectURI)
 
-		if string(req.Header.Method()) == "POST" && (statusCode == 301 || statusCode == 302) {
+		if string(req.Header.Method()) == MethodPost &&
+			(statusCode == StatusMovedPermanently || statusCode == StatusFound || statusCode == StatusSeeOther) {
 			req.Header.SetMethod(MethodGet)
+			req.ResetBody()
+			req.Header.SetContentLength(0)
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -1880,6 +1880,82 @@ func TestClientFollowRedirects(t *testing.T) {
 	ReleaseResponse(resp)
 }
 
+func TestClientPostRedirectSeeOtherUsesGetWithoutBody(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			switch string(ctx.Path()) {
+			case "/start":
+				if string(ctx.Method()) != MethodPost {
+					ctx.Error(fmt.Sprintf("unexpected start method %q", ctx.Method()), StatusInternalServerError)
+					return
+				}
+				if string(ctx.PostBody()) != "payload" {
+					ctx.Error(fmt.Sprintf("unexpected start body %q", ctx.PostBody()), StatusInternalServerError)
+					return
+				}
+
+				u := ctx.URI()
+				u.Update("/target")
+				ctx.Redirect(u.String(), StatusSeeOther)
+			case "/target":
+				if string(ctx.Method()) != MethodGet {
+					ctx.Error(fmt.Sprintf("unexpected redirected method %q", ctx.Method()), StatusInternalServerError)
+					return
+				}
+				if len(ctx.Request.Body()) != 0 {
+					ctx.Error(fmt.Sprintf("unexpected redirected body %q", ctx.Request.Body()), StatusInternalServerError)
+					return
+				}
+
+				ctx.Success("text/plain", []byte("ok"))
+			default:
+				ctx.NotFound()
+			}
+		},
+	}
+	ln := fasthttputil.NewInmemoryListener()
+	serverStopCh := make(chan struct{})
+	defer func() {
+		_ = ln.Close()
+		<-serverStopCh
+	}()
+
+	go func() {
+		if err := s.Serve(ln); err != nil && err != fasthttputil.ErrInmemoryListenerClosed {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(serverStopCh)
+	}()
+
+	c := &HostClient{
+		Addr: "xxx",
+		Dial: func(addr string) (net.Conn, error) {
+			return ln.Dial()
+		},
+	}
+
+	req := AcquireRequest()
+	resp := AcquireResponse()
+	defer ReleaseRequest(req)
+	defer ReleaseResponse(resp)
+
+	req.SetRequestURI("http://xxx/start")
+	req.Header.SetMethod(MethodPost)
+	req.SetBodyString("payload")
+
+	if err := c.DoRedirects(req, resp, 16); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if statusCode := resp.StatusCode(); statusCode != StatusOK {
+		t.Fatalf("unexpected status code: %d, body=%q", statusCode, resp.Body())
+	}
+	if body := string(resp.Body()); body != "ok" {
+		t.Fatalf("unexpected response %q. Expecting %q", body, "ok")
+	}
+}
+
 func TestShouldStripSensitiveHeadersOnRedirect(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #2240.

Summary:
- Treat a POST followed by `303 See Other` like the existing 301/302 redirect rewrite and continue with `GET`.
- Clear the original request body and stale `Content-Length` before the redirected request is sent.
- Add a regression test that verifies the redirected request reaches the target as `GET` without the POST body.

Tests:
- `go test ./ -run '^TestClientPostRedirectSeeOtherUsesGetWithoutBody$' -count=1 -timeout=30s`
- `go test ./ -run 'TestClient(FollowRedirects|PostRedirectSeeOtherUsesGetWithoutBody)$|TestShouldStripSensitiveHeadersOnRedirect$|Test_getRedirectURL$' -count=1`
- `go test ./... -count=1`
- `git diff --check`
