### PR TITLE
reject duplicate Content-Length in response header parser

### DIFF
--- a/header.go
+++ b/header.go
@@ -2993,6 +2993,7 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 	s.b = buf
 	var kv *argsKV
 	transferEncodingSeen := false
+	contentLengthSeen := false
 
 	for s.next() {
 		// Trim trailing whitespace before the colon to normalize headers
@@ -3038,6 +3039,11 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 				continue
 			}
 			if caseInsensitiveCompare(s.key, strContentLength) {
+				if contentLengthSeen {
+					h.connectionClose = true
+					return 0, ErrDuplicateContentLength
+				}
+				contentLengthSeen = true
 				var err error
 				contentLength, err := parseContentLength(s.value)
 				if err != nil {

--- a/header_test.go
+++ b/header_test.go
@@ -3112,10 +3112,6 @@ func TestResponseHeaderReadSuccess(t *testing.T) {
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 400 OK\nconTEnt-leNGTH: 123\nConTENT-TYPE: ass\r\n\r\n",
 		400, 123, "ass")
 
-	// duplicate content-length
-	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 456\r\nContent-Type: foo/bar\r\nContent-Length: 321\r\n\r\n",
-		200, 321, "foo/bar")
-
 	// duplicate content-type
 	testResponseHeaderReadSuccess(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 234\r\nContent-Type: foo/bar\r\nContent-Type: baz/bar\r\n\r\n",
 		200, 234, "baz/bar")
@@ -3358,6 +3354,9 @@ func TestResponseHeaderReadError(t *testing.T) {
 	testResponseHeaderReadError(t, h, "HTTP/1.1 foobar OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
 	testResponseHeaderReadError(t, h, "HTTP/1.1 123foobar OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
 	testResponseHeaderReadError(t, h, "HTTP/1.1 foobar344 OK\r\nContent-Length: 123\r\nContent-Type: text/html\r\n\r\n")
+
+	// duplicate content-length
+	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: 456\r\nContent-Type: foo/bar\r\nContent-Length: 321\r\n\r\n")
 
 	// non-numeric content-length
 	testResponseHeaderReadError(t, h, "HTTP/1.1 200 OK\r\nContent-Length: faaa\r\nContent-Type: text/html\r\n\r\nfoobar")


### PR DESCRIPTION
`Repro`: a response with two differing `Content-Length` lines.

`HTTP/1.1 200 OK\r\nContent-Length: 10\r\nContent-Length: 20\r\n\r\n`

`Expected`: rejected, like the request parser (#2190) and `net/http` (`message cannot contain multiple Content-Length headers`).
`Actual`: accepted, `ContentLength()` returns `20` (last value silently wins), which is a response desync vector for clients/proxies.

1. `ResponseHeader.parseHeaders` never tracked whether a `Content-Length` was already seen, so the second header overwrote the first.
2. `RequestHeader.parseHeaders` already returns `ErrDuplicateContentLength` for this case.

Mirrored the request-side check in the response parser and moved the existing duplicate-`Content-Length` case in `TestResponseHeaderReadError`.