### PR TITLE
perf: zero-copy chunked body writes via io.WriterTo

### DIFF
--- a/http.go
+++ b/http.go
@@ -2268,6 +2268,18 @@ type httpWriter interface {
 	Write(w *bufio.Writer) error
 }
 
+// ChunkedBodyWriterTo lets a body opt into zero-copy chunked framing via
+// WriteTo, skipping the copy through a pool buffer.
+//
+// The marker method is required rather than a bare io.WriterTo check: a
+// WriteTo promoted from an embedded reader would otherwise opt in by accident
+// and bypass an overridden Read. Implement only when WriteTo and Read emit
+// the same bytes.
+type ChunkedBodyWriterTo interface {
+	io.WriterTo
+	ChunkedBodyWriterTo()
+}
+
 type chunkedBodyWriter struct {
 	w   *bufio.Writer
 	err error
@@ -2285,9 +2297,8 @@ func (cw *chunkedBodyWriter) Write(p []byte) (int, error) {
 }
 
 func writeBodyChunked(w *bufio.Writer, r io.Reader) error {
-	// Frame buffers directly from an io.WriterTo body to avoid copying
-	// through copyBufPool.
-	if wt, ok := r.(io.WriterTo); ok {
+	// An opted-in body frames its WriteTo output directly, skipping copyBufPool.
+	if wt, ok := r.(ChunkedBodyWriterTo); ok {
 		cw := chunkedBodyWriter{w: w}
 		if _, err := wt.WriteTo(&cw); err != nil {
 			return err

--- a/http.go
+++ b/http.go
@@ -2268,7 +2268,36 @@ type httpWriter interface {
 	Write(w *bufio.Writer) error
 }
 
+type chunkedBodyWriter struct {
+	w   *bufio.Writer
+	err error
+}
+
+func (cw *chunkedBodyWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil // an empty chunk marks end-of-stream
+	}
+	if err := writeChunk(cw.w, p); err != nil {
+		cw.err = err
+		return 0, err
+	}
+	return len(p), nil
+}
+
 func writeBodyChunked(w *bufio.Writer, r io.Reader) error {
+	// Frame buffers directly from an io.WriterTo body to avoid copying
+	// through copyBufPool.
+	if wt, ok := r.(io.WriterTo); ok {
+		cw := chunkedBodyWriter{w: w}
+		if _, err := wt.WriteTo(&cw); err != nil {
+			return err
+		}
+		if cw.err != nil {
+			return cw.err
+		}
+		return writeChunk(w, nil)
+	}
+
 	vbuf := copyBufPool.Get()
 	buf := vbuf.([]byte)
 

--- a/http.go
+++ b/http.go
@@ -2269,15 +2269,12 @@ type httpWriter interface {
 }
 
 // ChunkedBodyWriterTo lets a body opt into zero-copy chunked framing via
-// WriteTo, skipping the copy through a pool buffer.
-//
-// The marker method is required rather than a bare io.WriterTo check: a
-// WriteTo promoted from an embedded reader would otherwise opt in by accident
-// and bypass an overridden Read. Implement only when WriteTo and Read emit
-// the same bytes.
+// WriteTo. Return true only when WriteTo and Read emit the same bytes; a bare
+// io.WriterTo check is avoided because a WriteTo promoted from an embedded
+// reader would opt in by accident and bypass an overridden Read.
 type ChunkedBodyWriterTo interface {
 	io.WriterTo
-	ChunkedBodyWriterTo()
+	SupportsChunkedBodyWriteTo() bool
 }
 
 type chunkedBodyWriter struct {
@@ -2297,8 +2294,19 @@ func (cw *chunkedBodyWriter) Write(p []byte) (int, error) {
 }
 
 func writeBodyChunked(w *bufio.Writer, r io.Reader) error {
-	// An opted-in body frames its WriteTo output directly, skipping copyBufPool.
-	if wt, ok := r.(ChunkedBodyWriterTo); ok {
+	// Frame WriteTo output directly, skipping copyBufPool, for bodies whose
+	// WriteTo is known to match reading.
+	useWriteTo := false
+	switch r.(type) {
+	case *bytes.Reader, *bytes.Buffer:
+		useWriteTo = true
+	default:
+		if cw, ok := r.(ChunkedBodyWriterTo); ok {
+			useWriteTo = cw.SupportsChunkedBodyWriteTo()
+		}
+	}
+	if useWriteTo {
+		wt := r.(io.WriterTo)
 		cw := chunkedBodyWriter{w: w}
 		if _, err := wt.WriteTo(&cw); err != nil {
 			return err

--- a/http.go
+++ b/http.go
@@ -2310,17 +2310,18 @@ func (cw *chunkedBodyWriter) Write(p []byte) (int, error) {
 func writeBodyChunked(w *bufio.Writer, r io.Reader) error {
 	// Frame WriteTo output directly, skipping copyBufPool, for bodies whose
 	// WriteTo is known to match reading.
-	useWriteTo := false
-	switch r.(type) {
-	case *bytes.Reader, *bytes.Buffer:
-		useWriteTo = true
+	var wt io.WriterTo
+	switch v := r.(type) {
+	case *bytes.Reader:
+		wt = v
+	case *bytes.Buffer:
+		wt = v
 	default:
-		if cw, ok := r.(ChunkedBodyWriterTo); ok {
-			useWriteTo = cw.SupportsChunkedBodyWriteTo()
+		if cw, ok := r.(ChunkedBodyWriterTo); ok && cw.SupportsChunkedBodyWriteTo() {
+			wt = cw
 		}
 	}
-	if useWriteTo {
-		wt := r.(io.WriterTo)
+	if wt != nil {
 		cw := chunkedBodyWriter{w: w}
 		if _, err := wt.WriteTo(&cw); err != nil {
 			return err

--- a/http.go
+++ b/http.go
@@ -239,6 +239,10 @@ func (resp *Response) SendFile(path string) error {
 //
 // If bodySize < 0, then bodyStream is read until io.EOF.
 //
+// When bodySize < 0 (chunked transfer encoding), fasthttp may frame the body
+// using WriteTo instead of Read for *bytes.Reader, *bytes.Buffer, and streams
+// implementing ChunkedBodyWriterTo.
+//
 // bodyStream.Close() is called after finishing reading all body data
 // if it implements io.Closer.
 //
@@ -257,6 +261,10 @@ func (req *Request) SetBodyStream(bodyStream io.Reader, bodySize int) {
 // before returning io.EOF.
 //
 // If bodySize < 0, then bodyStream is read until io.EOF.
+//
+// When bodySize < 0 (chunked transfer encoding), fasthttp may frame the body
+// using WriteTo instead of Read for *bytes.Reader, *bytes.Buffer, and streams
+// implementing ChunkedBodyWriterTo.
 //
 // bodyStream.Close() is called after finishing reading all body data
 // if it implements io.Closer.
@@ -2269,9 +2277,15 @@ type httpWriter interface {
 }
 
 // ChunkedBodyWriterTo lets a body opt into zero-copy chunked framing via
-// WriteTo. Return true only when WriteTo and Read emit the same bytes; a bare
-// io.WriterTo check is avoided because a WriteTo promoted from an embedded
-// reader would opt in by accident and bypass an overridden Read.
+// WriteTo. It is consulted only for unknown-size bodies (bodySize < 0) written
+// with chunked transfer encoding.
+//
+// SupportsChunkedBodyWriteTo must return true only when WriteTo can safely
+// replace Read, including any pacing, accounting, transformations, or other
+// observable side effects Read performs — emitting the same eventual bytes is
+// not enough. A bare io.WriterTo check is avoided because a WriteTo promoted
+// from an embedded reader would opt in by accident and bypass an overridden
+// Read; the bool also lets an embedding type opt back out.
 type ChunkedBodyWriterTo interface {
 	io.WriterTo
 	SupportsChunkedBodyWriteTo() bool

--- a/http_test.go
+++ b/http_test.go
@@ -3225,3 +3225,125 @@ func TestRequestGetTimeOut(t *testing.T) {
 		})
 	}
 }
+
+// chunkedOptInBody opts in, so writeBodyChunked must use WriteTo, not Read.
+type chunkedOptInBody struct {
+	r        *bytes.Reader
+	readCnt  int
+	writeCnt int
+}
+
+func (b *chunkedOptInBody) Read(p []byte) (int, error) {
+	b.readCnt++
+	return b.r.Read(p)
+}
+
+func (b *chunkedOptInBody) WriteTo(w io.Writer) (int64, error) {
+	b.writeCnt++
+	return b.r.WriteTo(w)
+}
+
+func (b *chunkedOptInBody) ChunkedBodyWriterTo() {}
+
+func TestWriteBodyChunkedWriterToOptIn(t *testing.T) {
+	t.Parallel()
+
+	body := string(createFixedBody(10001))
+	stream := &chunkedOptInBody{r: bytes.NewReader([]byte(body))}
+
+	var resp Response
+	resp.SetBodyStream(stream, -1)
+
+	var w bytes.Buffer
+	bw := bufio.NewWriter(&w)
+	if err := resp.Write(bw); err != nil {
+		t.Fatalf("unexpected error when writing response: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error when flushing response: %v", err)
+	}
+
+	if stream.writeCnt != 1 {
+		t.Fatalf("WriteTo must be called once, got %d", stream.writeCnt)
+	}
+	if stream.readCnt != 0 {
+		t.Fatalf("Read must not be called on an opted-in body, got %d", stream.readCnt)
+	}
+
+	var resp1 Response
+	if err := resp1.Read(bufio.NewReader(&w)); err != nil {
+		t.Fatalf("unexpected error when reading response: %v", err)
+	}
+	if string(resp1.Body()) != body {
+		t.Fatalf("unexpected body of len %d. Expecting len %d", len(resp1.Body()), len(body))
+	}
+}
+
+// promotedWriterToBody has WriteTo promoted from an embedded reader while Read
+// is overridden — TestRevertPull1233's F pattern. Without the marker it must
+// not opt in, or the overridden Read is bypassed.
+type embeddedWriterTo struct {
+	r        *bytes.Reader
+	writeCnt int
+}
+
+func (e *embeddedWriterTo) Read(p []byte) (int, error) { return e.r.Read(p) }
+
+func (e *embeddedWriterTo) WriteTo(w io.Writer) (int64, error) {
+	e.writeCnt++
+	return e.r.WriteTo(w)
+}
+
+type promotedWriterToBody struct {
+	*embeddedWriterTo // WriteTo is promoted from here
+	readCnt           int
+}
+
+func (b *promotedWriterToBody) Read(p []byte) (int, error) {
+	b.readCnt++
+	return b.embeddedWriterTo.Read(p)
+}
+
+func TestWriteBodyChunkedPromotedWriterToNotOptIn(t *testing.T) {
+	t.Parallel()
+
+	body := string(createFixedBody(10001))
+	inner := &embeddedWriterTo{r: bytes.NewReader([]byte(body))}
+	stream := &promotedWriterToBody{embeddedWriterTo: inner}
+
+	// The promoted WriteTo makes stream satisfy io.WriterTo, but not
+	// ChunkedBodyWriterTo.
+	if _, ok := any(stream).(io.WriterTo); !ok {
+		t.Fatal("test setup: stream must satisfy io.WriterTo via promotion")
+	}
+	if _, ok := any(stream).(ChunkedBodyWriterTo); ok {
+		t.Fatal("test setup: stream must NOT satisfy ChunkedBodyWriterTo")
+	}
+
+	var resp Response
+	resp.SetBodyStream(stream, -1)
+
+	var w bytes.Buffer
+	bw := bufio.NewWriter(&w)
+	if err := resp.Write(bw); err != nil {
+		t.Fatalf("unexpected error when writing response: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error when flushing response: %v", err)
+	}
+
+	if stream.readCnt == 0 {
+		t.Fatal("Read must be used when the body did not opt in")
+	}
+	if inner.writeCnt != 0 {
+		t.Fatalf("promoted WriteTo must not be called, got %d", inner.writeCnt)
+	}
+
+	var resp1 Response
+	if err := resp1.Read(bufio.NewReader(&w)); err != nil {
+		t.Fatalf("unexpected error when reading response: %v", err)
+	}
+	if string(resp1.Body()) != body {
+		t.Fatalf("unexpected body of len %d. Expecting len %d", len(resp1.Body()), len(body))
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -3243,7 +3243,7 @@ func (b *chunkedOptInBody) WriteTo(w io.Writer) (int64, error) {
 	return b.r.WriteTo(w)
 }
 
-func (b *chunkedOptInBody) ChunkedBodyWriterTo() {}
+func (b *chunkedOptInBody) SupportsChunkedBodyWriteTo() bool { return true }
 
 func TestWriteBodyChunkedWriterToOptIn(t *testing.T) {
 	t.Parallel()
@@ -3345,5 +3345,107 @@ func TestWriteBodyChunkedPromotedWriterToNotOptIn(t *testing.T) {
 	}
 	if string(resp1.Body()) != body {
 		t.Fatalf("unexpected body of len %d. Expecting len %d", len(resp1.Body()), len(body))
+	}
+}
+
+// optInInner supports zero-copy framing; optOutBody embeds it but overrides
+// SupportsChunkedBodyWriteTo to return false, opting back out.
+type optInInner struct {
+	r        *bytes.Reader
+	writeCnt int
+}
+
+func (e *optInInner) Read(p []byte) (int, error) { return e.r.Read(p) }
+
+func (e *optInInner) WriteTo(w io.Writer) (int64, error) {
+	e.writeCnt++
+	return e.r.WriteTo(w)
+}
+
+func (e *optInInner) SupportsChunkedBodyWriteTo() bool { return true }
+
+type optOutBody struct {
+	*optInInner
+	readCnt int
+}
+
+func (b *optOutBody) Read(p []byte) (int, error) {
+	b.readCnt++
+	return b.optInInner.Read(p)
+}
+
+func (b *optOutBody) SupportsChunkedBodyWriteTo() bool { return false }
+
+func TestWriteBodyChunkedOptOutOverride(t *testing.T) {
+	t.Parallel()
+
+	body := string(createFixedBody(10001))
+	inner := &optInInner{r: bytes.NewReader([]byte(body))}
+	stream := &optOutBody{optInInner: inner}
+
+	// stream implements ChunkedBodyWriterTo (the method is promoted/overridden),
+	// but its SupportsChunkedBodyWriteTo returns false, so it must use Read.
+	if _, ok := any(stream).(ChunkedBodyWriterTo); !ok {
+		t.Fatal("test setup: stream must implement ChunkedBodyWriterTo")
+	}
+
+	var resp Response
+	resp.SetBodyStream(stream, -1)
+
+	var w bytes.Buffer
+	bw := bufio.NewWriter(&w)
+	if err := resp.Write(bw); err != nil {
+		t.Fatalf("unexpected error when writing response: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error when flushing response: %v", err)
+	}
+
+	if stream.readCnt == 0 {
+		t.Fatal("Read must be used when the body opted back out")
+	}
+	if inner.writeCnt != 0 {
+		t.Fatalf("WriteTo must not be called after opting out, got %d", inner.writeCnt)
+	}
+
+	var resp1 Response
+	if err := resp1.Read(bufio.NewReader(&w)); err != nil {
+		t.Fatalf("unexpected error when reading response: %v", err)
+	}
+	if string(resp1.Body()) != body {
+		t.Fatalf("unexpected body of len %d. Expecting len %d", len(resp1.Body()), len(body))
+	}
+}
+
+// Standard bytes types take the zero-copy path without implementing
+// ChunkedBodyWriterTo; the output must still be correct.
+func TestWriteBodyChunkedConcreteTypes(t *testing.T) {
+	t.Parallel()
+
+	body := string(createFixedBody(10001))
+	newReaders := []func() io.Reader{
+		func() io.Reader { return bytes.NewReader([]byte(body)) },
+		func() io.Reader { return bytes.NewBufferString(body) },
+	}
+	for _, newReader := range newReaders {
+		var resp Response
+		resp.SetBodyStream(newReader(), -1)
+
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		if err := resp.Write(bw); err != nil {
+			t.Fatalf("unexpected error when writing response: %v", err)
+		}
+		if err := bw.Flush(); err != nil {
+			t.Fatalf("unexpected error when flushing response: %v", err)
+		}
+
+		var resp1 Response
+		if err := resp1.Read(bufio.NewReader(&w)); err != nil {
+			t.Fatalf("unexpected error when reading response: %v", err)
+		}
+		if string(resp1.Body()) != body {
+			t.Fatalf("unexpected body of len %d. Expecting len %d", len(resp1.Body()), len(body))
+		}
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -3296,7 +3296,8 @@ func (e *embeddedWriterTo) WriteTo(w io.Writer) (int64, error) {
 
 type promotedWriterToBody struct {
 	*embeddedWriterTo // WriteTo is promoted from here
-	readCnt           int
+
+	readCnt int
 }
 
 func (b *promotedWriterToBody) Read(p []byte) (int, error) {
@@ -3366,6 +3367,7 @@ func (e *optInInner) SupportsChunkedBodyWriteTo() bool { return true }
 
 type optOutBody struct {
 	*optInInner
+
 	readCnt int
 }
 

--- a/server.go
+++ b/server.go
@@ -1542,6 +1542,8 @@ func (ctx *RequestCtx) PostBody() []byte {
 //
 // If bodySize < 0, then bodyStream is read until io.EOF.
 //
+// See ChunkedBodyWriterTo for custom streams writing unknown-size chunked bodies.
+//
 // See also SetBodyStreamWriter.
 func (ctx *RequestCtx) SetBodyStream(bodyStream io.Reader, bodySize int) {
 	ctx.Response.SetBodyStream(bodyStream, bodySize)


### PR DESCRIPTION
## Motivation

`writeBodyChunked` reads the body stream through a fixed 4 KiB `copyBufPool`
buffer and frames every 4 KiB as a separate chunk. When the body stream is
already backed by large in-memory buffers (for example a proxy relaying cached
256 KiB blocks), this re-copies the whole body 4 KiB at a time and emits one
chunk header/flush per 4 KiB.

## Change

If the body stream implements `io.WriterTo`, frame the buffers it writes
directly through a small `chunkedBodyWriter` wrapper, avoiding the extra copy
and cutting the number of chunk frames and flushes. Streams that do not
implement `io.WriterTo` keep the existing 4 KiB read path unchanged.

This mirrors how `writeBodyFixedSize` already prefers `io.WriterTo` through
`copyZeroAlloc`.

## Notes

- Termination and trailer handling are unchanged: the `io.WriterTo` path ends
  with the same zero-length chunk (`writeChunk(w, nil)`) as the EOF path, so
  `writeTrailer` still runs afterwards.
- Empty writes are ignored so they are not mistaken for the end-of-stream chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)