### PR TITLE
security: SO_REUSEADDR on Windows enables port hijacking (#2254)

### DIFF
--- a/reuseport/reuseport_windows.go
+++ b/reuseport/reuseport_windows.go
@@ -16,8 +16,12 @@ var listenConfig = net.ListenConfig{
 	},
 }
 
-// Listen returns TCP listener with SO_REUSEADDR option set, SO_REUSEPORT is not supported on Windows, so it uses
-// SO_REUSEADDR as an alternative to achieve the same effect.
+// Listen returns TCP listener with SO_REUSEADDR option set.
+//
+// SO_REUSEPORT is not supported on Windows, so SO_REUSEADDR is used as an
+// approximation. Unlike POSIX SO_REUSEPORT, Windows SO_REUSEADDR does not
+// provide same-user or same-group isolation between processes that bind the
+// same address.
 func Listen(network, addr string) (net.Listener, error) {
 	return listenConfig.Listen(context.Background(), network, addr)
 }


### PR DESCRIPTION
Fixes #2254.