### PR TITLE
Stackfull compressors

### DIFF
--- a/brotli.go
+++ b/brotli.go
@@ -102,6 +102,21 @@ func AppendBrotliBytesLevel(dst, src []byte, level int) []byte {
 	return w.b
 }
 
+// AppendBrotliBytesLevelStackfull appends brotlied src to dst using the given
+// compression level and returns the resulting dst.
+//
+// Supported compression levels are:
+//
+//   - CompressBrotliNoCompression
+//   - CompressBrotliBestSpeed
+//   - CompressBrotliBestCompression
+//   - CompressBrotliDefaultCompression
+func AppendBrotliBytesLevelStackfull(dst, src []byte, level int) []byte {
+	w := &byteSliceWriter{b: dst}
+	WriteBrotliLevelStackfull(w, src, level) //nolint:errcheck
+	return w.b
+}
+
 // WriteBrotliLevel writes brotlied p to w using the given compression level
 // and returns the number of compressed bytes written to w.
 //
@@ -132,6 +147,22 @@ func WriteBrotliLevel(w io.Writer, p []byte, level int) (int, error) {
 	}
 }
 
+// WriteBrotliLevelStackfull writes brotlied p to w using the given compression level
+// and returns the number of compressed bytes written to w.
+//
+// Supported compression levels are:
+//
+//   - CompressBrotliNoCompression
+//   - CompressBrotliBestSpeed
+//   - CompressBrotliBestCompression
+//   - CompressBrotliDefaultCompression
+func WriteBrotliLevelStackfull(w io.Writer, p []byte, level int) (int, error) {
+	zw := acquireRealBrotliWriter(w, level)
+	n, err := zw.Write(p)
+	releaseRealBrotliWriter(zw, level)
+	return n, err
+}
+
 var (
 	stacklessWriteBrotliOnce sync.Once
 	stacklessWriteBrotliFunc func(ctx any) bool
@@ -159,9 +190,20 @@ func WriteBrotli(w io.Writer, p []byte) (int, error) {
 	return WriteBrotliLevel(w, p, CompressBrotliDefaultCompression)
 }
 
+// WriteBrotliStackfull writes brotlied p to w and returns the number of compressed
+// bytes written to w.
+func WriteBrotliStackfull(w io.Writer, p []byte) (int, error) {
+	return WriteBrotliLevelStackfull(w, p, CompressBrotliDefaultCompression)
+}
+
 // AppendBrotliBytes appends brotlied src to dst and returns the resulting dst.
 func AppendBrotliBytes(dst, src []byte) []byte {
 	return AppendBrotliBytesLevel(dst, src, CompressBrotliDefaultCompression)
+}
+
+// AppendBrotliBytesStackfull appends brotlied src to dst and returns the resulting dst.
+func AppendBrotliBytesStackfull(dst, src []byte) []byte {
+	return AppendBrotliBytesLevelStackfull(dst, src, CompressBrotliDefaultCompression)
 }
 
 // WriteUnbrotli writes unbrotlied p to w and returns the number of uncompressed

--- a/compress.go
+++ b/compress.go
@@ -146,6 +146,22 @@ func AppendGzipBytesLevel(dst, src []byte, level int) []byte {
 	return w.b
 }
 
+// AppendGzipBytesLevel appends gzipped src to dst using the given
+// compression level and returns the resulting dst.
+//
+// Supported compression levels are:
+//
+//   - CompressNoCompression
+//   - CompressBestSpeed
+//   - CompressBestCompression
+//   - CompressDefaultCompression
+//   - CompressHuffmanOnly
+func AppendGzipBytesLevelStackfull(dst, src []byte, level int) []byte {
+	w := &byteSliceWriter{b: dst}
+	WriteGzipLevelStackfull(w, src, level) //nolint:errcheck
+	return w.b
+}
+
 // WriteGzipLevel writes gzipped p to w using the given compression level
 // and returns the number of compressed bytes written to w.
 //
@@ -177,6 +193,23 @@ func WriteGzipLevel(w io.Writer, p []byte, level int) (int, error) {
 	}
 }
 
+// WriteGzipLevelStackfull writes gzipped p to w using the given compression level
+// and returns the number of compressed bytes written to w.
+//
+// Supported compression levels are:
+//
+//   - CompressNoCompression
+//   - CompressBestSpeed
+//   - CompressBestCompression
+//   - CompressDefaultCompression
+//   - CompressHuffmanOnly
+func WriteGzipLevelStackfull(w io.Writer, p []byte, level int) (int, error) {
+	zw := acquireRealGzipWriter(w, level)
+	n, err := zw.Write(p)
+	releaseRealGzipWriter(zw, level)
+	return n, err
+}
+
 var (
 	stacklessWriteGzipOnce sync.Once
 	stacklessWriteGzipFunc func(ctx any) bool
@@ -204,9 +237,20 @@ func WriteGzip(w io.Writer, p []byte) (int, error) {
 	return WriteGzipLevel(w, p, CompressDefaultCompression)
 }
 
+// WriteGzip writes gzipped p to w and returns the number of compressed
+// bytes written to w.
+func WriteGzipStackfull(w io.Writer, p []byte) (int, error) {
+	return WriteGzipLevelStackfull(w, p, CompressDefaultCompression)
+}
+
 // AppendGzipBytes appends gzipped src to dst and returns the resulting dst.
 func AppendGzipBytes(dst, src []byte) []byte {
 	return AppendGzipBytesLevel(dst, src, CompressDefaultCompression)
+}
+
+// AppendGzipBytes appends gzipped src to dst and returns the resulting dst.
+func AppendGzipBytesStackfull(dst, src []byte) []byte {
+	return AppendGzipBytesLevelStackfull(dst, src, CompressDefaultCompression)
 }
 
 // WriteGunzip writes ungzipped p to w and returns the number of uncompressed
@@ -253,6 +297,22 @@ func AppendDeflateBytesLevel(dst, src []byte, level int) []byte {
 	return w.b
 }
 
+// AppendDeflateBytesLevelStackfull appends deflated src to dst using the given
+// compression level and returns the resulting dst.
+//
+// Supported compression levels are:
+//
+//   - CompressNoCompression
+//   - CompressBestSpeed
+//   - CompressBestCompression
+//   - CompressDefaultCompression
+//   - CompressHuffmanOnly
+func AppendDeflateBytesLevelStackfull(dst, src []byte, level int) []byte {
+	w := &byteSliceWriter{b: dst}
+	WriteDeflateLevelStackfull(w, src, level) //nolint:errcheck
+	return w.b
+}
+
 // WriteDeflateLevel writes deflated p to w using the given compression level
 // and returns the number of compressed bytes written to w.
 //
@@ -282,6 +342,23 @@ func WriteDeflateLevel(w io.Writer, p []byte, level int) (int, error) {
 		releaseStacklessDeflateWriter(zw, level)
 		return n, err
 	}
+}
+
+// WriteDeflateLevelStackfull writes deflated p to w using the given compression level
+// and returns the number of compressed bytes written to w.
+//
+// Supported compression levels are:
+//
+//   - CompressNoCompression
+//   - CompressBestSpeed
+//   - CompressBestCompression
+//   - CompressDefaultCompression
+//   - CompressHuffmanOnly
+func WriteDeflateLevelStackfull(w io.Writer, p []byte, level int) (int, error) {
+	zw := acquireRealDeflateWriter(w, level)
+	n, err := zw.Write(p)
+	releaseRealDeflateWriter(zw, level)
+	return n, err
 }
 
 var (
@@ -317,9 +394,20 @@ func WriteDeflate(w io.Writer, p []byte) (int, error) {
 	return WriteDeflateLevel(w, p, CompressDefaultCompression)
 }
 
+// WriteDeflateStackfull writes deflated p to w and returns the number of compressed
+// bytes written to w.
+func WriteDeflateStackfull(w io.Writer, p []byte) (int, error) {
+	return WriteDeflateLevelStackfull(w, p, CompressDefaultCompression)
+}
+
 // AppendDeflateBytes appends deflated src to dst and returns the resulting dst.
 func AppendDeflateBytes(dst, src []byte) []byte {
 	return AppendDeflateBytesLevel(dst, src, CompressDefaultCompression)
+}
+
+// AppendDeflateBytes appends deflated src to dst and returns the resulting dst.
+func AppendDeflateBytesStackfull(dst, src []byte) []byte {
+	return AppendDeflateBytesLevelStackfull(dst, src, CompressDefaultCompression)
 }
 
 // WriteInflate writes inflated p to w and returns the number of uncompressed


### PR DESCRIPTION
Hello, why do we use stackless compressors? Is saving stack space really usefull? Any doc explaining?

I ran some benchmarks vs stackfull approach:
```
func BenchmarkStackfull(b *testing.B) {
	testdata := []byte(`hello world`)
	dst := make([]byte, 0, 1<<10)

	tests := []struct {
		name      string
		stackless func(dst []byte, src []byte) []byte
		stackfull func(dst []byte, src []byte) []byte
	}{
		{name: "brotli", stackless: AppendBrotliBytes, stackfull: AppendBrotliBytesStackfull},
		{name: "deflate", stackless: AppendDeflateBytes, stackfull: AppendDeflateBytesStackfull},
		{name: "gzip", stackless: AppendGzipBytes, stackfull: AppendGzipBytesStackfull},
	}

	for _, tt := range tests {
		b.Run(tt.name, func(b *testing.B) {
			b.Run("stackless", func(b *testing.B) {
				for b.Loop() {
					dst = tt.stackless(dst, testdata)[:0]
				}
			})
			b.Run("stackfull", func(b *testing.B) {
				for b.Loop() {
					dst = tt.stackfull(dst, testdata)[:0]
				}
			})
		})
	}
}
```
Here are the results:
```
goos: linux
goarch: amd64
pkg: github.com/valyala/fasthttp
cpu: AMD Ryzen 5 7500F 6-Core Processor             
BenchmarkStackfull/brotli/stackless-12         	  116010	     10878 ns/op	     132 B/op	       2 allocs/op
BenchmarkStackfull/brotli/stackfull-12         	  273409	      4419 ns/op	      24 B/op	       1 allocs/op
BenchmarkStackfull/deflate/stackless-12        	 2364337	       509.4 ns/op	     154 B/op	       2 allocs/op
BenchmarkStackfull/deflate/stackfull-12        	12102837	       101.1 ns/op	      29 B/op	       1 allocs/op
BenchmarkStackfull/gzip/stackless-12           	 2245543	       525.1 ns/op	     141 B/op	       2 allocs/op
BenchmarkStackfull/gzip/stackfull-12           	10197663	       115.5 ns/op	      28 B/op	       1 allocs/op
PASS
ok  	github.com/valyala/fasthttp	7.267s
```

In real apps that compress responses, it's even worse - chan send/recive inside stackless.Func triggers runtime scheduler, so you never konw when it will return to handler goroutine. While desireble workflow is process request completely before switching to the next one.

RFC:
* can we have Stackfull funcs as option?
* naming
* default behaviour (stackless vs stackfull)