### PR TITLE
bug: double concurrency counter increment in ServeConn causes counter leak (#2238)

### DIFF
--- a/server.go
+++ b/server.go
@@ -2154,19 +2154,16 @@ func (s *Server) ServeConn(c net.Conn) error {
 		c = pic
 	}
 
-	n := int(s.concurrency.Add(1)) // #nosec G115
-	if n > s.getConcurrency() {
-		s.concurrency.Add(^uint32(0))
+	if !s.tryAcquireConcurrency() {
 		s.writeFastError(c, StatusServiceUnavailable, "The connection cannot be served because Server.Concurrency limit exceeded")
 		c.Close()
 		return ErrConcurrencyLimit
 	}
+	defer s.releaseConcurrency()
 
 	s.open.Add(1)
 
-	err := s.serveConn(c)
-
-	s.concurrency.Add(^uint32(0))
+	err := s.serveConnCounted(c, false)
 
 	if err != errHijacked {
 		errc := c.Close()
@@ -2179,6 +2176,19 @@ func (s *Server) ServeConn(c net.Conn) error {
 		s.setState(c, StateHijacked)
 	}
 	return err
+}
+
+func (s *Server) tryAcquireConcurrency() bool {
+	n := int(s.concurrency.Add(1)) // #nosec G115
+	if n <= s.getConcurrency() {
+		return true
+	}
+	s.releaseConcurrency()
+	return false
+}
+
+func (s *Server) releaseConcurrency() {
+	s.concurrency.Add(^uint32(0))
 }
 
 var errHijacked = errors.New("connection has been hijacked")
@@ -2240,14 +2250,22 @@ func (s *Server) idleTimeout() time.Duration {
 	return s.ReadTimeout
 }
 
-func (s *Server) serveConnCleanup() {
+func (s *Server) serveConnCleanup(countConcurrency bool) {
 	s.open.Add(-1)
-	s.concurrency.Add(^uint32(0))
+	if countConcurrency {
+		s.releaseConcurrency()
+	}
 }
 
 func (s *Server) serveConn(c net.Conn) error {
-	defer s.serveConnCleanup()
-	s.concurrency.Add(1)
+	return s.serveConnCounted(c, true)
+}
+
+func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
+	defer s.serveConnCleanup(countConcurrency)
+	if countConcurrency {
+		s.concurrency.Add(1)
+	}
 
 	proto, err := s.getNextProto(c)
 	if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -3962,6 +3962,34 @@ func TestServeConnSingleRequest(t *testing.T) {
 	verifyResponse(t, br, 200, "aaa", "requestURI=/foo/bar?baz, host=google.com")
 }
 
+func TestServeConnCountsConcurrencyOnce(t *testing.T) {
+	t.Parallel()
+
+	var s *Server
+	s = &Server{
+		Concurrency: 1,
+		Handler: func(ctx *RequestCtx) {
+			if n := s.GetCurrentConcurrency(); n != 1 {
+				t.Errorf("unexpected concurrency %d. Expecting 1", n)
+			}
+			ctx.Success("text/plain", []byte("OK"))
+		},
+	}
+
+	rw := &readWriter{}
+	rw.r.WriteString("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
+
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from ServeConn: %v", err)
+	}
+	if n := s.GetCurrentConcurrency(); n != 0 {
+		t.Fatalf("unexpected concurrency after ServeConn: %d. Expecting 0", n)
+	}
+
+	br := bufio.NewReader(&rw.w)
+	verifyResponse(t, br, 200, "text/plain", "OK")
+}
+
 func TestServerSetFormValueFunc(t *testing.T) {
 	t.Parallel()
 	s := &Server{


### PR DESCRIPTION
Fixes #2238.