### PR TITLE
fix: guard against nil pointer dereference in decConnsCount

### DIFF
--- a/client.go
+++ b/client.go
@@ -1919,6 +1919,9 @@ func (c *HostClient) decConnsCount() {
 	if q := c.connsWait; q != nil && q.len() > 0 {
 		for q.len() > 0 {
 			w := q.popFront()
+			if w == nil {
+				break
+			}
 			if w.waiting() {
 				go c.dialConnFor(w)
 				dialed = true


### PR DESCRIPTION
## Problem

`decConnsCount` in `client.go` calls `q.popFront()` and immediately
dereferences the result with `w.waiting()` without a nil check. When
`MaxConnWaitTimeout > 0`, `connsWait.len()` is derived from the atomic
`failedWaiters` counter, which is incremented in `AcquireConn` outside
`connsLock`. This creates a window where `len()` reports a positive value
but the queue is actually empty, so `popFront()` returns `nil` and the
following `w.waiting()` call panics with a nil pointer dereference.

This can crash the process under high concurrency with connection pool
pressure.

## What changed

Added a nil guard right after `q.popFront()`. If the wait is `nil`, the
loop breaks immediately instead of dereferencing it:

```go
w := q.popFront()
if w == nil {
    break
}
if w.waiting() {
```

This matches the behavior the loop already intends: an empty queue should
terminate iteration, not crash.

## Validation

- Change is a 3-line addition with no logic change to the existing flow.
- `go vet` / `golangci-lint` clean: no new lint issues, lines well under
  the 130-char limit, formatting satisfies `gofumpt`/`goimports`.
- Existing `client_test.go` race tests (`go test -race -shuffle=on ./...`)
  continue to exercise this code path.

Fixes #2242