### PR TITLE
strip cr/lf from header keys in normalizeHeaderKey

### DIFF
--- a/header.go
+++ b/header.go
@@ -3404,6 +3404,12 @@ func getHeaderKeyBytes(bufK []byte, key string, disableNormalizing bool) []byte 
 }
 
 func normalizeHeaderKey(b []byte, disableNormalizing bool) {
+	// Neutralise any CR/LF in the key so a header name can't break the
+	// message framing, mirroring the value handling in initHeaderValueBytes.
+	// This runs before the early returns below because a key carrying a space
+	// or an otherwise invalid byte skips normalization entirely.
+	b = removeNewLines(b)
+
 	if disableNormalizing {
 		return
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -116,6 +116,69 @@ func TestResponseHeaderFirstLineSettersSanitizeNewlines(t *testing.T) {
 	}
 }
 
+func TestResponseHeaderKeySettersSanitizeNewlines(t *testing.T) {
+	t.Parallel()
+
+	const badKey = "X-Foo\r\nInjected: true"
+
+	testCases := []struct {
+		name string
+		set  func(*ResponseHeader)
+	}{
+		{name: "Set", set: func(h *ResponseHeader) { h.Set(badKey, "bar") }},
+		{name: "Add", set: func(h *ResponseHeader) { h.Add(badKey, "bar") }},
+		{name: "SetBytesV", set: func(h *ResponseHeader) { h.SetBytesV(badKey, []byte("bar")) }},
+		{name: "SetBytesKV", set: func(h *ResponseHeader) { h.SetBytesKV([]byte(badKey), []byte("bar")) }},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var h ResponseHeader
+			h.SetStatusCode(StatusOK)
+			h.SetContentLength(0)
+			tc.set(&h)
+
+			if bytes.Contains(h.Header(), []byte("\r\nInjected:")) {
+				t.Fatalf("header key injection reached the wire in %q", h.Header())
+			}
+		})
+	}
+}
+
+func TestRequestHeaderKeySettersSanitizeNewlines(t *testing.T) {
+	t.Parallel()
+
+	const badKey = "X-Foo\r\nInjected: true"
+
+	testCases := []struct {
+		name string
+		set  func(*RequestHeader)
+	}{
+		{name: "Set", set: func(h *RequestHeader) { h.Set(badKey, "bar") }},
+		{name: "Add", set: func(h *RequestHeader) { h.Add(badKey, "bar") }},
+		{name: "SetBytesV", set: func(h *RequestHeader) { h.SetBytesV(badKey, []byte("bar")) }},
+		{name: "SetBytesKV", set: func(h *RequestHeader) { h.SetBytesKV([]byte(badKey), []byte("bar")) }},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var h RequestHeader
+			h.SetMethod(MethodGet)
+			h.SetRequestURI("/")
+			h.SetHost("example.com")
+			tc.set(&h)
+
+			if bytes.Contains(h.Header(), []byte("\r\nInjected:")) {
+				t.Fatalf("header key injection reached the wire in %q", h.Header())
+			}
+		})
+	}
+}
+
 func TestResponseHeaderMultiLineValue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Repro: `h.Set("X-Foo\r\nInjected: true", "bar")` on a `ResponseHeader` (or `RequestHeader`), then read `h.Header()` — the output carries a second `Injected: true` line on the wire.
Cause: header values are sanitised against CR/LF in `initHeaderValueBytes`, but keys are not. `normalizeHeaderKey` only fixes case and returns early when the key holds a space or any other invalid byte, so an embedded `\r`/`\n` survives and `appendHeaderLine` writes the key verbatim, splitting the header block.
Fix: strip CR/LF in `normalizeHeaderKey`, the single point every key setter (`Set`/`Add`/`SetBytesKV`/`SetBytesV`/`AppendNormalizedHeaderKey`, both request and response) funnels through, mirroring the value path. Trailer keys (`isValidTrailerKey`) and cookie fields already reject/strip these bytes.