### PR TITLE
validate domain and path cookie attribute values on parse

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -428,11 +428,17 @@ func (c *Cookie) ParseBytes(src []byte) error {
 
 			case 'd': // "domain"
 				if caseInsensitiveCompare(strCookieDomain, k) {
+					if !validCookieValue(v) {
+						return ErrInvalidCookieValue
+					}
 					c.domain = initHeaderValueBytes(c.domain, v)
 				}
 
 			case 'p': // "path"
 				if caseInsensitiveCompare(strCookiePath, k) {
+					if !validCookiePathValue(v) {
+						return ErrInvalidCookieValue
+					}
 					c.path = initHeaderValueBytes(c.path, v)
 				}
 
@@ -657,6 +663,25 @@ func decodeCookieArg(dst, src []byte, skipQuotes bool) []byte {
 
 func validCookieValue(value []byte) bool {
 	return !bytes.ContainsAny(value, "\";\\")
+}
+
+// validCookiePathValue reports whether value is acceptable as a cookie Path.
+//
+// Unlike validCookieValue it permits '"' and '\', which are legal path
+// characters accepted by SetPath and net/http's Cookie.String. It rejects the
+// ';' attribute separator and control bytes, matching net/http's cookie path
+// rules. CR and LF are tolerated here because initHeaderValueBytes strips them
+// afterwards, the same as for the primary cookie value.
+func validCookiePathValue(value []byte) bool {
+	for _, b := range value {
+		if b == '\r' || b == '\n' {
+			continue
+		}
+		if b < 0x20 || b == 0x7f || b == ';' {
+			return false
+		}
+	}
+	return true
 }
 
 func trimCookieArgNoCopy(src []byte, skipQuotes bool) []byte {

--- a/cookie.go
+++ b/cookie.go
@@ -669,15 +669,16 @@ func validCookieValue(value []byte) bool {
 //
 // Unlike validCookieValue it permits '"' and '\', which are legal path
 // characters accepted by SetPath and net/http's Cookie.String. It rejects the
-// ';' attribute separator and control bytes, matching net/http's cookie path
-// rules. CR and LF are tolerated here because initHeaderValueBytes strips them
-// afterwards, the same as for the primary cookie value.
+// ';' attribute separator and every byte outside 0x20-0x7e, matching
+// net/http's validCookiePathByte. CR and LF are tolerated here because
+// initHeaderValueBytes strips them afterwards, the same as for the primary
+// cookie value.
 func validCookiePathValue(value []byte) bool {
 	for _, b := range value {
 		if b == '\r' || b == '\n' {
 			continue
 		}
-		if b < 0x20 || b == 0x7f || b == ';' {
+		if b < 0x20 || b >= 0x7f || b == ';' {
 			return false
 		}
 	}

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -188,6 +188,68 @@ func TestCookieParseRejectsInvalidQuotedValue(t *testing.T) {
 	}
 }
 
+func TestCookieParseRejectsInvalidAttributeValue(t *testing.T) {
+	t.Parallel()
+
+	// Domain values reject the quoted-string bytes (" ; \), the same set as the
+	// primary cookie value, since none are legal in a hostname.
+	domainCases := []string{
+		`sid=ok; Domain=victim.example"`,
+		`sid=ok; Domain=e"vil.example`,
+		`sid=ok; Domain=e\vil.example`,
+	}
+	for _, tc := range domainCases {
+		var c Cookie
+		if err := c.Parse(tc); err != ErrInvalidCookieValue {
+			t.Fatalf("unexpected error %v. Expecting %v. Cookie %q", err, ErrInvalidCookieValue, tc)
+		}
+		if len(c.Domain()) != 0 {
+			t.Fatalf("unexpected domain %q parsed from invalid cookie %q", c.Domain(), tc)
+		}
+	}
+
+	// Path values only reject the ';' separator and control bytes, matching
+	// net/http's path rules; '"' and '\' stay valid there.
+	pathCases := []string{
+		"sid=ok; Path=/a\x01b",
+		"sid=ok; Path=/a\x7fb",
+	}
+	for _, tc := range pathCases {
+		var c Cookie
+		if err := c.Parse(tc); err != ErrInvalidCookieValue {
+			t.Fatalf("unexpected error %v. Expecting %v. Cookie %q", err, ErrInvalidCookieValue, tc)
+		}
+		if len(c.Path()) != 0 {
+			t.Fatalf("unexpected path %q parsed from invalid cookie %q", c.Path(), tc)
+		}
+	}
+
+	// A backslash in Path is accepted and round-trips, matching SetPath.
+	var rt Cookie
+	rt.SetKey("sid")
+	rt.SetValue("ok")
+	rt.SetPath(`/a\b`)
+	var parsed Cookie
+	if err := parsed.ParseBytes(rt.Cookie()); err != nil {
+		t.Fatalf("unexpected error %v round-tripping a backslash path", err)
+	}
+	if string(parsed.Path()) != `/a\b` {
+		t.Fatalf("unexpected path %q, expecting %q", parsed.Path(), `/a\b`)
+	}
+
+	// A balanced quoted attribute is unquoted during the trim pass and stays valid.
+	var c Cookie
+	if err := c.Parse(`sid=ok; Domain="trusted.example"; Path="/app"`); err != nil {
+		t.Fatalf("unexpected error %v for balanced quoted attributes", err)
+	}
+	if string(c.Domain()) != "trusted.example" {
+		t.Fatalf("unexpected domain %q", c.Domain())
+	}
+	if string(c.Path()) != "/app" {
+		t.Fatalf("unexpected path %q", c.Path())
+	}
+}
+
 func TestCookieValueWithEqualAndSpaceChars(t *testing.T) {
 	t.Parallel()
 

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -208,11 +208,14 @@ func TestCookieParseRejectsInvalidAttributeValue(t *testing.T) {
 		}
 	}
 
-	// Path values only reject the ';' separator and control bytes, matching
-	// net/http's path rules; '"' and '\' stay valid there.
+	// Path values reject the ';' separator and every byte outside 0x20-0x7e,
+	// matching net/http's validCookiePathByte; '"' and '\' stay valid there.
 	pathCases := []string{
 		"sid=ok; Path=/a\x01b",
 		"sid=ok; Path=/a\x7fb",
+		"sid=ok; Path=/a\x80b",
+		"sid=ok; Path=/caf\xc3\xa9",
+		"sid=ok; Path=/a\xffb",
 	}
 	for _, tc := range pathCases {
 		var c Cookie


### PR DESCRIPTION
Repro: `c.Parse("sid=ok; Domain=victim.example\"; Path=/")` returns nil and `c.String()` re-emits the stray `"` inside `domain=`.
Cause: `Cookie.ParseBytes` runs `validCookieValue` on the primary value and on request-cookie values, but the `Domain`/`Path` attribute branches store the raw value via `initHeaderValueBytes` (CR/LF only), and it is round-tripped verbatim by `AppendBytes`. A `"` or `\` in an attribute therefore survives a parse then re-serialise (proxy/forwarding) at exactly the spot the primary value is now rejected.
Fix: apply `validCookieValue` to the `Domain` and `Path` branches, matching the primary-value guard added in `eb82c9a` and the existing `Max-Age`/`Expires` attribute error handling. Balanced quoted attributes are still unquoted during the trim pass and stay valid.
