### PR TITLE
preserve duplicate request headers in ConvertRequest

### DIFF
--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -62,7 +62,7 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 			if sk == fasthttp.HeaderCookie {
 				sv = strings.Clone(sv)
 			}
-			r.Header.Set(sk, sv)
+			r.Header.Add(sk, sv)
 		}
 	}
 

--- a/fasthttpadaptor/request_test.go
+++ b/fasthttpadaptor/request_test.go
@@ -7,6 +7,34 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+func TestConvertRequestPreservesDuplicateHeaders(t *testing.T) {
+	var ctx fasthttp.RequestCtx
+	var req fasthttp.Request
+
+	req.Header.SetMethod("GET")
+	req.SetRequestURI("/")
+	req.Header.SetHost("example.com")
+	req.Header.Add("X-Forwarded-For", "10.0.0.1")
+	req.Header.Add("X-Forwarded-For", "203.0.113.7")
+	ctx.Init(&req, nil, nil)
+
+	var r http.Request
+	if err := ConvertRequest(&ctx, &r, true); err != nil {
+		t.Fatalf("ConvertRequest returned error: %v", err)
+	}
+
+	got := r.Header.Values("X-Forwarded-For")
+	want := []string{"10.0.0.1", "203.0.113.7"}
+	if len(got) != len(want) {
+		t.Fatalf("X-Forwarded-For = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("X-Forwarded-For = %q, want %q", got, want)
+		}
+	}
+}
+
 func BenchmarkConvertRequest(b *testing.B) {
 	var httpReq http.Request
 


### PR DESCRIPTION
1. `ConvertRequest` copies request headers with `r.Header.Set`, so a request that repeats a header (two `X-Forwarded-For`, several `Via`/`Forwarded`) reaches the `http.Handler` with only the last value.
2. The response path in `adaptor.go` already uses `Add`, and `net/http` keeps repeated headers as separate values, so middleware reading `Header.Values` behind the adaptor silently loses the earlier ones.
3. Switched the copy to `r.Header.Add`; added a regression test.

Repro: two `X-Forwarded-For` headers in; `Header.Values("X-Forwarded-For")` returned `["203.0.113.7"]` (expected both). With `Add` both survive.
