### PR TITLE
Avoid default content type for empty requests

### DIFF
--- a/header.go
+++ b/header.go
@@ -2613,7 +2613,7 @@ func (h *RequestHeader) AppendBytes(dst []byte) []byte {
 	}
 
 	contentType := h.ContentType()
-	if !h.noDefaultContentType && len(contentType) == 0 && h.ContentLength() != 0 {
+	if !h.noDefaultContentType && len(contentType) == 0 && h.ContentLength() > 0 {
 		contentType = strDefaultContentType
 	}
 	if len(contentType) > 0 && !h.disableSpecialHeader {

--- a/header.go
+++ b/header.go
@@ -2613,7 +2613,7 @@ func (h *RequestHeader) AppendBytes(dst []byte) []byte {
 	}
 
 	contentType := h.ContentType()
-	if !h.noDefaultContentType && len(contentType) == 0 && !h.ignoreBody() {
+	if !h.noDefaultContentType && len(contentType) == 0 && h.ContentLength() != 0 {
 		contentType = strDefaultContentType
 	}
 	if len(contentType) > 0 && !h.disableSpecialHeader {

--- a/header_test.go
+++ b/header_test.go
@@ -1755,6 +1755,33 @@ func TestRequestContentTypeNoDefault(t *testing.T) {
 	}
 }
 
+func TestRequestWriteDeleteNoDefaultContentType(t *testing.T) {
+	t.Parallel()
+
+	var req Request
+	req.Header.SetMethod(MethodDelete)
+	req.Header.SetHost("example.com")
+
+	w := &bytes.Buffer{}
+	bw := bufio.NewWriter(w)
+	if err := req.Write(bw); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	var h RequestHeader
+	br := bufio.NewReader(w)
+	if err := h.Read(br); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(h.contentType) != 0 {
+		t.Fatalf("unexpected Content-Type %q. Expecting %q", h.contentType, "")
+	}
+}
+
 func TestResponseDateNoDefaultNotEmpty(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #873.

This avoids adding the default `Content-Type` header when writing requests with no body, such as an empty `DELETE` request. Requests with a non-zero content length still keep the existing default content type behavior.

Validation:

```sh
go test ./ -run 'TestRequestContentType|TestRequestWriteDeleteNoDefaultContentType'
go test ./... -run 'TestRequestContentType|TestRequestWriteDeleteNoDefaultContentType'
go list ./... | rg -v '^github\.com/valyala/fasthttp$' | xargs go test
```
