### PR TITLE
test: normalize Go test names

### DIFF
--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -205,27 +205,27 @@ func TestParseHTTPDateCompatibility(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name      string
-		value     string
-		hasError  bool
-		roundTrip bool
+		name              string
+		value             string
+		expectedError     bool
+		expectedRoundTrip bool
 	}{
-		{name: "gmt-fast-path", value: "Tue, 10 Nov 2009 23:00:00 GMT", roundTrip: true},
-		{name: "epoch", value: "Thu, 01 Jan 1970 00:00:00 GMT", roundTrip: true},
-		{name: "year-boundary", value: "Fri, 31 Dec 1999 23:59:59 GMT", roundTrip: true},
-		{name: "leap-year", value: "Mon, 29 Feb 2016 12:34:56 GMT", roundTrip: true},
-		{name: "utc-fallback", value: "Tue, 10 Nov 2009 23:00:00 UTC", hasError: true},
+		{name: "gmt-fast-path", value: "Tue, 10 Nov 2009 23:00:00 GMT", expectedRoundTrip: true},
+		{name: "epoch", value: "Thu, 01 Jan 1970 00:00:00 GMT", expectedRoundTrip: true},
+		{name: "year-boundary", value: "Fri, 31 Dec 1999 23:59:59 GMT", expectedRoundTrip: true},
+		{name: "leap-year", value: "Mon, 29 Feb 2016 12:34:56 GMT", expectedRoundTrip: true},
+		{name: "utc-fallback", value: "Tue, 10 Nov 2009 23:00:00 UTC", expectedError: true},
 		{name: "mixedcase-weekday-month", value: "tUe, 10 nOv 2009 23:00:00 GMT"},
-		{name: "day-zero", value: "Tue, 00 Nov 2009 23:00:00 GMT", hasError: true},
-		{name: "invalid-day", value: "Tue, 31 Feb 2009 23:00:00 GMT", hasError: true},
-		{name: "invalid-weekday", value: "Xxx, 10 Nov 2009 23:00:00 GMT", hasError: true},
-		{name: "invalid-month", value: "Tue, 10 Foo 2009 23:00:00 GMT", hasError: true},
-		{name: "invalid-hour", value: "Tue, 10 Nov 2009 24:00:00 GMT", hasError: true},
-		{name: "invalid-minute", value: "Tue, 10 Nov 2009 23:60:00 GMT", hasError: true},
-		{name: "invalid-second", value: "Tue, 10 Nov 2009 23:00:60 GMT", hasError: true},
-		{name: "invalid-separator", value: "Tue 10 Nov 2009 23:00:00 GMT", hasError: true},
-		{name: "invalid-time-separator", value: "Tue, 10 Nov 2009 23-00-00 GMT", hasError: true},
-		{name: "non-leap-year", value: "Tue, 29 Feb 2019 23:00:00 GMT", hasError: true},
+		{name: "day-zero", value: "Tue, 00 Nov 2009 23:00:00 GMT", expectedError: true},
+		{name: "invalid-day", value: "Tue, 31 Feb 2009 23:00:00 GMT", expectedError: true},
+		{name: "invalid-weekday", value: "Xxx, 10 Nov 2009 23:00:00 GMT", expectedError: true},
+		{name: "invalid-month", value: "Tue, 10 Foo 2009 23:00:00 GMT", expectedError: true},
+		{name: "invalid-hour", value: "Tue, 10 Nov 2009 24:00:00 GMT", expectedError: true},
+		{name: "invalid-minute", value: "Tue, 10 Nov 2009 23:60:00 GMT", expectedError: true},
+		{name: "invalid-second", value: "Tue, 10 Nov 2009 23:00:60 GMT", expectedError: true},
+		{name: "invalid-separator", value: "Tue 10 Nov 2009 23:00:00 GMT", expectedError: true},
+		{name: "invalid-time-separator", value: "Tue, 10 Nov 2009 23-00-00 GMT", expectedError: true},
+		{name: "non-leap-year", value: "Tue, 29 Feb 2019 23:00:00 GMT", expectedError: true},
 	}
 
 	for _, tc := range testCases {
@@ -238,8 +238,8 @@ func TestParseHTTPDateCompatibility(t *testing.T) {
 			if (gotErr != nil) != (wantErr != nil) {
 				t.Fatalf("error mismatch for %q: ParseHTTPDate err=%v, ParseInLocation err=%v", tc.value, gotErr, wantErr)
 			}
-			if tc.hasError != (gotErr != nil) {
-				t.Fatalf("unexpected error state for %q: gotErr=%v, expectedError=%v", tc.value, gotErr, tc.hasError)
+			if tc.expectedError != (gotErr != nil) {
+				t.Fatalf("unexpected error state for %q: gotErr=%v, expectedError=%v", tc.value, gotErr, tc.expectedError)
 			}
 			if gotErr != nil {
 				return
@@ -247,7 +247,7 @@ func TestParseHTTPDateCompatibility(t *testing.T) {
 			if !got.Equal(want) {
 				t.Fatalf("parsed time mismatch for %q: got=%v want=%v", tc.value, got, want)
 			}
-			if tc.roundTrip && got.Format(time.RFC1123) != tc.value {
+			if tc.expectedRoundTrip && got.Format(time.RFC1123) != tc.value {
 				t.Fatalf("unexpected formatted date %q. Expecting %q", got.Format(time.RFC1123), tc.value)
 			}
 		})

--- a/client_test.go
+++ b/client_test.go
@@ -2061,9 +2061,9 @@ func TestClientRedirectMethodSwitch(t *testing.T) {
 	}
 
 	tests := []struct {
-		method   string
-		path     string
-		wantBody string
+		method       string
+		path         string
+		expectedBody string
 	}{
 		// 303 must always switch a POST to a body-less GET.
 		{MethodPost, "/redirect-303", "GET|"},
@@ -2093,8 +2093,8 @@ func TestClientRedirectMethodSwitch(t *testing.T) {
 			if got := resp.StatusCode(); got != StatusOK {
 				t.Fatalf("unexpected status code: %d", got)
 			}
-			if got := string(resp.Body()); got != tc.wantBody {
-				t.Fatalf("unexpected landing echo %q. Expecting %q", got, tc.wantBody)
+			if got := string(resp.Body()); got != tc.expectedBody {
+				t.Fatalf("unexpected landing echo %q. Expecting %q", got, tc.expectedBody)
 			}
 		})
 	}
@@ -2164,49 +2164,49 @@ func TestShouldStripSensitiveHeadersOnRedirect(t *testing.T) {
 		name        string
 		initialURL  string
 		redirectURL string
-		want        bool
+		expected    bool
 	}{
 		{
 			name:        "same host keeps headers",
 			initialURL:  "http://example.com/foo",
 			redirectURL: "http://example.com/bar",
-			want:        false,
+			expected:    false,
 		},
 		{
 			name:        "subdomain keeps headers",
 			initialURL:  "http://example.com/foo",
 			redirectURL: "https://sub.example.com:8443/bar",
-			want:        false,
+			expected:    false,
 		},
 		{
 			name:        "same host different port keeps headers",
 			initialURL:  "http://example.com/foo",
 			redirectURL: "http://example.com:8080/bar",
-			want:        false,
+			expected:    false,
 		},
 		{
 			name:        "http upgrade keeps headers",
 			initialURL:  "http://example.com/foo",
 			redirectURL: "https://example.com/bar",
-			want:        false,
+			expected:    false,
 		},
 		{
 			name:        "https downgrade keeps headers",
 			initialURL:  "https://example.com/foo",
 			redirectURL: "http://example.com/bar",
-			want:        false,
+			expected:    false,
 		},
 		{
 			name:        "parent domain strips when initial host is subdomain",
 			initialURL:  "http://sub.example.com/foo",
 			redirectURL: "http://example.com/bar",
-			want:        true,
+			expected:    true,
 		},
 		{
 			name:        "unrelated host strips headers",
 			initialURL:  "http://example.com/foo",
 			redirectURL: "http://example.net/bar",
-			want:        true,
+			expected:    true,
 		},
 	}
 
@@ -2217,8 +2217,8 @@ func TestShouldStripSensitiveHeadersOnRedirect(t *testing.T) {
 			var redirectURI URI
 			redirectURI.Update(tc.redirectURL)
 
-			if got := shouldStripSensitiveHeadersOnRedirect(initialHost, redirectURI.Host()); got != tc.want {
-				t.Fatalf("unexpected redirect stripping decision: got %v, want %v", got, tc.want)
+			if got := shouldStripSensitiveHeadersOnRedirect(initialHost, redirectURI.Host()); got != tc.expected {
+				t.Fatalf("unexpected redirect stripping decision: got %v, expected %v", got, tc.expected)
 			}
 		})
 	}
@@ -2498,7 +2498,7 @@ func (r *readTimeoutConn) SetWriteDeadline(d time.Time) error {
 	return nil
 }
 
-func TestClientNonIdempotentRetry_BodyStream(t *testing.T) {
+func TestClientNonIdempotentRetryBodyStream(t *testing.T) {
 	t.Parallel()
 
 	dialsCount := 0
@@ -3721,7 +3721,7 @@ func TestHostClientErrConnPoolStrategyNotImpl(t *testing.T) {
 	}
 }
 
-func Test_AddMissingPort(t *testing.T) {
+func TestAddMissingPort(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
@@ -3729,55 +3729,55 @@ func Test_AddMissingPort(t *testing.T) {
 		isTLS bool
 	}
 	tests := []struct {
-		name string
-		want string
-		args args
+		name     string
+		expected string
+		args     args
 	}{
 		{
-			args: args{addr: "127.1", isTLS: false}, // 127.1 is a short form of 127.0.0.1
-			want: "127.1:80",
+			args:     args{addr: "127.1", isTLS: false}, // 127.1 is a short form of 127.0.0.1
+			expected: "127.1:80",
 		},
 		{
-			args: args{addr: "127.0.0.1", isTLS: false},
-			want: "127.0.0.1:80",
+			args:     args{addr: "127.0.0.1", isTLS: false},
+			expected: "127.0.0.1:80",
 		},
 		{
-			args: args{addr: "127.0.0.1", isTLS: true},
-			want: "127.0.0.1:443",
+			args:     args{addr: "127.0.0.1", isTLS: true},
+			expected: "127.0.0.1:443",
 		},
 		{
-			args: args{addr: "[::1]", isTLS: false},
-			want: "[::1]:80",
+			args:     args{addr: "[::1]", isTLS: false},
+			expected: "[::1]:80",
 		},
 		{
-			args: args{addr: "::1", isTLS: false},
-			want: "::1", // keep as is
+			args:     args{addr: "::1", isTLS: false},
+			expected: "::1", // keep as is
 		},
 		{
-			args: args{addr: "[::1]", isTLS: true},
-			want: "[::1]:443",
+			args:     args{addr: "[::1]", isTLS: true},
+			expected: "[::1]:443",
 		},
 		{
-			args: args{addr: "127.0.0.1:8080", isTLS: false},
-			want: "127.0.0.1:8080",
+			args:     args{addr: "127.0.0.1:8080", isTLS: false},
+			expected: "127.0.0.1:8080",
 		},
 		{
-			args: args{addr: "127.0.0.1:8443", isTLS: true},
-			want: "127.0.0.1:8443",
+			args:     args{addr: "127.0.0.1:8443", isTLS: true},
+			expected: "127.0.0.1:8443",
 		},
 		{
-			args: args{addr: "[::1]:8080", isTLS: false},
-			want: "[::1]:8080",
+			args:     args{addr: "[::1]:8080", isTLS: false},
+			expected: "[::1]:8080",
 		},
 		{
-			args: args{addr: "[::1]:8443", isTLS: true},
-			want: "[::1]:8443",
+			args:     args{addr: "[::1]:8443", isTLS: true},
+			expected: "[::1]:8443",
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			if got := AddMissingPort(tt.args.addr, tt.args.isTLS); got != tt.want {
-				t.Errorf("AddMissingPort() = %v, want %v", got, tt.want)
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := AddMissingPort(tt.args.addr, tt.args.isTLS); got != tt.expected {
+				t.Errorf("AddMissingPort() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -3855,52 +3855,52 @@ func TestClientTransportEx(t *testing.T) {
 	}
 }
 
-func Test_getRedirectURL(t *testing.T) {
+func TestGetRedirectURL(t *testing.T) {
 	type args struct {
 		baseURL                string
 		location               []byte
 		disablePathNormalizing bool
 	}
 	tests := []struct {
-		name string
-		want string
-		args args
+		name     string
+		expected string
+		args     args
 	}{
 		{
-			name: "Path normalizing enabled, no special characters in path",
+			name: "path normalizing enabled, no special characters in path",
 			args: args{
 				baseURL:                "http://foo.example.com/abc",
 				location:               []byte("http://bar.example.com/def"),
 				disablePathNormalizing: false,
 			},
-			want: "http://bar.example.com/def",
+			expected: "http://bar.example.com/def",
 		},
 		{
-			name: "Path normalizing enabled, special characters in path",
+			name: "path normalizing enabled, special characters in path",
 			args: args{
 				baseURL:                "http://foo.example.com/abc/*/def",
 				location:               []byte("http://bar.example.com/123/*/456"),
 				disablePathNormalizing: false,
 			},
-			want: "http://bar.example.com/123/%2A/456",
+			expected: "http://bar.example.com/123/%2A/456",
 		},
 		{
-			name: "Path normalizing disabled, no special characters in path",
+			name: "path normalizing disabled, no special characters in path",
 			args: args{
 				baseURL:                "http://foo.example.com/abc",
 				location:               []byte("http://bar.example.com/def"),
 				disablePathNormalizing: true,
 			},
-			want: "http://bar.example.com/def",
+			expected: "http://bar.example.com/def",
 		},
 		{
-			name: "Path normalizing disabled, special characters in path",
+			name: "path normalizing disabled, special characters in path",
 			args: args{
 				baseURL:                "http://foo.example.com/abc/*/def",
 				location:               []byte("http://bar.example.com/123/*/456"),
 				disablePathNormalizing: true,
 			},
-			want: "http://bar.example.com/123/*/456",
+			expected: "http://bar.example.com/123/*/456",
 		},
 	}
 	for _, tt := range tests {
@@ -3908,8 +3908,8 @@ func Test_getRedirectURL(t *testing.T) {
 			redirectURI := AcquireURI()
 			got := getRedirectURL(tt.args.baseURL, tt.args.location, tt.args.disablePathNormalizing, redirectURI)
 			ReleaseURI(redirectURI)
-			if got != tt.want {
-				t.Errorf("getRedirectURL() = %v, want %v", got, tt.want)
+			if got != tt.expected {
+				t.Errorf("getRedirectURL() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}
@@ -3929,7 +3929,7 @@ func TestDialTimeout(t *testing.T) {
 		shouldFailFast bool
 	}{
 		{
-			name: "Client should fail after a millisecond due to request timeout",
+			name: "client should fail after a millisecond due to request timeout",
 			client: &Client{
 				// should be ignored due to DialTimeout
 				Dial: func(addr string) (net.Conn, error) {
@@ -3946,7 +3946,7 @@ func TestDialTimeout(t *testing.T) {
 			shouldFailFast: true,
 		},
 		{
-			name: "Client should fail after a second due to no DialTimeout set",
+			name: "client should fail after a second due to no dial timeout set",
 			client: &Client{
 				Dial: func(addr string) (net.Conn, error) {
 					time.Sleep(time.Second)
@@ -3957,7 +3957,7 @@ func TestDialTimeout(t *testing.T) {
 			shouldFailFast: false,
 		},
 		{
-			name: "HostClient should fail after a millisecond due to request timeout",
+			name: "host client should fail after a millisecond due to request timeout",
 			client: &HostClient{
 				// should be ignored due to DialTimeout
 				Dial: func(addr string) (net.Conn, error) {
@@ -3974,7 +3974,7 @@ func TestDialTimeout(t *testing.T) {
 			shouldFailFast: true,
 		},
 		{
-			name: "HostClient should fail after a second due to no DialTimeout set",
+			name: "host client should fail after a second due to no dial timeout set",
 			client: &HostClient{
 				Dial: func(addr string) (net.Conn, error) {
 					time.Sleep(time.Second)
@@ -4255,11 +4255,11 @@ func (t *TransportMock) RoundTrip(hc *HostClient, req *Request, resp *Response) 
 	return t.wrapperFunc(hc, req, resp)
 }
 
-func TestClient_RetryIfErrUpstream(t *testing.T) {
+func TestClientRetryIfErrUpstream(t *testing.T) {
 	t.Parallel()
 	upstreamErr := errors.New("upstream error")
 
-	t.Run("upstream_known", func(t *testing.T) {
+	t.Run("upstream known", func(t *testing.T) {
 		retryIfErrCalled := false
 		c := &Client{
 			Transport: &TransportMock{
@@ -4291,7 +4291,7 @@ func TestClient_RetryIfErrUpstream(t *testing.T) {
 		}
 	})
 
-	t.Run("no_upstream", func(t *testing.T) {
+	t.Run("no upstream", func(t *testing.T) {
 		retryIfErrCalled := false
 		c := &Client{
 			Transport: &TransportMock{

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -23,39 +23,39 @@ func TestCookieSettersSanitizeNewLines(t *testing.T) {
 		set  func(c *Cookie)
 	}{
 		{
-			name: "SetKey",
+			name: "set key",
 			set:  func(c *Cookie) { c.SetKey("sid\r\nSet-Cookie: admin=1") },
 		},
 		{
-			name: "SetKeyBytes",
+			name: "set key bytes",
 			set:  func(c *Cookie) { c.SetKeyBytes([]byte("sid\r\nSet-Cookie: admin=1")) },
 		},
 		{
-			name: "SetValue",
+			name: "set value",
 			set:  func(c *Cookie) { c.SetValue("abc\r\nSet-Cookie: admin=1") },
 		},
 		{
-			name: "SetValueBytes",
+			name: "set value bytes",
 			set:  func(c *Cookie) { c.SetValueBytes([]byte("abc\r\nSet-Cookie: admin=1")) },
 		},
 		{
-			name: "SetDomain",
+			name: "set domain",
 			set:  func(c *Cookie) { c.SetDomain("example.com\r\nSet-Cookie: admin=1") },
 		},
 		{
-			name: "SetDomainBytes",
+			name: "set domain bytes",
 			set:  func(c *Cookie) { c.SetDomainBytes([]byte("example.com\r\nSet-Cookie: admin=1")) },
 		},
 		{
-			name: "SetPath",
+			name: "set path",
 			set:  func(c *Cookie) { c.SetPath("/account\r\nSet-Cookie: admin=1") },
 		},
 		{
-			name: "SetPathBytes",
+			name: "set path bytes",
 			set:  func(c *Cookie) { c.SetPathBytes([]byte("/account\r\nSet-Cookie: admin=1")) },
 		},
 		{
-			name: "SetPathEncodedNewLine",
+			name: "set path encoded new line",
 			set:  func(c *Cookie) { c.SetPath("/account%0d%0aSet-Cookie:%20admin=1") },
 		},
 	}
@@ -87,42 +87,42 @@ func TestCookieSettersSanitizeSemicolons(t *testing.T) {
 		get  func(c *Cookie) []byte
 	}{
 		{
-			name: "SetKey",
+			name: "set key",
 			set:  func(c *Cookie) { c.SetKey("sid; Secure") },
 			get:  (*Cookie).Key,
 		},
 		{
-			name: "SetKeyBytes",
+			name: "set key bytes",
 			set:  func(c *Cookie) { c.SetKeyBytes([]byte("sid; Secure")) },
 			get:  (*Cookie).Key,
 		},
 		{
-			name: "SetValue",
+			name: "set value",
 			set:  func(c *Cookie) { c.SetValue("abc; Secure") },
 			get:  (*Cookie).Value,
 		},
 		{
-			name: "SetValueBytes",
+			name: "set value bytes",
 			set:  func(c *Cookie) { c.SetValueBytes([]byte("abc; Secure")) },
 			get:  (*Cookie).Value,
 		},
 		{
-			name: "SetDomain",
+			name: "set domain",
 			set:  func(c *Cookie) { c.SetDomain("example.com; Secure") },
 			get:  (*Cookie).Domain,
 		},
 		{
-			name: "SetDomainBytes",
+			name: "set domain bytes",
 			set:  func(c *Cookie) { c.SetDomainBytes([]byte("example.com; Secure")) },
 			get:  (*Cookie).Domain,
 		},
 		{
-			name: "SetPath",
+			name: "set path",
 			set:  func(c *Cookie) { c.SetPath("/account; Secure") },
 			get:  (*Cookie).Path,
 		},
 		{
-			name: "SetPathBytes",
+			name: "set path bytes",
 			set:  func(c *Cookie) { c.SetPathBytes([]byte("/account; Secure")) },
 			get:  (*Cookie).Path,
 		},

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -515,7 +515,7 @@ func TestHijackFlush(t *testing.T) {
 	}
 }
 
-func TestResourceRecyclingUnderLoad_OneEndpoint(t *testing.T) {
+func TestResourceRecyclingUnderLoadOneEndpoint(t *testing.T) {
 	t.Parallel()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -550,7 +550,7 @@ func TestResourceRecyclingUnderLoad_OneEndpoint(t *testing.T) {
 	}
 }
 
-func TestResourceRecyclingUnderLoad_MultipleEndpoints(t *testing.T) {
+func TestResourceRecyclingUnderLoadMultipleEndpoints(t *testing.T) {
 	t.Parallel()
 
 	handlers := []struct {

--- a/fasthttpproxy/dialer_test.go
+++ b/fasthttpproxy/dialer_test.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/net/http/httpproxy"
 )
 
-func TestDialer_GetDialFunc(t *testing.T) {
+func TestDialerGetDialFunc(t *testing.T) {
 	counts := make([]atomic.Int64, 4)
 	proxyListenPorts := []string{"8001", "8002", "8003", "8004"}
 	lns := startProxyServer(t, proxyListenPorts, counts)
@@ -34,12 +34,12 @@ func TestDialer_GetDialFunc(t *testing.T) {
 		useEnv bool
 	}
 	tests := []struct {
-		name           string
-		fields         fields
-		args           args
-		wantCounts     []int64
-		dialAddr       string
-		wantErrMessage string
+		name               string
+		fields             fields
+		args               args
+		expectedCounts     []int64
+		dialAddr           string
+		expectedErrMessage string
 	}{
 		{
 			name: "proxy information comes from the configuration. dial https host",
@@ -51,8 +51,8 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts: []int64{0, 1, 0, 0},
-			dialAddr:   "github.io:443",
+			expectedCounts: []int64{0, 1, 0, 0},
+			dialAddr:       "github.io:443",
 		},
 		{
 			name: "proxy information comes from the configuration. dial http host",
@@ -64,11 +64,11 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts: []int64{1, 0, 0, 0},
-			dialAddr:   "github.io:80",
+			expectedCounts: []int64{1, 0, 0, 0},
+			dialAddr:       "github.io:80",
 		},
 		{
-			name: "proxy information comes from the configuration. dial http host matched with noProxy",
+			name: "proxy information comes from the configuration. dial http host matched with no proxy",
 			fields: fields{
 				httpProxy:  "http://127.0.0.1:" + proxyListenPorts[0],
 				httpsProxy: "http://127.0.0.1:" + proxyListenPorts[1],
@@ -77,11 +77,11 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts: []int64{0, 0, 0, 0},
-			dialAddr:   "github.com:80",
+			expectedCounts: []int64{0, 0, 0, 0},
+			dialAddr:       "github.com:80",
 		},
 		{
-			name: "proxy information comes from the configuration. dial https host matched with noProxy",
+			name: "proxy information comes from the configuration. dial https host matched with no proxy",
 			fields: fields{
 				httpProxy:  "http://127.0.0.1:" + proxyListenPorts[0],
 				httpsProxy: "http://127.0.0.1:" + proxyListenPorts[1],
@@ -90,8 +90,8 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts: []int64{0, 0, 0, 0},
-			dialAddr:   "github.com:443",
+			expectedCounts: []int64{0, 0, 0, 0},
+			dialAddr:       "github.com:443",
 		},
 		{
 			name: "proxy information comes from the env. dial http host",
@@ -103,8 +103,8 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: true,
 			},
-			wantCounts: []int64{0, 0, 1, 0},
-			dialAddr:   "github.io:80",
+			expectedCounts: []int64{0, 0, 1, 0},
+			dialAddr:       "github.io:80",
 		},
 		{
 			name: "proxy information comes from the env. dial https host",
@@ -116,12 +116,12 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: true,
 			},
-			wantCounts: []int64{0, 0, 0, 1},
-			dialAddr:   "github.io:443",
+			expectedCounts: []int64{0, 0, 0, 1},
+			dialAddr:       "github.io:443",
 		},
 
 		{
-			name: "proxy information comes from the env. dial http host matched with noProxy",
+			name: "proxy information comes from the env. dial http host matched with no proxy",
 			fields: fields{
 				httpProxy:  "http://127.0.0.1:" + proxyListenPorts[0],
 				httpsProxy: "http://127.0.0.1:" + proxyListenPorts[1],
@@ -130,11 +130,11 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: true,
 			},
-			wantCounts: []int64{0, 0, 0, 0},
-			dialAddr:   "github.com:80",
+			expectedCounts: []int64{0, 0, 0, 0},
+			dialAddr:       "github.com:80",
 		},
 		{
-			name: "proxy information comes from the env. dial https host matched with noProxy",
+			name: "proxy information comes from the env. dial https host matched with no proxy",
 			fields: fields{
 				httpProxy:  "http://127.0.0.1:" + proxyListenPorts[0],
 				httpsProxy: "http://127.0.0.1:" + proxyListenPorts[1],
@@ -143,11 +143,11 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: true,
 			},
-			wantCounts: []int64{0, 0, 0, 0},
-			dialAddr:   "github.com:443",
+			expectedCounts: []int64{0, 0, 0, 0},
+			dialAddr:       "github.com:443",
 		},
 		{
-			name: "proxy information comes from the configuration and httpProxy same with httpsProxy. dial http host",
+			name: "proxy information comes from the configuration and http proxy same with https proxy. dial http host",
 			fields: fields{
 				httpProxy:  "http://127.0.0.1:" + proxyListenPorts[0],
 				httpsProxy: "http://127.0.0.1:" + proxyListenPorts[0],
@@ -156,11 +156,11 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts: []int64{1, 0, 0, 0},
-			dialAddr:   "github.io:80",
+			expectedCounts: []int64{1, 0, 0, 0},
+			dialAddr:       "github.io:80",
 		},
 		{
-			name: "proxy information comes from the configuration and httpProxy same with httpsProxy. dial https host",
+			name: "proxy information comes from the configuration and http proxy same with https proxy. dial https host",
 			fields: fields{
 				httpProxy:  "http://127.0.0.1:" + proxyListenPorts[0],
 				httpsProxy: "http://127.0.0.1:" + proxyListenPorts[0],
@@ -169,11 +169,11 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts: []int64{1, 0, 0, 0},
-			dialAddr:   "github.io:443",
+			expectedCounts: []int64{1, 0, 0, 0},
+			dialAddr:       "github.io:443",
 		},
 		{
-			name: "proxy information comes from the configuration and httpProxy same with httpsProxy. dial http host matched with noProxy",
+			name: "proxy information comes from the configuration and http proxy same with https proxy. dial http host matched with no proxy",
 			fields: fields{
 				httpProxy:  "http://127.0.0.1:" + proxyListenPorts[0],
 				httpsProxy: "http://127.0.0.1:" + proxyListenPorts[0],
@@ -182,11 +182,11 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts: []int64{0, 0, 0, 0},
-			dialAddr:   "github.com:80",
+			expectedCounts: []int64{0, 0, 0, 0},
+			dialAddr:       "github.com:80",
 		},
 		{
-			name: "proxy information comes from the configuration and httpProxy same with httpsProxy. dial https host matched with noProxy",
+			name: "proxy information comes from the configuration and http proxy same with https proxy. dial https host matched with no proxy",
 			fields: fields{
 				httpProxy:  "http://127.0.0.1:" + proxyListenPorts[0],
 				httpsProxy: "http://127.0.0.1:" + proxyListenPorts[0],
@@ -195,8 +195,8 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts: []int64{0, 0, 0, 0},
-			dialAddr:   "github.com:443",
+			expectedCounts: []int64{0, 0, 0, 0},
+			dialAddr:       "github.com:443",
 		},
 		{
 			name: "return an error for unsupported proxy protocols.",
@@ -207,22 +207,22 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			args: args{
 				useEnv: false,
 			},
-			wantCounts:     []int64{0, 0, 0, 0},
-			dialAddr:       "github.io:80",
-			wantErrMessage: "proxy: unknown scheme: socket6",
+			expectedCounts:     []int64{0, 0, 0, 0},
+			dialAddr:           "github.io:80",
+			expectedErrMessage: "proxy: unknown scheme: socket6",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := getDialer(tt.fields.httpProxy, tt.fields.httpsProxy, tt.fields.noProxy)
 			dialFunc, err := d.GetDialFunc(tt.args.useEnv)
-			if (err != nil) != (tt.wantErrMessage != "") {
-				t.Fatalf("GetDialFunc() error = %v, wantErr %v", err, tt.wantErrMessage)
+			if (err != nil) != (tt.expectedErrMessage != "") {
+				t.Fatalf("GetDialFunc() error = %v, expectedErr %v", err, tt.expectedErrMessage)
 				return
 			}
-			if tt.wantErrMessage != "" {
-				if err.Error() != tt.wantErrMessage {
-					t.Fatalf("want error message: %s, got: %s", err.Error(), tt.wantErrMessage)
+			if tt.expectedErrMessage != "" {
+				if err.Error() != tt.expectedErrMessage {
+					t.Fatalf("expected error message: %s, got: %s", tt.expectedErrMessage, err.Error())
 				}
 				return
 			}
@@ -230,8 +230,8 @@ func TestDialer_GetDialFunc(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !countsEqual(getCounts(counts), tt.wantCounts) {
-				t.Errorf("GetDialFunc() counts = %v, want %v", getCounts(counts), tt.wantCounts)
+			if !countsEqual(getCounts(counts), tt.expectedCounts) {
+				t.Errorf("GetDialFunc() counts = %v, expected %v", getCounts(counts), tt.expectedCounts)
 			}
 		})
 		for i := range counts {

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -937,7 +937,7 @@ func TestDirFSServeFileDirectoryRedirect(t *testing.T) {
 func TestFSFSGenerateIndexOsDirFS(t *testing.T) {
 	t.Parallel()
 
-	t.Run("dirFS", func(t *testing.T) {
+	t.Run("dir fs", func(t *testing.T) {
 		t.Parallel()
 
 		fs := &FS{
@@ -976,7 +976,7 @@ func TestFSFSGenerateIndexOsDirFS(t *testing.T) {
 		}
 	})
 
-	t.Run("embedFS", func(t *testing.T) {
+	t.Run("embed fs", func(t *testing.T) {
 		t.Parallel()
 
 		fs := &FS{
@@ -1114,31 +1114,31 @@ func TestHasDotDotPathSegment(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		path string
-		want bool
+		path     string
+		expected bool
 	}{
-		{path: "", want: false},
-		{path: ".", want: false},
-		{path: "..", want: true},
-		{path: "../secret.txt", want: true},
-		{path: "/../secret.txt", want: true},
-		{path: "nested/../info", want: true},
-		{path: "nested/..", want: true},
-		{path: "nested/..hidden/info", want: false},
-		{path: "nested..", want: false},
-		{path: "/index.html", want: false},
+		{path: "", expected: false},
+		{path: ".", expected: false},
+		{path: "..", expected: true},
+		{path: "../secret.txt", expected: true},
+		{path: "/../secret.txt", expected: true},
+		{path: "nested/../info", expected: true},
+		{path: "nested/..", expected: true},
+		{path: "nested/..hidden/info", expected: false},
+		{path: "nested..", expected: false},
+		{path: "/index.html", expected: false},
 	}
 
 	if filepath.Separator == '\\' {
 		testCases = append(testCases,
 			struct {
-				path string
-				want bool
-			}{path: `..\secret.txt`, want: true},
+				path     string
+				expected bool
+			}{path: `..\secret.txt`, expected: true},
 			struct {
-				path string
-				want bool
-			}{path: `nested\..\info`, want: true},
+				path     string
+				expected bool
+			}{path: `nested\..\info`, expected: true},
 		)
 	}
 
@@ -1146,8 +1146,8 @@ func TestHasDotDotPathSegment(t *testing.T) {
 		t.Run(tc.path, func(t *testing.T) {
 			t.Parallel()
 
-			if got := hasDotDotPathSegment([]byte(tc.path)); got != tc.want {
-				t.Fatalf("unexpected result for %q: got %v want %v", tc.path, got, tc.want)
+			if got := hasDotDotPathSegment([]byte(tc.path)); got != tc.expected {
+				t.Fatalf("unexpected result for %q: got %v expected %v", tc.path, got, tc.expected)
 			}
 		})
 	}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -150,7 +150,7 @@ func FuzzURIParse(f *testing.F) {
 	})
 }
 
-func FuzzTestHeaderScanner(f *testing.F) {
+func FuzzHeaderScanner(f *testing.F) {
 	f.Add([]byte("Host: example.com\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip, deflate\r\n\r\n"))
 	f.Add([]byte("Content-Type: application/x-www-form-urlencoded\r\nContent-Length: 27\r\n\r\nname=John+Doe&age=30"))
 	f.Add([]byte(" 3 :\r\n\r\n"))

--- a/header_test.go
+++ b/header_test.go
@@ -62,29 +62,29 @@ func TestResponseHeaderFirstLineSettersSanitizeNewlines(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name          string
-		set           func(*ResponseHeader)
-		value         func(*ResponseHeader) []byte
-		wantValue     string
-		wantFirstLine string
+		name              string
+		set               func(*ResponseHeader)
+		value             func(*ResponseHeader) []byte
+		expectedValue     string
+		expectedFirstLine string
 	}{
 		{
-			name: "SetStatusMessage",
+			name: "set status message",
 			set: func(h *ResponseHeader) {
 				h.SetStatusMessage([]byte("OK\r\nInjected-Status: true"))
 			},
-			value:         func(h *ResponseHeader) []byte { return h.StatusMessage() },
-			wantValue:     "OK  Injected-Status: true",
-			wantFirstLine: "HTTP/1.1 200 OK  Injected-Status: true",
+			value:             func(h *ResponseHeader) []byte { return h.StatusMessage() },
+			expectedValue:     "OK  Injected-Status: true",
+			expectedFirstLine: "HTTP/1.1 200 OK  Injected-Status: true",
 		},
 		{
-			name: "SetProtocol",
+			name: "set protocol",
 			set: func(h *ResponseHeader) {
 				h.SetProtocol([]byte("HTTP/1.1\r\nInjected-Protocol: true"))
 			},
-			value:         func(h *ResponseHeader) []byte { return h.Protocol() },
-			wantValue:     "HTTP/1.1  Injected-Protocol: true",
-			wantFirstLine: "HTTP/1.1  Injected-Protocol: true 200 OK",
+			value:             func(h *ResponseHeader) []byte { return h.Protocol() },
+			expectedValue:     "HTTP/1.1  Injected-Protocol: true",
+			expectedFirstLine: "HTTP/1.1  Injected-Protocol: true 200 OK",
 		},
 	}
 
@@ -98,16 +98,16 @@ func TestResponseHeaderFirstLineSettersSanitizeNewlines(t *testing.T) {
 
 			tc.set(&h)
 
-			if got := string(tc.value(&h)); got != tc.wantValue {
-				t.Fatalf("unexpected sanitized value: %q. Expected %q", got, tc.wantValue)
+			if got := string(tc.value(&h)); got != tc.expectedValue {
+				t.Fatalf("unexpected sanitized value: %q. Expected %q", got, tc.expectedValue)
 			}
 
 			firstLine, _, ok := bytes.Cut(h.Header(), strCRLF)
 			if !ok {
 				t.Fatalf("missing response first line terminator in header %q", h.Header())
 			}
-			if got := string(firstLine); got != tc.wantFirstLine {
-				t.Fatalf("unexpected response first line: %q. Expected %q", got, tc.wantFirstLine)
+			if got := string(firstLine); got != tc.expectedFirstLine {
+				t.Fatalf("unexpected response first line: %q. Expected %q", got, tc.expectedFirstLine)
 			}
 			if bytes.Contains(h.Header(), []byte("\r\nInjected-")) {
 				t.Fatalf("unexpected injected header line in %q", h.Header())
@@ -125,10 +125,10 @@ func TestResponseHeaderKeySettersSanitizeNewlines(t *testing.T) {
 		name string
 		set  func(*ResponseHeader)
 	}{
-		{name: "Set", set: func(h *ResponseHeader) { h.Set(badKey, "bar") }},
-		{name: "Add", set: func(h *ResponseHeader) { h.Add(badKey, "bar") }},
-		{name: "SetBytesV", set: func(h *ResponseHeader) { h.SetBytesV(badKey, []byte("bar")) }},
-		{name: "SetBytesKV", set: func(h *ResponseHeader) { h.SetBytesKV([]byte(badKey), []byte("bar")) }},
+		{name: "set", set: func(h *ResponseHeader) { h.Set(badKey, "bar") }},
+		{name: "add", set: func(h *ResponseHeader) { h.Add(badKey, "bar") }},
+		{name: "set bytes v", set: func(h *ResponseHeader) { h.SetBytesV(badKey, []byte("bar")) }},
+		{name: "set bytes kv", set: func(h *ResponseHeader) { h.SetBytesKV([]byte(badKey), []byte("bar")) }},
 	}
 
 	for _, tc := range testCases {
@@ -156,10 +156,10 @@ func TestRequestHeaderKeySettersSanitizeNewlines(t *testing.T) {
 		name string
 		set  func(*RequestHeader)
 	}{
-		{name: "Set", set: func(h *RequestHeader) { h.Set(badKey, "bar") }},
-		{name: "Add", set: func(h *RequestHeader) { h.Add(badKey, "bar") }},
-		{name: "SetBytesV", set: func(h *RequestHeader) { h.SetBytesV(badKey, []byte("bar")) }},
-		{name: "SetBytesKV", set: func(h *RequestHeader) { h.SetBytesKV([]byte(badKey), []byte("bar")) }},
+		{name: "set", set: func(h *RequestHeader) { h.Set(badKey, "bar") }},
+		{name: "add", set: func(h *RequestHeader) { h.Add(badKey, "bar") }},
+		{name: "set bytes v", set: func(h *RequestHeader) { h.SetBytesV(badKey, []byte("bar")) }},
+		{name: "set bytes kv", set: func(h *RequestHeader) { h.SetBytesKV([]byte(badKey), []byte("bar")) }},
 	}
 
 	for _, tc := range testCases {
@@ -2216,7 +2216,7 @@ func TestRequestHeaderAddTrailerRejectsInvalidNames(t *testing.T) {
 func TestHeaderAddTrailerTrimsOWS(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ResponseHeader", func(t *testing.T) {
+	t.Run("response header", func(t *testing.T) {
 		t.Parallel()
 
 		var h ResponseHeader
@@ -2228,7 +2228,7 @@ func TestHeaderAddTrailerTrimsOWS(t *testing.T) {
 		}
 	})
 
-	t.Run("RequestHeader", func(t *testing.T) {
+	t.Run("request header", func(t *testing.T) {
 		t.Parallel()
 
 		var h RequestHeader
@@ -2251,23 +2251,23 @@ func TestTrailerSecurityVulnerabilityFix(t *testing.T) {
 		header      string
 		description string
 	}{
-		{"Content-Type", "Content-Type", "off-by-one fix: exactly 'Content-Type' should be blocked"},
-		{"Cookie", "Cookie", "session hijacking prevention"},
-		{"Set-Cookie", "Set-Cookie", "session hijacking prevention"},
-		{"Location", "Location", "redirect attack prevention"},
-		{"X-Forwarded-For", "X-Forwarded-For", "IP spoofing prevention"},
-		{"X-Forwarded-Host", "X-Forwarded-Host", "IP spoofing prevention"},
-		{"X-Forwarded-Proto", "X-Forwarded-Proto", "IP spoofing prevention"},
-		{"X-Real-IP", "X-Real-IP", "IP spoofing prevention"},
-		{"X-Real-Ip", "X-Real-Ip", "IP spoofing prevention (case insensitive)"},
-		{"Authorization", "Authorization", "auth bypass prevention"},
-		{"Host", "Host", "host header attack prevention"},
-		{"Connection", "Connection", "connection control prevention"},
+		{"content-type", "Content-Type", "off-by-one fix: exactly 'Content-Type' should be blocked"},
+		{"cookie", "Cookie", "session hijacking prevention"},
+		{"set-cookie", "Set-Cookie", "session hijacking prevention"},
+		{"location", "Location", "redirect attack prevention"},
+		{"x-forwarded-for", "X-Forwarded-For", "IP spoofing prevention"},
+		{"x-forwarded-host", "X-Forwarded-Host", "IP spoofing prevention"},
+		{"x-forwarded-proto", "X-Forwarded-Proto", "IP spoofing prevention"},
+		{"x-real-ip", "X-Real-IP", "IP spoofing prevention"},
+		{"x-real-ip case insensitive", "X-Real-Ip", "IP spoofing prevention (case insensitive)"},
+		{"authorization", "Authorization", "auth bypass prevention"},
+		{"host", "Host", "host header attack prevention"},
+		{"connection", "Connection", "connection control prevention"},
 	}
 
 	// Test RequestHeader AddTrailer blocking dangerous headers.
 	for _, tc := range dangerousHeaders {
-		t.Run("RequestHeader_"+tc.name, func(t *testing.T) {
+		t.Run("request header/"+tc.name, func(t *testing.T) {
 			var h RequestHeader
 			err := h.AddTrailer(tc.header)
 			if !errors.Is(err, ErrBadTrailer) {
@@ -2283,7 +2283,7 @@ func TestTrailerSecurityVulnerabilityFix(t *testing.T) {
 
 	// Test ResponseHeader AddTrailer blocking dangerous headers
 	for _, tc := range dangerousHeaders {
-		t.Run("ResponseHeader_"+tc.name, func(t *testing.T) {
+		t.Run("response header/"+tc.name, func(t *testing.T) {
 			var h ResponseHeader
 			err := h.AddTrailer(tc.header)
 
@@ -2302,7 +2302,7 @@ func TestTrailerSecurityVulnerabilityFix(t *testing.T) {
 	safeHeaders := []string{"Foo", "X-Custom-Safe", "My-App-Trailer", "Debug-Info"}
 
 	for _, header := range safeHeaders {
-		t.Run("Safe_RequestHeader_"+header, func(t *testing.T) {
+		t.Run("safe request header/"+strings.ToLower(header), func(t *testing.T) {
 			var h RequestHeader
 			err := h.AddTrailer(header)
 			if err != nil {
@@ -2315,7 +2315,7 @@ func TestTrailerSecurityVulnerabilityFix(t *testing.T) {
 			}
 		})
 
-		t.Run("Safe_ResponseHeader_"+header, func(t *testing.T) {
+		t.Run("safe response header/"+strings.ToLower(header), func(t *testing.T) {
 			var h ResponseHeader
 			err := h.AddTrailer(header)
 			if err != nil {
@@ -2345,7 +2345,7 @@ func TestTrailerParsingSecurityFix(t *testing.T) {
 	}
 
 	for i, trailer := range dangerousTrailers {
-		t.Run("Request_"+strconv.Itoa(i), func(t *testing.T) {
+		t.Run("request/"+strconv.Itoa(i), func(t *testing.T) {
 			var h RequestHeader
 			r := bytes.NewBufferString(trailer)
 			br := bufio.NewReader(r)
@@ -2361,7 +2361,7 @@ func TestTrailerParsingSecurityFix(t *testing.T) {
 			}
 		})
 
-		t.Run("Response_"+strconv.Itoa(i), func(t *testing.T) {
+		t.Run("response/"+strconv.Itoa(i), func(t *testing.T) {
 			var h ResponseHeader
 			r := bytes.NewBufferString(trailer)
 			br := bufio.NewReader(r)
@@ -2386,7 +2386,7 @@ func TestTrailerParsingSecurityFix(t *testing.T) {
 	}
 
 	for i, trailer := range safeTrailers {
-		t.Run("Safe_Request_"+strconv.Itoa(i), func(t *testing.T) {
+		t.Run("safe request/"+strconv.Itoa(i), func(t *testing.T) {
 			var h RequestHeader
 			r := bytes.NewBufferString(trailer)
 			br := bufio.NewReader(r)
@@ -2397,7 +2397,7 @@ func TestTrailerParsingSecurityFix(t *testing.T) {
 			}
 		})
 
-		t.Run("Safe_Response_"+strconv.Itoa(i), func(t *testing.T) {
+		t.Run("safe response/"+strconv.Itoa(i), func(t *testing.T) {
 			var h ResponseHeader
 			r := bytes.NewBufferString(trailer)
 			br := bufio.NewReader(r)
@@ -2424,7 +2424,7 @@ func TestTrailerValueControlBytesRejected(t *testing.T) {
 	}
 
 	for i, trailer := range badTrailers {
-		t.Run("Request_"+strconv.Itoa(i), func(t *testing.T) {
+		t.Run("request/"+strconv.Itoa(i), func(t *testing.T) {
 			var h RequestHeader
 			err := h.ReadTrailer(bufio.NewReader(bytes.NewBufferString(trailer)))
 			if err == nil {
@@ -2435,7 +2435,7 @@ func TestTrailerValueControlBytesRejected(t *testing.T) {
 			}
 		})
 
-		t.Run("Response_"+strconv.Itoa(i), func(t *testing.T) {
+		t.Run("response/"+strconv.Itoa(i), func(t *testing.T) {
 			var h ResponseHeader
 			err := h.ReadTrailer(bufio.NewReader(bytes.NewBufferString(trailer)))
 			if err == nil {
@@ -2805,68 +2805,68 @@ func TestRequestHeaderFirstLineSettersSanitizeNewlines(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name          string
-		set           func(*RequestHeader)
-		value         func(*RequestHeader) []byte
-		wantValue     string
-		wantFirstLine string
-		wantNoHTTP11  bool
+		name              string
+		set               func(*RequestHeader)
+		value             func(*RequestHeader) []byte
+		expectedValue     string
+		expectedFirstLine string
+		expectedNoHTTP11  bool
 	}{
 		{
-			name: "SetMethod",
+			name: "set method",
 			set: func(h *RequestHeader) {
 				h.SetMethod("GET\r\nInjected-Method: true")
 			},
-			value:         func(h *RequestHeader) []byte { return h.Method() },
-			wantValue:     "GET  Injected-Method: true",
-			wantFirstLine: "GET  Injected-Method: true / HTTP/1.1",
+			value:             func(h *RequestHeader) []byte { return h.Method() },
+			expectedValue:     "GET  Injected-Method: true",
+			expectedFirstLine: "GET  Injected-Method: true / HTTP/1.1",
 		},
 		{
-			name: "SetMethodBytes",
+			name: "set method bytes",
 			set: func(h *RequestHeader) {
 				h.SetMethodBytes([]byte("GET\r\nInjected-Method-Bytes: true"))
 			},
-			value:         func(h *RequestHeader) []byte { return h.Method() },
-			wantValue:     "GET  Injected-Method-Bytes: true",
-			wantFirstLine: "GET  Injected-Method-Bytes: true / HTTP/1.1",
+			value:             func(h *RequestHeader) []byte { return h.Method() },
+			expectedValue:     "GET  Injected-Method-Bytes: true",
+			expectedFirstLine: "GET  Injected-Method-Bytes: true / HTTP/1.1",
 		},
 		{
-			name: "SetRequestURI",
+			name: "set request uri",
 			set: func(h *RequestHeader) {
 				h.SetRequestURI("/\r\nInjected-URI: true")
 			},
-			value:         func(h *RequestHeader) []byte { return h.RequestURI() },
-			wantValue:     "/  Injected-URI: true",
-			wantFirstLine: "GET /  Injected-URI: true HTTP/1.1",
+			value:             func(h *RequestHeader) []byte { return h.RequestURI() },
+			expectedValue:     "/  Injected-URI: true",
+			expectedFirstLine: "GET /  Injected-URI: true HTTP/1.1",
 		},
 		{
-			name: "SetRequestURIBytes",
+			name: "set request uri bytes",
 			set: func(h *RequestHeader) {
 				h.SetRequestURIBytes([]byte("/\r\nInjected-URI-Bytes: true"))
 			},
-			value:         func(h *RequestHeader) []byte { return h.RequestURI() },
-			wantValue:     "/  Injected-URI-Bytes: true",
-			wantFirstLine: "GET /  Injected-URI-Bytes: true HTTP/1.1",
+			value:             func(h *RequestHeader) []byte { return h.RequestURI() },
+			expectedValue:     "/  Injected-URI-Bytes: true",
+			expectedFirstLine: "GET /  Injected-URI-Bytes: true HTTP/1.1",
 		},
 		{
-			name: "SetProtocol",
+			name: "set protocol",
 			set: func(h *RequestHeader) {
 				h.SetProtocol("HTTP/1.1\r\nInjected-Protocol: true")
 			},
-			value:         func(h *RequestHeader) []byte { return h.Protocol() },
-			wantValue:     "HTTP/1.1  Injected-Protocol: true",
-			wantFirstLine: "GET / HTTP/1.1  Injected-Protocol: true",
-			wantNoHTTP11:  true,
+			value:             func(h *RequestHeader) []byte { return h.Protocol() },
+			expectedValue:     "HTTP/1.1  Injected-Protocol: true",
+			expectedFirstLine: "GET / HTTP/1.1  Injected-Protocol: true",
+			expectedNoHTTP11:  true,
 		},
 		{
-			name: "SetProtocolBytes",
+			name: "set protocol bytes",
 			set: func(h *RequestHeader) {
 				h.SetProtocolBytes([]byte("HTTP/1.1\r\nInjected-Protocol-Bytes: true"))
 			},
-			value:         func(h *RequestHeader) []byte { return h.Protocol() },
-			wantValue:     "HTTP/1.1  Injected-Protocol-Bytes: true",
-			wantFirstLine: "GET / HTTP/1.1  Injected-Protocol-Bytes: true",
-			wantNoHTTP11:  true,
+			value:             func(h *RequestHeader) []byte { return h.Protocol() },
+			expectedValue:     "HTTP/1.1  Injected-Protocol-Bytes: true",
+			expectedFirstLine: "GET / HTTP/1.1  Injected-Protocol-Bytes: true",
+			expectedNoHTTP11:  true,
 		},
 	}
 
@@ -2882,22 +2882,22 @@ func TestRequestHeaderFirstLineSettersSanitizeNewlines(t *testing.T) {
 
 			tc.set(&h)
 
-			if got := string(tc.value(&h)); got != tc.wantValue {
-				t.Fatalf("unexpected sanitized value: %q. Expected %q", got, tc.wantValue)
+			if got := string(tc.value(&h)); got != tc.expectedValue {
+				t.Fatalf("unexpected sanitized value: %q. Expected %q", got, tc.expectedValue)
 			}
 
 			firstLine, _, ok := bytes.Cut(h.Header(), strCRLF)
 			if !ok {
 				t.Fatalf("missing request first line terminator in header %q", h.Header())
 			}
-			if got := string(firstLine); got != tc.wantFirstLine {
-				t.Fatalf("unexpected request first line: %q. Expected %q", got, tc.wantFirstLine)
+			if got := string(firstLine); got != tc.expectedFirstLine {
+				t.Fatalf("unexpected request first line: %q. Expected %q", got, tc.expectedFirstLine)
 			}
 			if bytes.Contains(h.Header(), []byte("\r\nInjected-")) {
 				t.Fatalf("unexpected injected header line in %q", h.Header())
 			}
-			if h.noHTTP11 != tc.wantNoHTTP11 {
-				t.Fatalf("unexpected noHTTP11 flag: %v. Expected %v", h.noHTTP11, tc.wantNoHTTP11)
+			if h.noHTTP11 != tc.expectedNoHTTP11 {
+				t.Fatalf("unexpected noHTTP11 flag: %v. Expected %v", h.noHTTP11, tc.expectedNoHTTP11)
 			}
 		})
 	}
@@ -3765,7 +3765,7 @@ func verifyTrailer(t *testing.T, h peeker, expectedTrailers map[string]string) {
 	}
 }
 
-func TestRequestHeader_PeekAll(t *testing.T) {
+func TestRequestHeaderPeekAll(t *testing.T) {
 	t.Parallel()
 	h := &RequestHeader{}
 	h.Add(HeaderConnection, "keep-alive")
@@ -3804,7 +3804,7 @@ func expectRequestHeaderAll(t *testing.T, h *RequestHeader, key string, expected
 	}
 }
 
-func TestResponseHeader_PeekAll(t *testing.T) {
+func TestResponseHeaderPeekAll(t *testing.T) {
 	t.Parallel()
 
 	h := &ResponseHeader{}
@@ -3840,7 +3840,7 @@ func expectResponseHeaderAll(t *testing.T, h *ResponseHeader, key string, expect
 	}
 }
 
-func TestRequestHeader_Keys(t *testing.T) {
+func TestRequestHeaderKeys(t *testing.T) {
 	h := &RequestHeader{}
 	h.Add(HeaderConnection, "keep-alive")
 	h.Add("Content-Type", "aaa")
@@ -3881,7 +3881,7 @@ func TestResponseHeaderCopyToCopiesTrailerKeys(t *testing.T) {
 	}
 }
 
-func TestResponseHeader_Keys(t *testing.T) {
+func TestResponseHeaderKeys(t *testing.T) {
 	h := &ResponseHeader{}
 	h.Add(HeaderConnection, "keep-alive")
 	h.Add("Content-Type", "aaa")

--- a/http_test.go
+++ b/http_test.go
@@ -502,7 +502,7 @@ func TestBodyDecodeWithLimitTooLarge(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		t.Run(testCase.name+"_request_uncompressed", func(t *testing.T) {
+		t.Run(testCase.name+"/request uncompressed", func(t *testing.T) {
 			var req Request
 			req.Header.SetContentEncoding(testCase.encoding)
 			req.SetBodyRaw(testCase.encode(body))
@@ -512,7 +512,7 @@ func TestBodyDecodeWithLimitTooLarge(t *testing.T) {
 			}
 		})
 
-		t.Run(testCase.name+"_response_uncompressed", func(t *testing.T) {
+		t.Run(testCase.name+"/response uncompressed", func(t *testing.T) {
 			var resp Response
 			resp.Header.SetContentEncoding(testCase.encoding)
 			resp.SetBodyRaw(testCase.encode(body))
@@ -539,7 +539,7 @@ func TestRequestMultipartFormWithLimitGzip(t *testing.T) {
 	formBody := formBodyBuffer.Bytes()
 	gzippedBody := AppendGzipBytes(nil, formBody)
 
-	t.Run("buffered_too_large", func(t *testing.T) {
+	t.Run("buffered too large", func(t *testing.T) {
 		var req Request
 		req.Header.SetMultipartFormBoundary(boundary)
 		req.Header.SetContentEncoding("gzip")
@@ -551,7 +551,7 @@ func TestRequestMultipartFormWithLimitGzip(t *testing.T) {
 		}
 	})
 
-	t.Run("streamed_too_large", func(t *testing.T) {
+	t.Run("streamed too large", func(t *testing.T) {
 		var req Request
 		req.Header.SetMultipartFormBoundary(boundary)
 		req.Header.SetContentEncoding("gzip")
@@ -563,7 +563,7 @@ func TestRequestMultipartFormWithLimitGzip(t *testing.T) {
 		}
 	})
 
-	t.Run("buffered_success", func(t *testing.T) {
+	t.Run("buffered success", func(t *testing.T) {
 		var req Request
 		req.Header.SetMultipartFormBoundary(boundary)
 		req.Header.SetContentEncoding("gzip")
@@ -3736,10 +3736,10 @@ func TestRequestGetTimeOut(t *testing.T) {
 		timeout  time.Duration
 		expected time.Duration
 	}{
-		{"Timeout set to 0", 0, 0},
-		{"Timeout set to 5s", 5 * time.Second, 5 * time.Second},
-		{"Timeout set to 1m", 1 * time.Minute, 1 * time.Minute},
-		{"Timeout set to 500ms", 500 * time.Millisecond, 500 * time.Millisecond},
+		{"timeout set to 0", 0, 0},
+		{"timeout set to 5s", 5 * time.Second, 5 * time.Second},
+		{"timeout set to 1m", 1 * time.Minute, 1 * time.Minute},
+		{"timeout set to 500ms", 500 * time.Millisecond, 500 * time.Millisecond},
 	}
 
 	for _, test := range tests {

--- a/prefork/prefork_test.go
+++ b/prefork/prefork_test.go
@@ -51,7 +51,7 @@ func noopChildProducer(t testing.TB) (func(files []*os.File) (*exec.Cmd, error),
 	return produce, cleanup
 }
 
-func Test_IsChild(t *testing.T) {
+func TestIsChild(t *testing.T) {
 	// This test cannot run in parallel — IsChild() reads a process-global env var.
 	if IsChild() {
 		t.Fatal("test starts as child unexpectedly")
@@ -63,7 +63,7 @@ func Test_IsChild(t *testing.T) {
 	}
 }
 
-func Test_setTCPListenerFiles(t *testing.T) {
+func TestSetTCPListenerFiles(t *testing.T) {
 	t.Parallel()
 
 	if runtime.GOOS == "windows" {
@@ -94,11 +94,11 @@ func Test_setTCPListenerFiles(t *testing.T) {
 	}
 }
 
-// Test_setTCPListenerFilesClosesListenerOnFileError verifies that
+// TestSetTCPListenerFilesClosesListenerOnFileError verifies that
 // setTCPListenerFiles closes the bound listener and leaves Prefork.files nil
 // when the duplicate-fd step fails. Injects the failure through tcpListenerFile
 // so no real socket is leaked.
-func Test_setTCPListenerFilesClosesListenerOnFileError(t *testing.T) {
+func TestSetTCPListenerFilesClosesListenerOnFileError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
@@ -128,10 +128,10 @@ func Test_setTCPListenerFilesClosesListenerOnFileError(t *testing.T) {
 	}
 }
 
-// Test_childEnv verifies the child environment carries exactly one canonical
+// TestChildEnv verifies the child environment carries exactly one canonical
 // prefork marker: a pre-existing marker (any value) is stripped and replaced,
 // while an unrelated variable that merely shares the prefix is left untouched.
-func Test_childEnv(t *testing.T) {
+func TestChildEnv(t *testing.T) {
 	t.Setenv(preforkChildEnvVariable, "stale")
 	t.Setenv(preforkChildEnvVariable+"_SIBLING", "keep")
 
@@ -160,10 +160,10 @@ func Test_childEnv(t *testing.T) {
 	}
 }
 
-// Test_preforkClosesParentListenerFiles asserts the master closes the duped
+// TestPreforkClosesParentListenerFiles asserts the master closes the duped
 // listener fd it passed to the child after prefork() returns, so the parent
 // process does not leak file descriptors across restarts.
-func Test_preforkClosesParentListenerFiles(t *testing.T) {
+func TestPreforkClosesParentListenerFiles(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
@@ -206,10 +206,10 @@ func Test_preforkClosesParentListenerFiles(t *testing.T) {
 	}
 }
 
-// Test_ListenAndServe_Stub_ChildPath drives the child branch of all three
+// TestListenAndServeStubChildPath drives the child branch of all three
 // ListenAndServe* entry points using a stubbed Serve function. It replaces the
 // previous trio of near-identical tests that only validated field assignment.
-func Test_ListenAndServe_Stub_ChildPath(t *testing.T) {
+func TestListenAndServeStubChildPath(t *testing.T) {
 	// child env mutation precludes t.Parallel.
 	t.Setenv(preforkChildEnvVariable, preforkChildEnvValue)
 
@@ -227,28 +227,28 @@ func Test_ListenAndServe_Stub_ChildPath(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		run  func(t *testing.T, p *Prefork, addr string) error
-		want call
+		name     string
+		run      func(t *testing.T, p *Prefork, addr string) error
+		expected call
 	}{
 		{
-			name: "ListenAndServe",
-			run:  func(_ *testing.T, p *Prefork, addr string) error { return p.ListenAndServe(addr) },
-			want: call{listener: true},
+			name:     "listen and serve",
+			run:      func(_ *testing.T, p *Prefork, addr string) error { return p.ListenAndServe(addr) },
+			expected: call{listener: true},
 		},
 		{
-			name: "ListenAndServeTLS",
+			name: "listen and serve tls",
 			run: func(_ *testing.T, p *Prefork, addr string) error {
 				return p.ListenAndServeTLS(addr, "./key", "./cert")
 			},
-			want: call{listener: true, certFile: "./cert", keyFile: "./key"},
+			expected: call{listener: true, certFile: "./cert", keyFile: "./key"},
 		},
 		{
-			name: "ListenAndServeTLSEmbed",
+			name: "listen and serve tls embed",
 			run: func(_ *testing.T, p *Prefork, addr string) error {
 				return p.ListenAndServeTLSEmbed(addr, []byte("certPEM"), []byte("keyPEM"))
 			},
-			want: call{listener: true, certData: "certPEM", keyData: "keyPEM"},
+			expected: call{listener: true, certData: "certPEM", keyData: "keyPEM"},
 		},
 	}
 
@@ -284,28 +284,28 @@ func Test_ListenAndServe_Stub_ChildPath(t *testing.T) {
 				}
 			})
 
-			if got != tc.want {
-				t.Errorf("%s call = %+v, want %+v", tc.name, got, tc.want)
+			if got != tc.expected {
+				t.Errorf("%s call = %+v, expected %+v", tc.name, got, tc.expected)
 			}
 		})
 	}
 }
 
-func Test_doCommand_CommandProducerErrors(t *testing.T) {
+func TestDoCommandCommandProducerErrors(t *testing.T) {
 	t.Parallel()
 
 	producerErr := errors.New("boom")
 	tests := []struct {
-		name    string
-		produce func(files []*os.File) (*exec.Cmd, error)
-		wantErr error
+		name        string
+		produce     func(files []*os.File) (*exec.Cmd, error)
+		expectedErr error
 	}{
 		{
 			name: "producer returns error",
 			produce: func([]*os.File) (*exec.Cmd, error) {
 				return nil, producerErr
 			},
-			wantErr: producerErr,
+			expectedErr: producerErr,
 		},
 		{
 			name: "producer returns nil cmd",
@@ -313,14 +313,14 @@ func Test_doCommand_CommandProducerErrors(t *testing.T) {
 			produce: func([]*os.File) (*exec.Cmd, error) {
 				return nil, nil
 			},
-			wantErr: ErrCommandProducerNilCmd,
+			expectedErr: ErrCommandProducerNilCmd,
 		},
 		{
 			name: "producer returns unstarted cmd",
 			produce: func([]*os.File) (*exec.Cmd, error) {
 				return &exec.Cmd{}, nil
 			},
-			wantErr: ErrCommandProducerNotStarted,
+			expectedErr: ErrCommandProducerNotStarted,
 		},
 	}
 
@@ -335,8 +335,8 @@ func Test_doCommand_CommandProducerErrors(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
-			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
-				t.Errorf("err = %v, want errors.Is %v", err, tc.wantErr)
+			if tc.expectedErr != nil && !errors.Is(err, tc.expectedErr) {
+				t.Errorf("err = %v, expected errors.Is %v", err, tc.expectedErr)
 			}
 		})
 	}
@@ -354,9 +354,9 @@ func (l *testLogger) Printf(format string, args ...any) {
 	l.mu.Unlock()
 }
 
-// Test_Prefork_Lifecycle drives prefork() to ErrOverRecovery via
+// TestPreforkLifecycle drives prefork() to ErrOverRecovery via
 // short-lived no-op children and asserts the callback ordering / arguments.
-func Test_Prefork_Lifecycle(t *testing.T) {
+func TestPreforkLifecycle(t *testing.T) {
 	prev := runtime.GOMAXPROCS(2)
 	t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
 
@@ -471,7 +471,7 @@ func Test_Prefork_Lifecycle(t *testing.T) {
 	}
 }
 
-func Test_Prefork_InitialChildSpawnError(t *testing.T) {
+func TestPreforkInitialChildSpawnError(t *testing.T) {
 	prev := runtime.GOMAXPROCS(2)
 	t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
 
@@ -501,7 +501,7 @@ func Test_Prefork_InitialChildSpawnError(t *testing.T) {
 	}
 }
 
-func Test_Prefork_OnMasterReadyError(t *testing.T) {
+func TestPreforkOnMasterReadyError(t *testing.T) {
 	prev := runtime.GOMAXPROCS(2)
 	t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
 
@@ -525,7 +525,7 @@ func Test_Prefork_OnMasterReadyError(t *testing.T) {
 	}
 }
 
-func Test_Prefork_RecoveredChildSpawnError(t *testing.T) {
+func TestPreforkRecoveredChildSpawnError(t *testing.T) {
 	prev := runtime.GOMAXPROCS(2)
 	t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
 
@@ -564,8 +564,8 @@ func Test_Prefork_RecoveredChildSpawnError(t *testing.T) {
 	}
 }
 
-// Test_Prefork_RecoverInterval verifies the optional backoff delays the respawn.
-func Test_Prefork_RecoverInterval(t *testing.T) {
+// TestPreforkRecoverInterval verifies the optional backoff delays the respawn.
+func TestPreforkRecoverInterval(t *testing.T) {
 	prev := runtime.GOMAXPROCS(2)
 	t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
 
@@ -594,13 +594,13 @@ func Test_Prefork_RecoverInterval(t *testing.T) {
 	}
 }
 
-// Test_Prefork_ShutdownDoesNotBlockOnRecoverInterval guards against a child
+// TestPreforkShutdownDoesNotBlockOnRecoverInterval guards against a child
 // that already exited (and whose Wait goroutine is parked on the RecoverInterval
 // backoff) holding up shutdown. prefork() returns immediately via an
 // OnMasterReady error while the noop children are sitting in a long backoff;
 // shutdown must cancel the backoff and return promptly instead of waiting for
 // RecoverInterval or ShutdownGracePeriod to elapse.
-func Test_Prefork_ShutdownDoesNotBlockOnRecoverInterval(t *testing.T) {
+func TestPreforkShutdownDoesNotBlockOnRecoverInterval(t *testing.T) {
 	prev := runtime.GOMAXPROCS(2)
 	t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
 

--- a/server_test.go
+++ b/server_test.go
@@ -35,7 +35,7 @@ func (c *closerWithRequestCtx) Close() error {
 	return c.closeFunc(c.ctx)
 }
 
-func TestServerCRNLAfterPost_Pipeline(t *testing.T) {
+func TestServerCRNLAfterPostPipeline(t *testing.T) {
 	t.Parallel()
 
 	s := &Server{

--- a/userdata_test.go
+++ b/userdata_test.go
@@ -121,7 +121,7 @@ func TestUserDataSetAndRemove(t *testing.T) {
 	testUserDataGet(t, &u, []byte(longKey), "")
 }
 
-func TestUserData_GC(t *testing.T) {
+func TestUserDataGC(t *testing.T) {
 	t.Parallel()
 
 	var u userData


### PR DESCRIPTION
Fixes #2230 

```
% go test ./...
ok  	github.com/valyala/fasthttp	3.132s
?   	github.com/valyala/fasthttp/examples/client	[no test files]
?   	github.com/valyala/fasthttp/examples/fileserver	[no test files]
?   	github.com/valyala/fasthttp/examples/helloworldserver	[no test files]
?   	github.com/valyala/fasthttp/examples/host_client	[no test files]
?   	github.com/valyala/fasthttp/examples/letsencrypt	[no test files]
?   	github.com/valyala/fasthttp/examples/multidomain	[no test files]
ok  	github.com/valyala/fasthttp/expvarhandler	(cached)
ok  	github.com/valyala/fasthttp/fasthttpadaptor	5.223s
ok  	github.com/valyala/fasthttp/fasthttpproxy	0.823s
ok  	github.com/valyala/fasthttp/fasthttputil	(cached)
?   	github.com/valyala/fasthttp/pprofhandler	[no test files]
ok  	github.com/valyala/fasthttp/prefork	0.730s
ok  	github.com/valyala/fasthttp/reuseport	(cached)
ok  	github.com/valyala/fasthttp/stackless	(cached)
ok  	github.com/valyala/fasthttp/tcplisten	(cached)
```