### PR TITLE
ci: re-enable gocritic deferInLoop check for non-test code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,7 +47,6 @@ linters:
   settings:
     gocritic:
       disabled-checks:
-        - deferInLoop
         - importShadow
         - sloppyReassign
         - unnamedResult

--- a/client_test.go
+++ b/client_test.go
@@ -2943,12 +2943,20 @@ func TestClientHTTPSConcurrent(t *testing.T) {
 func TestClientManyServers(t *testing.T) {
 	t.Parallel()
 
+	servers := make([]*testEchoServer, 0, 10)
 	addrs := make([]string, 0, 10)
 	for range 10 {
 		s := startEchoServer(t, "tcp", "127.0.0.1:")
-		defer s.Stop()
+		servers = append(servers, s)
 		addrs = append(addrs, s.Addr())
 	}
+	// All servers must stay up until the test ends, so stop them with a single
+	// deferred loop rather than deferring inside the loop above.
+	defer func() {
+		for _, s := range servers {
+			s.Stop()
+		}
+	}()
 
 	var wg sync.WaitGroup
 	for i := range 4 {

--- a/fasthttputil/inmemory_listener_test.go
+++ b/fasthttputil/inmemory_listener_test.go
@@ -57,24 +57,26 @@ func TestInmemoryListener(t *testing.T) {
 				close(serverCh)
 				return
 			}
-			defer conn.Close()
-			buf := make([]byte, 30)
-			n, err := conn.Read(buf)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			buf = buf[:n]
-			if !bytes.HasPrefix(buf, []byte("request_")) {
-				t.Errorf("unexpected request prefix %q. Expecting %q", buf, "request_")
-			}
-			resp := fmt.Sprintf("response_%s", buf[len("request_"):])
-			n, err = conn.Write([]byte(resp))
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if n != len(resp) {
-				t.Errorf("unexpected number of bytes written: %d. Expecting %d", n, len(resp))
-			}
+			func() {
+				defer conn.Close()
+				buf := make([]byte, 30)
+				n, err := conn.Read(buf)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				buf = buf[:n]
+				if !bytes.HasPrefix(buf, []byte("request_")) {
+					t.Errorf("unexpected request prefix %q. Expecting %q", buf, "request_")
+				}
+				resp := fmt.Sprintf("response_%s", buf[len("request_"):])
+				n, err = conn.Write([]byte(resp))
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if n != len(resp) {
+					t.Errorf("unexpected number of bytes written: %d. Expecting %d", n, len(resp))
+				}
+			}()
 		}
 	}()
 


### PR DESCRIPTION
deferInLoop was disabled in .golangci.yml, so CI could not catch defer statements added inside for loops. Such defers run only at function exit, not per iteration, leaking file descriptors, connections, or locks under load.

Re-enable the check, but exclude _test.go files: deferring cleanup to the end of a short-lived test is a common and harmless pattern, while the leak matters in the long-running server and connection-handling loops of the non-test code, which is now guarded against regressions.

Fixes #2233