### PR TITLE
reject duplicate Transfer-Encoding in request header parser

### DIFF
--- a/header.go
+++ b/header.go
@@ -3142,6 +3142,7 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 	h.contentLength = -2
 
 	contentLengthSeen := false
+	transferEncodingSeen := false
 	hostSeen := false
 
 	var s headerScanner
@@ -3203,6 +3204,14 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 		case 't':
 			if caseInsensitiveCompare(s.key, strTransferEncoding) {
 				isTransferEncoding = true
+				if transferEncodingSeen {
+					h.connectionClose = true
+					if h.secureErrorLogMessage {
+						return 0, ErrUnsupportedTransferEncoding
+					}
+					return 0, errors.New("too many Transfer-Encoding headers")
+				}
+				transferEncodingSeen = true
 			}
 		}
 

--- a/header_test.go
+++ b/header_test.go
@@ -3506,6 +3506,9 @@ func TestRequestHeaderReadError(t *testing.T) {
 	// post with duplicate content-length
 	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nContent-Type: s\r\nContent-Length: 13\r\nContent-Length: 1\r\n\r\n")
 
+	// post with duplicate transfer-encoding
+	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
+
 	// invalid Content-Length with Transfer-Encoding
 	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nContent-Length: nope\r\nTransfer-Encoding: chunked\r\n\r\n")
 	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nTransfer-Encoding: chunked\r\nContent-Length: nope\r\n\r\n")


### PR DESCRIPTION
`Repro`: a request carrying two `Transfer-Encoding` headers.

`POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n`

`Expected`: rejected, like the response parser (`too many Transfer-Encoding headers`) and the request parser's own duplicate `Content-Length`/`Host` checks.
`Actual`: accepted and read as an ordinary chunked request, a `TE.TE` smuggling/desync vector when fasthttp sits behind or in front of a server that resolves the duplicate differently.

1. `RequestHeader.parseHeaders` never tracked whether a `Transfer-Encoding` header had already been seen, so a second one passed straight through.
2. `ResponseHeader.parseHeaders` already rejects this case.

Mirrored the response-side guard in the request parser and added the duplicate case to `TestRequestHeaderReadError`.