### PR TITLE
Fix temp file leak in SaveMultipartFile on cross-device rename failure

### DIFF
--- a/server.go
+++ b/server.go
@@ -1190,6 +1190,7 @@ func SaveMultipartFile(fh *multipart.FileHeader, path string) (err error) {
 		if f, err = fh.Open(); err != nil {
 			return err
 		}
+		defer os.Remove(ff.Name())
 	}
 
 	defer func() {


### PR DESCRIPTION
## Summary

When `os.Rename` fails in `SaveMultipartFile` (e.g., source `/tmp` and destination on different filesystems), the copy fallback path leaves the original multipart temp file orphaned in `/tmp`.

This adds `defer os.Remove(ff.Name())` after reopening the file for the copy path. The defer captures `ff.Name()` (the temp file path) before `ff` is reassigned to the destination file, ensuring cleanup on all return paths.

Fixes #1439

## Background

As noted in #1439, Go's `mime/multipart` writes uploads exceeding 8KB to temp files in `/tmp/multipart-*`. `SaveMultipartFile` attempts `os.Rename` for an atomic move, but when that fails (cross-device), it falls back to copy — without removing the source temp file.

## Test plan

- [ ] Verify `SaveMultipartFile` still works when rename succeeds (no behavior change — early return before defer)
- [ ] Verify temp file is removed after copy fallback
- [ ] Verify temp file is removed if `os.Create` or `copyZeroAlloc` fails