### PR TITLE
perf: reduce redundant scans and allocations in hot paths

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -656,7 +656,12 @@ func decodeCookieArg(dst, src []byte, skipQuotes bool) []byte {
 }
 
 func validCookieValue(value []byte) bool {
-	return !bytes.ContainsAny(value, "\";\\")
+	for _, c := range value {
+		if c == '"' || c == ';' || c == '\\' {
+			return false
+		}
+	}
+	return true
 }
 
 func trimCookieArgNoCopy(src []byte, skipQuotes bool) []byte {

--- a/header.go
+++ b/header.go
@@ -2380,13 +2380,13 @@ func updateServerDate() {
 }
 
 var (
-	serverDate     atomic.Value
+	serverDate     atomic.Pointer[[]byte]
 	serverDateOnce sync.Once // serverDateOnce.Do(updateServerDate)
 )
 
 func refreshServerDate() {
 	b := AppendHTTPDate(nil, time.Now())
-	serverDate.Store(b)
+	serverDate.Store(&b)
 }
 
 // Write writes response header to w.
@@ -2465,7 +2465,7 @@ func (h *ResponseHeader) AppendBytes(dst []byte) []byte {
 
 	if !h.noDefaultDate {
 		serverDateOnce.Do(updateServerDate)
-		dst = appendHeaderLine(dst, strDate, serverDate.Load().([]byte)) //nolint:forcetypeassert
+		dst = appendHeaderLine(dst, strDate, *serverDate.Load())
 	}
 
 	// Append Content-Type only for non-zero responses

--- a/server.go
+++ b/server.go
@@ -2331,6 +2331,8 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		return handler(c)
 	}
 
+	connTime := time.Now()
+
 	s.idleConnsMu.Lock()
 	if s.idleConns == nil {
 		s.idleConns = make(map[net.Conn]*atomic.Int64)
@@ -2348,13 +2350,12 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 	// Count the connection as Idle after 5 seconds.
 	// Same as net/http.Server:
 	// https://github.com/golang/go/blob/85d7bab91d9a3ed1f76842e4328973ea75efef54/src/net/http/server.go#L2834-L2836
-	idleConnTime.Store(time.Now().Add(time.Second * 5).Unix())
+	idleConnTime.Store(connTime.Add(time.Second * 5).Unix())
 	s.idleConnsMu.Unlock()
 
 	serverName := s.getServerName()
 	connRequestNum := uint64(0)
 	connID := nextConnID()
-	connTime := time.Now()
 	maxRequestBodySize := s.MaxRequestBodySize
 	if maxRequestBodySize <= 0 {
 		maxRequestBodySize = DefaultMaxRequestBodySize
@@ -2724,7 +2725,7 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 			ctx.Request.bodyStream = nil
 		}
 
-		idleConnTime.Store(time.Now().Unix())
+		idleConnTime.Store(ctx.time.Unix())
 		s.setState(c, StateIdle)
 		ctx.Request.Reset()
 		ctx.Response.Reset()

--- a/server.go
+++ b/server.go
@@ -3092,7 +3092,7 @@ func (s *Server) writeFastError(w io.Writer, statusCode int, msg string) {
 	date := ""
 	if !s.NoDefaultDate {
 		serverDateOnce.Do(updateServerDate)
-		date = fmt.Sprintf("Date: %s\r\n", serverDate.Load())
+		date = fmt.Sprintf("Date: %s\r\n", *serverDate.Load())
 	}
 
 	fmt.Fprintf(w, "Connection: close\r\n"+

--- a/server_test.go
+++ b/server_test.go
@@ -1119,6 +1119,10 @@ func TestServerWriteFastError(t *testing.T) {
 	if !resp.Header.ConnectionClose() {
 		t.Fatal("expecting 'Connection: close' response header")
 	}
+	date := string(resp.Header.Peek(HeaderDate))
+	if _, err := time.Parse(time.RFC1123, date); err != nil {
+		t.Fatalf("invalid date header %q: %v", date, err)
+	}
 }
 
 func TestServerTLS(t *testing.T) {

--- a/uri.go
+++ b/uri.go
@@ -446,7 +446,7 @@ func parseHost(host []byte) ([]byte, error) {
 			return append(host1, append(host2, host3...)...), nil
 		}
 	} else {
-		if bytes.ContainsAny(host, "[]") {
+		if bytes.IndexByte(host, '[') >= 0 || bytes.IndexByte(host, ']') >= 0 {
 			return nil, fmt.Errorf("invalid host %q", host)
 		}
 
@@ -641,8 +641,13 @@ func normalizePath(dst, src []byte) []byte {
 	}
 	dst = dst[:bSize]
 
-	// remove /./ parts
+	// No '.' means no "/./", "/../" or "/.." to remove.
 	b = dst
+	if bytes.IndexByte(b, '.') < 0 {
+		return b
+	}
+
+	// remove /./ parts
 	for {
 		n := bytes.Index(b, strSlashDotSlash)
 		if n < 0 {


### PR DESCRIPTION
Five small, independent hot-path optimizations. Each is a semantic no-op verified against the full test suite, `go test -race`, and the URI/Cookie fuzz targets; every speedup is measured with `benchstat` (n>=10, 1s benchtime) on the relevant benchmark.

## Changes

**`normalizePath` (`uri.go`)** - dot-free paths skip the `bytes.Index` passes for `/./`, `/../` and `/..` (3 on unix, 7 on windows) behind a single `IndexByte('.')` guard, since every one of those tokens contains a dot.

**`parseHost` (`uri.go`)** and **`validCookieValue` (`cookie.go`)** - `bytes.ContainsAny` rebuilds an ASCII set from its constant needle on every call; a direct `IndexByte` / byte scan is equivalent and skips that setup. Both run per request (host / cookie).

**`serverDate` (`header.go`)** - `atomic.Value` only ever held a `[]byte`, so every default response paid an interface unbox plus a type assertion. `atomic.Pointer[[]byte]` removes both (and a `//nolint`).

**serve loop (`server.go`)** - two redundant `time.Now()` calls dropped by reusing `connTime` (per connection) and `ctx.time` (per request); `closeIdleConns` only requires the stored timestamp to be non-zero and in the past.

## Performance

Apple M2 Pro, go1.24, `benchstat` n>=10 at 1s benchtime. Times are the median ns/op.

| Optimization | Benchmark | Before | After | Change |
| --- | --- | --- | --- | --- |
| `normalizePath` dot-skip | `URIParsePath` | 19.8 ns | 17.4 ns | **-12%** |
| `parseHost` byte scan | `URIParseHostname` | 14.41 ns | 14.17 ns | **-1.7%** |
| `validCookieValue` byte scan | `CookieParseMin` | 35.70 ns | 27.64 ns | **-22.6%** |
| | `CookieParseNoExpires` | 82.20 ns | 73.03 ns | **-11.2%** |
| | `CookieParseFull` | 135.5 ns | 126.7 ns | **-6.5%** |
| serve loop timestamp reuse | `ServerGet1ReqPerConn` | 1672 ns | 1579 ns | **-5.6%** |
| `serverDate` atomic.Pointer | `ResponseHeaderWrite` | 10.21 ns | 10.19 ns | neutral (cleanup) |

All changes above are statistically significant (p < 0.05) except the `serverDate` row, which is a readability/type cleanup with no measurable cost. `allocs/op` is unchanged (0) across every benchmark.

## Verification

- `go test ./...` - green
- `go test -race ./...` - green, no data races
- `FuzzURIParse` and `FuzzCookieParse` - 10s each, no crashers
