### PR TITLE
fix(server): close listener on serve error in ListenAndServe helpers

### DIFF
--- a/server.go
+++ b/server.go
@@ -1771,6 +1771,9 @@ func (s *Server) ListenAndServeUNIX(addr string, mode os.FileMode) error {
 		return err
 	}
 	if err = os.Chmod(addr, mode); err != nil {
+		// Close the listener so the unix socket file descriptor is not
+		// leaked when chmod fails before Serve takes ownership of it.
+		_ = ln.Close()
 		return fmt.Errorf("cannot chmod %#o for %q: %w", mode, addr, err)
 	}
 	return s.Serve(ln)
@@ -1792,7 +1795,14 @@ func (s *Server) ListenAndServeTLS(addr, certFile, keyFile string) error {
 	if err != nil {
 		return err
 	}
-	return s.ServeTLS(ln, certFile, keyFile)
+	// ServeTLS only takes ownership of ln on the serving path; close it
+	// here when it returns an error (e.g. cert loading) so the listener
+	// is not leaked.
+	if err := s.ServeTLS(ln, certFile, keyFile); err != nil {
+		_ = ln.Close()
+		return err
+	}
+	return nil
 }
 
 // ListenAndServeTLSEmbed serves HTTPS requests from the given TCP4 addr.
@@ -1811,7 +1821,14 @@ func (s *Server) ListenAndServeTLSEmbed(addr string, certData, keyData []byte) e
 	if err != nil {
 		return err
 	}
-	return s.ServeTLSEmbed(ln, certData, keyData)
+	// ServeTLSEmbed only takes ownership of ln on the serving path; close
+	// it here when it returns an error (e.g. cert loading) so the listener
+	// is not leaked.
+	if err := s.ServeTLSEmbed(ln, certData, keyData); err != nil {
+		_ = ln.Close()
+		return err
+	}
+	return nil
 }
 
 // ServeTLS serves HTTPS requests from the given listener.

--- a/server_test.go
+++ b/server_test.go
@@ -1372,6 +1372,75 @@ func TestServerServeTLSEmbed(t *testing.T) {
 	}
 }
 
+func TestServerListenAndServeTLSClosesListenerOnCertError(t *testing.T) {
+	// Not parallel on purpose: the test binds a specific address and then
+	// rebinds the same address to verify that the listener allocated by
+	// ListenAndServeTLS is closed when ServeTLS fails before handing
+	// ownership of the listener over to Serve.
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err = ln.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := &Server{
+		Handler: func(*RequestCtx) {},
+	}
+
+	// Missing certificate files make ServeTLS return an error before Serve
+	// takes ownership of the listener created by ListenAndServeTLS.
+	if err = s.ListenAndServeTLS(addr, "does-not-exist-cert", "does-not-exist-key"); err == nil {
+		t.Fatal("expected error when serving TLS with missing certificate files")
+	}
+
+	// The listener must have been closed on the error path; otherwise the
+	// address is still in use and rebinding it fails.
+	ln, err = net.Listen("tcp4", addr)
+	if err != nil {
+		t.Fatalf("listener leaked: address %q still in use after serve error: %v", addr, err)
+	}
+	if err = ln.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServerListenAndServeTLSEmbedClosesListenerOnCertError(t *testing.T) {
+	// Not parallel on purpose: see TestServerListenAndServeTLSClosesListenerOnCertError.
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err = ln.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := &Server{
+		Handler: func(*RequestCtx) {},
+	}
+
+	// Invalid certificate data makes ServeTLSEmbed return an error before
+	// Serve takes ownership of the listener created by ListenAndServeTLSEmbed.
+	if err = s.ListenAndServeTLSEmbed(addr, []byte("invalid cert"), []byte("invalid key")); err == nil {
+		t.Fatal("expected error when serving TLS with invalid certificate data")
+	}
+
+	// The listener must have been closed on the error path; otherwise the
+	// address is still in use and rebinding it fails.
+	ln, err = net.Listen("tcp4", addr)
+	if err != nil {
+		t.Fatalf("listener leaked: address %q still in use after serve error: %v", addr, err)
+	}
+	if err = ln.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestServerMultipartFormDataRequest(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Hi,

I've built a static analyzer for Go called [Ghoul](https://fereidani.com/ghoul), and I ran it against the fasthttp codebase. It flagged a few resource leaks in the ListenAndServe helpers, where a listener created with net.Listen is not closed when an error occurs before Serve takes ownership of it. It also flagged one piece of dead code.

Ghoul related reports:
```txt
server.go:1774:3: [resource-leak] resource from net.Listen allocated at server.go:1769 never closed (confidence: 6.4/10, CWE-404)
  --> server.go:1769:23: source:      resource allocated by net.Listen
server.go:1795:19: [resource-leak] resource from net.Listen passed to ServeTLS which may leak it on an error path (the helper owns it on some paths but not all) (confidence: 6.4/10, CWE-404)
  --> server.go:1791:23: source:      resource allocated by net.Listen
server.go:1814:24: [resource-leak] resource from net.Listen passed to ServeTLSEmbed which may leak it on an error path (the helper owns it on some paths but not all) (confidence: 6.4/10, CWE-404)
  --> server.go:1810:23: source:      resource allocated by net.Listen
peripconn.go:139:6: [dead-code] function uint322ip is never referenced; it is dead code (confidence: 7.4/10, CWE-563)
```

This change closes the listener on the error paths of `ListenAndServeUNIX` (chmod failure), `ListenAndServeTLS`, and `ListenAndServeTLSEmbed` (certificate load failure), so the file descriptor is released instead of leaked. The fix lives in the `ListenAndServe*` wrappers, which are the functions that allocate the listener, so the existing behavior of `ServeTLS` and `ServeTLSEmbed` (the caller owns the listener it passes in) is unchanged. I also added two regression tests that rebind the same address to confirm the listener is closed on the error path.

The `uint322ip` dead-code finding in `peripconn.go` is included above for awareness. I left it as-is because it is the inverse of the production-used `ip2uint32` and is covered by a round-trip test, but you may want to remove it if you consider it unused.