### PR TITLE
test: fix host comparison in FuzzURIParse

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -115,6 +115,10 @@ func FuzzURIParse(f *testing.F) {
 	f.Add(`http://foobar.com/aaa/bb?cc#dd`)
 	f.Add(`http://google.com?github.com`)
 	f.Add(`http://google.com#@github.com`)
+	// Hosts hiding an uppercase letter and a non-UTF-8 byte behind
+	// percent-encoding, see the host comparison below.
+	f.Add(`http://[%255%2c%2c%2c%2c%4c%2c2c%2c%2c]`)
+	f.Add(`http://aa0aaa%80000000000`)
 
 	f.Fuzz(func(t *testing.T, uri string) {
 		// Limit the size of the URI to avoid OOMs or timeouts.
@@ -141,8 +145,15 @@ func FuzzURIParse(f *testing.F) {
 			return
 		}
 
-		if string(u.Host()) != nu.Host {
-			t.Fatalf("%q: unexpected host: %q. Expecting %q", uri, u.Host(), nu.Host)
+		// fasthttp lowercases the host after unescaping it, net/url keeps
+		// the case of percent-decoded bytes, and the ToLower above cannot
+		// reach them ("%4c" decodes to 'L'). Lower the expectation the same
+		// way fasthttp does; strings.ToLower would mangle non-UTF-8 bytes
+		// like a decoded "%80".
+		expectedHost := []byte(nu.Host)
+		lowercaseBytes(expectedHost)
+		if !bytes.Equal(u.Host(), expectedHost) {
+			t.Fatalf("%q: unexpected host: %q. Expecting %q", uri, u.Host(), expectedHost)
 		}
 		if string(u.QueryString()) != nu.RawQuery {
 			t.Fatalf("%q: unexpected query string: %q. Expecting %q", uri, u.QueryString(), nu.RawQuery)


### PR DESCRIPTION
The cifuzz job on #2312 hit this crasher in FuzzURIParse ([run](https://github.com/valyala/fasthttp/actions/runs/28555598522/job/84662236366)):

```
"http://[%255%2c%2c%2c%2c%4c%2c2c%2c%2c]": unexpected host: "[%5,,,,l,2c,,]". Expecting "[%5,,,,L,2c,,]"
panic: fatal
```
<img width="1416" height="997" alt="image" src="https://github.com/user-attachments/assets/b32bb647-e619-434b-9b78-075e48546ef8" />


The crash is unrelated to that PR: uri.go is untouched there and the input reproduces on master.

FuzzURIParse lowercases the input to hide that fasthttp normalizes the host to lowercase while net/url does not. That trick cannot reach bytes hidden behind percent-encoding: "%4c" survives ToLower and only decodes to 'L' afterwards, so fasthttp returns "l" where net/url keeps "L". fasthttp's behavior is the documented one (Host is always lowercased), so this fixes the comparison instead: the expectation is lowered the same way fasthttp does it, byte-wise via lowercaseBytes. strings.ToLower would mangle non-UTF-8 bytes such as a decoded "%80", which the fuzzer promptly found while testing the fixed harness.

Both inputs are added as seeds; 120s of local fuzzing pass.