### PR TITLE
fix: preserve pre-set status code in NewFastHTTPHandler

### DIFF
--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -347,6 +347,11 @@ func (w *writer) Close() error {
 func (w *writer) status() int {
 	code := int(w.statusCode.Load())
 	if code == 0 {
+		// No WriteHeader was called; check if ctx already has a status code set
+		// by a caller before NewFastHTTPHandler ran.
+		if ctxCode := w.ctx.Response.StatusCode(); ctxCode != 0 {
+			return ctxCode
+		}
 		return http.StatusOK
 	}
 	return code

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -749,3 +749,55 @@ func TestWriterWriteRechecksStreamingReadyAfterLock(t *testing.T) {
 		t.Fatalf("timeout waiting for Write")
 	}
 }
+
+func TestNewFastHTTPHandlerPreservesPresetStatusCode(t *testing.T) {
+	t.Parallel()
+
+	// Verify that a status code set on ctx before calling NewFastHTTPHandler
+	// is preserved when the net/http handler does not call WriteHeader.
+	nethttpH := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+
+	fasthttpH := NewFastHTTPHandler(nethttpH)
+
+	var ctx fasthttp.RequestCtx
+	ctx.Request.SetRequestURI("/test")
+	// Pre-set a status code that should survive through the adaptor.
+	ctx.Response.SetStatusCode(fasthttp.StatusForbidden)
+
+	fasthttpH(&ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Fatalf("unexpected status code: %d. Expecting %d (pre-set code should be preserved)",
+			ctx.Response.StatusCode(), fasthttp.StatusForbidden)
+	}
+	if string(ctx.Response.Body()) != "ok" {
+		t.Fatalf("unexpected body: %q. Expecting %q", string(ctx.Response.Body()), "ok")
+	}
+}
+
+func TestNewFastHTTPHandlerPresetStatusCodeOverriddenByHandler(t *testing.T) {
+	t.Parallel()
+
+	// If the net/http handler explicitly calls WriteHeader, that should take precedence
+	// over any pre-set status code.
+	nethttpH := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("not found"))
+	})
+
+	fasthttpH := NewFastHTTPHandler(nethttpH)
+
+	var ctx fasthttp.RequestCtx
+	ctx.Request.SetRequestURI("/test")
+	ctx.Response.SetStatusCode(fasthttp.StatusForbidden)
+
+	fasthttpH(&ctx)
+
+	// WriteHeader(404) should override the pre-set 403.
+	if ctx.Response.StatusCode() != fasthttp.StatusNotFound {
+		t.Fatalf("unexpected status code: %d. Expecting %d (handler's WriteHeader should win)",
+			ctx.Response.StatusCode(), fasthttp.StatusNotFound)
+	}
+}

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -756,7 +756,7 @@ func TestNewFastHTTPHandlerPreservesPresetStatusCode(t *testing.T) {
 	// Verify that a status code set on ctx before calling NewFastHTTPHandler
 	// is preserved when the net/http handler does not call WriteHeader.
 	nethttpH := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	})
 
 	fasthttpH := NewFastHTTPHandler(nethttpH)
@@ -784,7 +784,7 @@ func TestNewFastHTTPHandlerPresetStatusCodeOverriddenByHandler(t *testing.T) {
 	// over any pre-set status code.
 	nethttpH := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("not found"))
+		_, _ = w.Write([]byte("not found"))
 	})
 
 	fasthttpH := NewFastHTTPHandler(nethttpH)


### PR DESCRIPTION
Closes #1754

**Problem:** When a caller sets `ctx.Response.SetStatusCode()` before the handler returned by `NewFastHTTPHandler` runs, the pre-set status code is silently overwritten with 200. This is because `writer.status()` defaults to `http.StatusOK` when `WriteHeader` was never called by the net/http handler, ignoring whatever was already on `ctx.Response`.

This breaks frameworks like go.fiber + Templ that set a status code before delegating to a net/http handler through the adaptor.

**Fix:** In `writer.status()`, fall back to `ctx.Response.StatusCode()` before defaulting to `http.StatusOK`. Explicit `WriteHeader` calls from the net/http handler still take precedence (via `CompareAndSwap(0, code)`).

```go
// Before
func (w *writer) status() int {
    code := int(w.statusCode.Load())
    if code == 0 {
        return http.StatusOK
    }
    return code
}

// After
func (w *writer) status() int {
    code := int(w.statusCode.Load())
    if code == 0 {
        if ctxCode := w.ctx.Response.StatusCode(); ctxCode != 0 {
            return ctxCode
        }
        return http.StatusOK
    }
    return code
}
```

**Tests:** Two new test cases:
- `TestNewFastHTTPHandlerPreservesPresetStatusCode`: pre-set 403, handler calls `w.Write()` only → response status is 403
- `TestNewFastHTTPHandlerPresetStatusCodeOverriddenByHandler`: pre-set 403, handler calls `WriteHeader(404)` → response status is 404 (handler wins)

All existing tests pass.

AI-assisted: written with the help of an AI coding agent (OpenClaw/GlM-5.1).