### PR TITLE
avoid following a symlink when writing the FS compressed cache

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -1713,15 +1713,20 @@ func (h *fsHandler) compressFileNolock(
 
 	// Create temporary file, so concurrent goroutines don't use
 	// it until it is created.
-	tmpFilePath := compressedFilePath + ".tmp"
-	zf, err := os.Create(tmpFilePath)
+	//
+	// os.CreateTemp gives the file a random name and opens it with O_EXCL and
+	// 0600, so a symlink pre-planted at the otherwise predictable temp path
+	// can't be followed to truncate an arbitrary file, and the cache file
+	// isn't left group/world-readable.
+	zf, err := os.CreateTemp(filepath.Dir(compressedFilePath), filepath.Base(compressedFilePath)+".tmp-*")
 	if err != nil {
 		_ = f.Close()
 		if !errors.Is(err, fs.ErrPermission) {
-			return nil, fmt.Errorf("cannot create temporary file %q: %w", tmpFilePath, err)
+			return nil, fmt.Errorf("cannot create temporary file for %q: %w", compressedFilePath, err)
 		}
 		return nil, errNoCreatePermission
 	}
+	tmpFilePath := zf.Name()
 	switch fileEncoding {
 	case "br":
 		zw := acquireStacklessBrotliWriter(zf, CompressDefaultCompression)

--- a/fs_test.go
+++ b/fs_test.go
@@ -813,6 +813,48 @@ func TestFSCompressSingleThreadSkipCache(t *testing.T) {
 	})
 }
 
+func TestFSCompressTmpFileSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks needs extra privileges on Windows")
+	}
+
+	dir := t.TempDir()
+	served := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(served, bytes.Repeat([]byte("compressible-data-"), 1000), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	victimDir := t.TempDir()
+	victim := filepath.Join(victimDir, "victim.txt")
+	const original = "victim-original-content"
+	if err := os.WriteFile(victim, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plant a symlink at the temp path the compressor is about to write.
+	if err := os.Symlink(victim, served+".fasthttp.gz.tmp"); err != nil {
+		t.Fatal(err)
+	}
+
+	h := (&FS{Root: dir, Compress: true}).NewRequestHandler()
+
+	var ctx RequestCtx
+	var req Request
+	req.SetRequestURI("/index.html")
+	req.Header.SetMethod(MethodGet)
+	req.Header.Set(HeaderAcceptEncoding, "gzip")
+	ctx.Init(&req, nil, nil)
+	h(&ctx)
+
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Fatalf("victim file was overwritten through the temp-path symlink: %q", got)
+	}
+}
+
 func TestFileLockRefCountUsesPathLock(t *testing.T) {
 	path := "/tmp/" + t.Name()
 	otherPath := path + "-other"


### PR DESCRIPTION
Repro: enable `FS.Compress`, then (as a local user with write access to the served directory) plant a symlink at `<file>.fasthttp.gz.tmp` pointing at any file the server process can write, and request `<file>` with `Accept-Encoding: gzip`. The target file is truncated and overwritten with the compressed output.
Cause: `compressFileNolock` writes the cache to the predictable path `compressedFilePath + ".tmp"` via `os.Create`, which follows the symlink (and also leaves the cache file `0666`).
Fix: create the temp file with `os.CreateTemp` in the same directory (random name, `O_EXCL`, `0600`), so a pre-planted symlink cannot be followed; the atomic rename to the final path is unchanged.