### PR TITLE
perf: avoid redundant scans when parsing request headers

### DIFF
--- a/header.go
+++ b/header.go
@@ -551,20 +551,29 @@ func validHeaderValueByte(c byte) bool {
 	return validHeaderValueByteTable[c] == 1
 }
 
-// isValidHeaderKey returns true if a is a valid header key.
-func isValidHeaderKey(a []byte) bool {
+// isValidHeaderKey returns whether a is a valid header key, and whether a
+// contains a space before its last non-space byte. Such a space survives
+// trailing-whitespace trimming, and a key carrying it is accepted but must
+// not be canonicalized. See https://go.dev/issue/34540 and
+// https://github.com/valyala/fasthttp/issues/1917.
+func isValidHeaderKey(a []byte) (valid, innerSpace bool) {
 	if len(a) == 0 {
-		return false
+		return false, false
 	}
+	seenSpace := false
 	for _, c := range a {
-		// A space is accepted here: we allow invalid headers with a space
-		// before the colon, but they must not be canonicalized.
-		// See https://go.dev/issue/34540.
-		if !validHeaderFieldByte(c) && c != ' ' {
-			return false
+		if c == ' ' {
+			seenSpace = true
+			continue
+		}
+		if !validHeaderFieldByte(c) {
+			return false, false
+		}
+		if seenSpace {
+			innerSpace = true
 		}
 	}
-	return true
+	return true, innerSpace
 }
 
 // VisitHeaderParams calls f for each parameter in the given header bytes.
@@ -2700,19 +2709,8 @@ func parseTrailer(src []byte, dest []argsKV, disableNormalizing bool) ([]argsKV,
 		if len(s.key) == 0 {
 			continue
 		}
-		disable := disableNormalizing
-		for _, ch := range s.key {
-			if !validHeaderFieldByte(ch) {
-				// We accept invalid headers with a space before the
-				// colon, but must not canonicalize them.
-				// See: https://github.com/valyala/fasthttp/issues/1917
-				if ch == ' ' {
-					disable = true
-					continue
-				}
-				return dest, 0, fmt.Errorf("invalid trailer key %q", s.key)
-			}
-		}
+		// Key bytes were already validated by the scanner.
+		disable := disableNormalizing || s.keyHasSpace
 		// Forbidden by RFC 7230, section 4.1.2
 		if isBadTrailer(s.key) {
 			return dest, 0, fmt.Errorf("forbidden trailer key %q", s.key)
@@ -2998,19 +2996,13 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 			return 0, fmt.Errorf("invalid header key %q", s.key)
 		}
 
+		// Key bytes were already validated by the scanner. A key containing
+		// a space is tolerated, but must not be canonicalized and closes
+		// the connection.
 		disableNormalizing := h.disableNormalizing
-		for _, ch := range s.key {
-			if !validHeaderFieldByte(ch) {
-				h.connectionClose = true
-				// We accept invalid headers with a space before the
-				// colon, but must not canonicalize them.
-				// See: https://github.com/valyala/fasthttp/issues/1917
-				if ch == ' ' {
-					disableNormalizing = true
-					continue
-				}
-				return 0, fmt.Errorf("invalid header key %q", s.key)
-			}
+		if s.keyHasSpace {
+			h.connectionClose = true
+			disableNormalizing = true
 		}
 		normalizeHeaderKeyValidated(s.key, disableNormalizing)
 
@@ -3155,18 +3147,8 @@ func (h *RequestHeader) parseHeaders(buf []byte, blockEnd int) (int, error) {
 			return 0, fmt.Errorf("invalid header key %q", s.key)
 		}
 
-		disableNormalizing := h.disableNormalizing
-		for _, ch := range s.key {
-			if !validHeaderFieldByte(ch) {
-				if ch == ' ' {
-					disableNormalizing = true
-					continue
-				}
-				h.connectionClose = true
-				return 0, fmt.Errorf("invalid header key %q", s.key)
-			}
-		}
-		normalizeHeaderKeyValidated(s.key, disableNormalizing)
+		// Key bytes were already validated by the scanner.
+		normalizeHeaderKeyValidated(s.key, h.disableNormalizing || s.keyHasSpace)
 
 		for _, ch := range s.value {
 			if !validHeaderValueByte(ch) {

--- a/header.go
+++ b/header.go
@@ -556,27 +556,14 @@ func isValidHeaderKey(a []byte) bool {
 	if len(a) == 0 {
 		return false
 	}
-
-	// See if a looks like a header key. If not, return it unchanged.
-	noCanon := false
 	for _, c := range a {
-		if validHeaderFieldByte(c) {
-			continue
+		// A space is accepted here: we allow invalid headers with a space
+		// before the colon, but they must not be canonicalized.
+		// See https://go.dev/issue/34540.
+		if !validHeaderFieldByte(c) && c != ' ' {
+			return false
 		}
-		// Don't canonicalize.
-		if c == ' ' {
-			// We accept invalid headers with a space before the
-			// colon, but must not canonicalize them.
-			// See https://go.dev/issue/34540.
-			noCanon = true
-			continue
-		}
-		return false
 	}
-	if noCanon {
-		return true
-	}
-
 	return true
 }
 
@@ -1306,9 +1293,10 @@ func (h *RequestHeader) AllInOrder() iter.Seq2[[]byte, []byte] {
 	return func(yield func([]byte, []byte) bool) {
 		var s headerScanner
 		s.b = h.rawHeaders
+		s.blockEnd = len(h.rawHeaders)
 		for s.next() {
 			s.key = trimTrailingSpace(s.key)
-			normalizeHeaderKey(s.key, h.disableNormalizing || bytes.IndexByte(s.key, ' ') != -1)
+			normalizeHeaderKey(s.key, h.disableNormalizing)
 			if len(s.key) > 0 {
 				if !yield(s.key, s.value) {
 					break
@@ -1343,7 +1331,7 @@ func (h *ResponseHeader) Del(key string) {
 // DelBytes deletes header with the given key.
 func (h *ResponseHeader) DelBytes(key []byte) {
 	h.bufK = append(h.bufK[:0], key...)
-	normalizeHeaderKey(h.bufK, h.disableNormalizing || bytes.IndexByte(key, ' ') != -1)
+	normalizeHeaderKey(h.bufK, h.disableNormalizing)
 	h.del(h.bufK)
 }
 
@@ -1377,7 +1365,7 @@ func (h *RequestHeader) Del(key string) {
 // DelBytes deletes header with the given key.
 func (h *RequestHeader) DelBytes(key []byte) {
 	h.bufK = append(h.bufK[:0], key...)
-	normalizeHeaderKey(h.bufK, h.disableNormalizing || bytes.IndexByte(key, ' ') != -1)
+	normalizeHeaderKey(h.bufK, h.disableNormalizing)
 	h.del(h.bufK)
 }
 
@@ -1638,7 +1626,7 @@ func (h *ResponseHeader) SetBytesV(key string, value []byte) {
 // Use AddBytesKV for setting multiple header values under the same key.
 func (h *ResponseHeader) SetBytesKV(key, value []byte) {
 	h.bufK = append(h.bufK[:0], key...)
-	normalizeHeaderKey(h.bufK, h.disableNormalizing || bytes.IndexByte(key, ' ') != -1)
+	normalizeHeaderKey(h.bufK, h.disableNormalizing)
 	h.SetCanonical(h.bufK, value)
 }
 
@@ -1869,7 +1857,7 @@ func (h *RequestHeader) SetBytesV(key string, value []byte) {
 // Use AddBytesKV for setting multiple header values under the same key.
 func (h *RequestHeader) SetBytesKV(key, value []byte) {
 	h.bufK = append(h.bufK[:0], key...)
-	normalizeHeaderKey(h.bufK, h.disableNormalizing || bytes.IndexByte(key, ' ') != -1)
+	normalizeHeaderKey(h.bufK, h.disableNormalizing)
 	h.SetCanonical(h.bufK, value)
 }
 
@@ -1906,7 +1894,7 @@ func (h *ResponseHeader) Peek(key string) []byte {
 // Do not store references to returned value. Make copies instead.
 func (h *ResponseHeader) PeekBytes(key []byte) []byte {
 	h.bufK = append(h.bufK[:0], key...)
-	normalizeHeaderKey(h.bufK, h.disableNormalizing || bytes.IndexByte(key, ' ') != -1)
+	normalizeHeaderKey(h.bufK, h.disableNormalizing)
 	return h.peek(h.bufK)
 }
 
@@ -1927,7 +1915,7 @@ func (h *RequestHeader) Peek(key string) []byte {
 // Do not store references to returned value. Make copies instead.
 func (h *RequestHeader) PeekBytes(key []byte) []byte {
 	h.bufK = append(h.bufK[:0], key...)
-	normalizeHeaderKey(h.bufK, h.disableNormalizing || bytes.IndexByte(key, ' ') != -1)
+	normalizeHeaderKey(h.bufK, h.disableNormalizing)
 	return h.peek(h.bufK)
 }
 
@@ -2688,12 +2676,12 @@ func (h *RequestHeader) parse(buf []byte) (int, error) {
 		return 0, err
 	}
 
-	h.rawHeaders, _, err = readRawHeaders(h.rawHeaders[:0], buf[m:])
+	var rawEnd int
+	h.rawHeaders, rawEnd, err = readRawHeaders(h.rawHeaders[:0], buf[m:])
 	if err != nil {
 		return 0, err
 	}
-	var n int
-	n, err = h.parseHeaders(buf[m:])
+	n, err := h.parseHeaders(buf[m:], rawEnd)
 	if err != nil {
 		return 0, err
 	}
@@ -3143,7 +3131,7 @@ func (h *ResponseHeader) parseHeaders(buf []byte) (int, error) {
 	return s.r, nil
 }
 
-func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
+func (h *RequestHeader) parseHeaders(buf []byte, blockEnd int) (int, error) {
 	h.contentLength = -2
 
 	contentLengthSeen := false
@@ -3152,6 +3140,7 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 
 	var s headerScanner
 	s.b = buf
+	s.blockEnd = blockEnd
 
 	for s.next() {
 		key := s.key
@@ -3413,7 +3402,7 @@ func initHeaderValueBytes(bufV, value []byte) []byte {
 
 func getHeaderKeyBytes(bufK []byte, key string, disableNormalizing bool) []byte {
 	bufK = append(bufK[:0], key...)
-	normalizeHeaderKey(bufK, disableNormalizing || bytes.IndexByte(bufK, ' ') != -1)
+	normalizeHeaderKey(bufK, disableNormalizing)
 	return bufK
 }
 

--- a/header_test.go
+++ b/header_test.go
@@ -413,6 +413,47 @@ func TestRequestHeaderEmptyValueFromString(t *testing.T) {
 	}
 }
 
+func TestRequestHeaderReadMixedLineEndings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lf-line-crlf-terminator", func(t *testing.T) {
+		// The raw header block ends with CRLFCRLF, so the scanner takes the
+		// blockEnd fast path even though a header line uses a bare LF.
+		var h RequestHeader
+		br := bufio.NewReader(bytes.NewBufferString("GET / HTTP/1.1\r\nHost: a\nFoo: bar\r\n\r\n"))
+		if err := h.Read(br); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(h.Host()) != "a" {
+			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "a")
+		}
+		if string(h.Peek("Foo")) != "bar" {
+			t.Fatalf("unexpected Foo value: %q. Expecting %q", h.Peek("Foo"), "bar")
+		}
+	})
+	t.Run("lf-terminated-block-with-crlf-following", func(t *testing.T) {
+		// readRawHeaders ends the block at "\n\r\n", which is not CRLFCRLF,
+		// so the scanner falls back to scanning for the terminator itself.
+		var h RequestHeader
+		br := bufio.NewReader(bytes.NewBufferString("GET / HTTP/1.1\r\nHost: a\n\r\n\r\n"))
+		if err := h.Read(br); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(h.Host()) != "a" {
+			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "a")
+		}
+	})
+	t.Run("lf-only-terminator", func(t *testing.T) {
+		// A header block terminated only by "\n\n" contains no CRLFCRLF and
+		// must be rejected, not accepted via the blockEnd fast path.
+		var h RequestHeader
+		br := bufio.NewReader(bytes.NewBufferString("GET / HTTP/1.1\r\nHost: a\n\n"))
+		if err := h.Read(br); err == nil {
+			t.Fatal("expecting error when header block is terminated by bare LFs")
+		}
+	})
+}
+
 func TestRequestRawHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/headerscanner.go
+++ b/headerscanner.go
@@ -20,6 +20,10 @@ type headerScanner struct {
 	key   []byte
 	value []byte
 
+	// keyHasSpace reports whether key contains a space that survives
+	// trailing-whitespace trimming; such keys must not be canonicalized.
+	keyHasSpace bool
+
 	err error
 }
 
@@ -52,22 +56,20 @@ func (s *headerScanner) next() bool {
 		s.initialized = true
 	}
 
-	kv, err := s.readContinuedLineSlice()
+	kv, colon, err := s.readContinuedLineSlice()
 	if len(kv) == 0 {
 		s.err = err
 		return false
 	}
 
-	// Key ends at first colon.
-	k, v, ok := bytes.Cut(kv, strColon)
-	if !ok {
+	// Key ends at the first colon, already found by readContinuedLineSlice.
+	k, v := kv[:colon], kv[colon+1:]
+	valid, innerSpace := isValidHeaderKey(k)
+	if !valid {
 		s.err = fmt.Errorf("malformed MIME header line: %q", kv)
 		return false
 	}
-	if !isValidHeaderKey(k) {
-		s.err = fmt.Errorf("malformed MIME header line: %q", kv)
-		return false
-	}
+	s.keyHasSpace = innerSpace
 
 	// Skip initial spaces in value, without bytes.TrimLeft: it would
 	// rebuild its ASCII set on every call.
@@ -86,54 +88,45 @@ func (s *headerScanner) next() bool {
 	return true
 }
 
-// readLine reads a line from b, starting at s.r, and returns it.
-func (s *headerScanner) readLine() (line []byte) {
-	searchStart := 0
-
-	for {
-		if i := bytes.IndexByte(s.b[s.r+searchStart:], '\n'); i >= 0 {
-			i += searchStart
-			line = s.b[s.r : s.r+i+1]
-			s.r += i + 1
-			break
-		}
-
-		searchStart = len(s.b) - s.r
-	}
-
-	if len(line) == 0 {
+// readLine reads a line from b, starting at s.r, and returns it with the
+// trailing \n and a possible preceding \r dropped. b is truncated at the
+// header block terminator, so every line ends in \n.
+func (s *headerScanner) readLine() []byte {
+	i := bytes.IndexByte(s.b[s.r:], '\n')
+	if i < 0 {
 		return nil
 	}
-
-	// drop \n and possible preceding \r
-	if line[len(line)-1] == '\n' {
-		drop := 1
-		if len(line) > 1 && line[len(line)-2] == '\r' {
-			drop = 2
-		}
-		line = line[:len(line)-drop]
+	line := s.b[s.r : s.r+i]
+	s.r += i + 1
+	if i > 0 && line[i-1] == '\r' {
+		line = line[:i-1]
 	}
 	return line
 }
 
 // readContinuedLineSlice reads continued lines from b until it finds a line
 // that does not start with a space or tab, or it reaches the end of b.
-func (s *headerScanner) readContinuedLineSlice() ([]byte, error) {
+// It also returns the position of the first colon in the returned line:
+// the line can never start with a space or tab (the scanner rejects that for
+// the first line and joins such lines into the previous header), so trimming
+// it doesn't shift the colon.
+func (s *headerScanner) readContinuedLineSlice() ([]byte, int, error) {
 	line := s.readLine()
 	if len(line) == 0 { // blank line - no continuation
-		return line, nil
+		return line, -1, nil
 	}
 
-	if bytes.IndexByte(line, ':') < 0 {
-		return nil, fmt.Errorf("malformed MIME header: missing colon: %q", line)
+	colon := bytes.IndexByte(line, ':')
+	if colon < 0 {
+		return nil, -1, fmt.Errorf("malformed MIME header: missing colon: %q", line)
 	}
 
-	// If the line doesn't start with a space or tab, we are done.
+	// If the next line doesn't start with a space or tab, we are done.
 	if len(s.b)-s.r > 1 {
 		peek := s.b[s.r : s.r+2]
 		if len(peek) > 0 && (isASCIILetter(peek[0]) || peek[0] == '\n') ||
 			len(peek) == 2 && peek[0] == '\r' && peek[1] == '\n' {
-			return trim(line), nil
+			return trim(line), colon, nil
 		}
 	}
 
@@ -145,7 +138,7 @@ func (s *headerScanner) readContinuedLineSlice() ([]byte, error) {
 		line := s.readLine()
 		mline = append(mline, trim(line)...)
 	}
-	return mline, nil
+	return mline, colon, nil
 }
 
 // skipSpace skips one or multiple spaces and tabs in b.

--- a/headerscanner.go
+++ b/headerscanner.go
@@ -12,6 +12,11 @@ type headerScanner struct {
 	b []byte
 	r int
 
+	// blockEnd is the end of the header block in b when the caller has
+	// already found it (see readRawHeaders), 0 otherwise. next only trusts
+	// it if the block really ends in CRLFCRLF there.
+	blockEnd int
+
 	key   []byte
 	value []byte
 
@@ -25,14 +30,20 @@ func (s *headerScanner) next() bool {
 			return false
 		}
 
-		i := bytes.Index(s.b, strCRLFCRLF)
-		if i < 0 {
-			s.err = ErrNeedMore
-			return false
+		if s.blockEnd >= 4 && s.blockEnd <= len(s.b) &&
+			bytes.Equal(s.b[s.blockEnd-4:s.blockEnd], strCRLFCRLF) {
+			// The caller already found the end of the block, no need to
+			// search for it again. The first CRLFCRLF can only sit at
+			// blockEnd-4 since readRawHeaders stops at the first blank line.
+			s.b = s.b[:s.blockEnd]
+		} else {
+			i := bytes.Index(s.b, strCRLFCRLF)
+			if i < 0 {
+				s.err = ErrNeedMore
+				return false
+			}
+			s.b = s.b[:i+4]
 		}
-		i += 4
-
-		s.b = s.b[:i]
 		if len(s.b) > 0 && (s.b[0] == ' ' || s.b[0] == '\t') {
 			s.err = errors.New("invalid headers, headers cannot start with space or tab")
 			return false
@@ -58,8 +69,11 @@ func (s *headerScanner) next() bool {
 		return false
 	}
 
-	// Skip initial spaces in value.
-	v = bytes.TrimLeft(v, " \t")
+	// Skip initial spaces in value, without bytes.TrimLeft: it would
+	// rebuild its ASCII set on every call.
+	for len(v) > 0 && (v[0] == ' ' || v[0] == '\t') {
+		v = v[1:]
+	}
 
 	s.key = k
 	s.value = v


### PR DESCRIPTION
RequestHeader.parse walks the header block twice before the lines are actually parsed: readRawHeaders looks for the end of the block, then headerScanner searches for the CRLFCRLF terminator once more. The scanner now reuses the block end that readRawHeaders already found, guarded by a check that the block really ends in CRLFCRLF. Blocks with bare LF terminators fail that check and take the old search path, so those cases keep behaving exactly as before.

The second commit removes duplicated per-line work on top of that:

- readContinuedLineSlice already finds the colon in every header line; next() now reuses that position instead of running bytes.Cut over the line again. Lines handed out by readContinuedLineSlice can never start with a space or tab, so trimming never shifts the position.
- isValidHeaderKey also reports whether the key contains a space that survives trailing-whitespace trimming. The per-byte key loops in parseHeaders and parseTrailer only existed to derive exactly that flag, their reject branches were unreachable since the scanner validates first. The quirk that a space in a response header key closes the connection is preserved.
- readLine drops its searchStart loop; the scanner truncates the block at the terminator, so every line ends in \n.

Smaller cleanups along the way:

- trim header values with a plain loop, bytes.TrimLeft rebuilds its ASCII set on every call for the " \t" cutset
- drop the bytes.IndexByte(key, ' ') checks in front of normalizeHeaderKey; space is not a valid header field byte, so its validation loop refuses to canonicalize such keys either way, and removeNewLines runs before the early returns in both flows, including the #1917 case of a space before the colon

benchstat (Apple M2 Pro, n=10):

```
RequestHeaderRead-12     79.48n ± 1%   56.06n ± 1%   -29.48% (p=0.000)
ServerGet1ReqPerConn-12  1.693µ ± 3%   1.665µ ± 2%   ~ (p=0.052)
```

A new test covers mixed line endings: the fast path, the fallback, and the rejection of LF-only terminated blocks. The net diff removes more code than it adds.