### PR TITLE
validate trailer values in parseTrailer

### DIFF
--- a/header.go
+++ b/header.go
@@ -2729,6 +2729,11 @@ func parseTrailer(src []byte, dest []argsKV, disableNormalizing bool) ([]argsKV,
 		if isBadTrailer(s.key) {
 			return dest, 0, fmt.Errorf("forbidden trailer key %q", s.key)
 		}
+		for _, ch := range s.value {
+			if !validHeaderValueByte(ch) {
+				return dest, 0, fmt.Errorf("invalid trailer value %q", s.value)
+			}
+		}
 		normalizeHeaderKeyValidated(s.key, disable)
 		dest = appendArgBytes(dest, s.key, s.value, argsHasValue)
 	}

--- a/header_test.go
+++ b/header_test.go
@@ -2383,6 +2383,50 @@ func TestTrailerParsingSecurityFix(t *testing.T) {
 	}
 }
 
+func TestTrailerValueControlBytesRejected(t *testing.T) {
+	t.Parallel()
+
+	// Trailer values carrying control bytes must be rejected, matching the
+	// validation the regular header parsers apply to header values. Without
+	// this an undeclared trailer is merged into the header set and re-emitted
+	// verbatim, so a bare CR slips into the serialised header block.
+	badTrailers := []string{
+		"X-Foo: a\rb\r\n\r\n",
+		"X-Foo: a\x00b\r\n\r\n",
+		"X-Foo: a\x01b\r\n\r\n",
+	}
+
+	for i, trailer := range badTrailers {
+		t.Run("Request_"+strconv.Itoa(i), func(t *testing.T) {
+			var h RequestHeader
+			err := h.ReadTrailer(bufio.NewReader(bytes.NewBufferString(trailer)))
+			if err == nil {
+				t.Fatalf("expected error for trailer value with control byte: %q", trailer)
+			}
+			if !strings.Contains(err.Error(), "invalid trailer value") {
+				t.Fatalf("expected 'invalid trailer value' error for %q, got: %v", trailer, err)
+			}
+		})
+
+		t.Run("Response_"+strconv.Itoa(i), func(t *testing.T) {
+			var h ResponseHeader
+			err := h.ReadTrailer(bufio.NewReader(bytes.NewBufferString(trailer)))
+			if err == nil {
+				t.Fatalf("expected error for trailer value with control byte: %q", trailer)
+			}
+			if !strings.Contains(err.Error(), "invalid trailer value") {
+				t.Fatalf("expected 'invalid trailer value' error for %q, got: %v", trailer, err)
+			}
+		})
+	}
+
+	// A normal trailer value is still accepted.
+	var h RequestHeader
+	if err := h.ReadTrailer(bufio.NewReader(bytes.NewBufferString("X-Foo: bar\r\n\r\n"))); err != nil && err != io.EOF {
+		t.Fatalf("unexpected error for safe trailer value: %v", err)
+	}
+}
+
 func TestResponseHeaderCookie(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`Repro:` send a chunked message ending in an undeclared trailer whose value holds a bare `\r`, e.g. `X-Sneaky: a\rInjected: yes`. After `Response.Read` the bare CR survives into `resp.Header.Header()` because an undeclared trailer is merged into the normal header set and re-emitted verbatim by `AppendBytes`. A regular header with the same byte is refused (`invalid header value`).

`Cause:` `parseTrailer` validated only the trailer key (and `isBadTrailer`), but never the value, whereas both `parseHeaders` paths run every value byte through `validHeaderValueByte`. So a trailer can smuggle control bytes (bare CR, NUL, other CTLs) past the validation the rest of the stack enforces.

`Fix:` run the same per-byte `validHeaderValueByte` check over the trailer value in `parseTrailer`, rejecting with `invalid trailer value`. Normal trailer values are unaffected.