### PR TITLE
fix(fasthttputil): add stop channel to InmemoryListener to avoid dead…

### DIFF
--- a/fasthttputil/inmemory_listener.go
+++ b/fasthttputil/inmemory_listener.go
@@ -19,6 +19,7 @@ type InmemoryListener struct {
 	addrLock     sync.RWMutex
 	lock         sync.Mutex
 	closed       bool
+	stopCh       chan struct{}
 }
 
 type acceptConn struct {
@@ -29,7 +30,8 @@ type acceptConn struct {
 // NewInmemoryListener returns new in-memory dialer<->net.Listener.
 func NewInmemoryListener() *InmemoryListener {
 	return &InmemoryListener{
-		conns: make(chan acceptConn, 1024),
+		conns:  make(chan acceptConn, 1024),
+		stopCh: make(chan struct{}),
 	}
 }
 
@@ -47,12 +49,22 @@ func (ln *InmemoryListener) SetLocalAddr(localAddr net.Addr) {
 //
 // Accept returns new connection per each Dial call.
 func (ln *InmemoryListener) Accept() (net.Conn, error) {
-	c, ok := <-ln.conns
-	if !ok {
+	ln.lock.Lock()
+	if ln.closed {
+		ln.lock.Unlock()
 		return nil, ErrInmemoryListenerClosed
 	}
-	close(c.accepted)
-	return c.conn, nil
+	ln.lock.Unlock()
+	select {
+	case c, ok := <-ln.conns:
+		if !ok {
+			return nil, ErrInmemoryListenerClosed
+		}
+		close(c.accepted)
+		return c.conn, nil
+	case <-ln.stopCh:
+		return nil, ErrInmemoryListenerClosed
+	}
 }
 
 // Close implements net.Listener's Close.
@@ -61,7 +73,8 @@ func (ln *InmemoryListener) Close() error {
 
 	ln.lock.Lock()
 	if !ln.closed {
-		close(ln.conns)
+		// close(ln.conns)
+		close(ln.stopCh)
 		ln.closed = true
 	} else {
 		err = ErrInmemoryListenerClosed
@@ -109,26 +122,36 @@ func (ln *InmemoryListener) Dial() (net.Conn, error) {
 // It is safe calling Dial from concurrently running goroutines.
 func (ln *InmemoryListener) DialWithLocalAddr(local net.Addr) (net.Conn, error) {
 	pc := NewPipeConns()
-
 	pc.SetAddresses(local, ln.Addr(), ln.Addr(), local)
 
 	cConn := pc.Conn1()
 	sConn := pc.Conn2()
+
 	ln.lock.Lock()
-	accepted := make(chan struct{})
-	if !ln.closed {
-		ln.conns <- acceptConn{conn: sConn, accepted: accepted}
-		// Wait until the connection has been accepted.
-		<-accepted
-	} else {
+	if ln.closed {
+		ln.lock.Unlock()
 		_ = sConn.Close()
 		_ = cConn.Close()
-		cConn = nil
+		return nil, ErrInmemoryListenerClosed
 	}
 	ln.lock.Unlock()
 
-	if cConn == nil {
+	accepted := make(chan struct{})
+	req := acceptConn{conn: sConn, accepted: accepted}
+
+	select {
+	case ln.conns <- req:
+		select {
+		case <-accepted:
+			return cConn, nil
+		case <-ln.stopCh:
+			_ = sConn.Close()
+			_ = cConn.Close()
+			return nil, ErrInmemoryListenerClosed
+		}
+	case <-ln.stopCh:
+		_ = sConn.Close()
+		_ = cConn.Close()
 		return nil, ErrInmemoryListenerClosed
 	}
-	return cConn, nil
 }

--- a/fasthttputil/inmemory_listener_test.go
+++ b/fasthttputil/inmemory_listener_test.go
@@ -271,3 +271,33 @@ func TestInmemoryListenerAddrCustom(t *testing.T) {
 	verifyAddr(t, c.LocalAddr(), clientAddr)
 	verifyAddr(t, c.RemoteAddr(), listenerAddr)
 }
+func TestInmemoryListener_Deadlock_Fix(t *testing.T) {
+	ln := NewInmemoryListener()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1500; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = ln.Dial()
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ln.Close()
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Logf("Listener closed successfully (expected): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ln.Close() timed out because the mutex is held by a blocked Dial goroutine")
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Description
Fixes a critical deadlock and potential panic in `InmemoryListener` under high concurrency or when `Close()` is called while `Dial()` calls are blocked.

### The Problem
1. **Deadlock**: In `DialWithLocalAddr`, the listener held `ln.lock` while performing blocking channel operations (`ln.conns <- req` and `<-accepted`). If the buffer was full, it blocked holding the mutex, preventing `Close()` from acquiring the same lock.
2. **Panic**: Attempting to fix this by simply unlocking early introduced a `panic: send on closed channel` because `Close()` explicitly closed `ln.conns` while concurrent writers (`Dial`) were randomly selected to execute the send case in a multi-case `select`.

### The Solution
- Introduced a dedicated signaling channel `stopCh` to handle listener termination.
- Removed `close(ln.conns)` from `Close()` to avoid panics on concurrent sends. The channel will be garbage collected normally.
- Updated `DialWithLocalAddr` and `Accept` to leverage `stopCh` inside non-blocking `select` blocks outside of the critical section (`ln.lock`).
- Added strict `ln.closed` guards at the entry of `Accept` and `DialWithLocalAddr` to comply with standard `net.Listener` behavior after closure.

## Verification
- All existing package tests pass successfully.
- Added a new concurrent stress test `TestInmemoryListener_Deadlock_Fix` which reliably reproduces the deadlock on the master branch and passes smoothly with this fix.