### PR TITLE
reject backslash '..' traversal in fs handler on windows

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -1302,12 +1302,15 @@ func (h *fsHandler) handleRequest(ctx *RequestCtx) {
 		ctx.Error("Are you a hacker?", StatusBadRequest)
 		return
 	}
-	if h.pathRewrite != nil {
-		// There is no need to check rewritten paths if path = ctx.Path(),
-		// since ctx.Path must normalize and sanitize the path.
-
+	// Rewritten paths bypass ctx.Path()'s normalization, so they must be
+	// checked for '..' segments here. On Windows every path is checked
+	// regardless: ctx.Path() normalization only treats '/' as a separator,
+	// so backslash traversal such as `\..\` and `\../` survives it and
+	// filepath.FromSlash later turns it into a real parent-directory jump
+	// (https://github.com/valyala/fasthttp/issues/1691).
+	if h.pathRewrite != nil || filepath.Separator == '\\' {
 		if hasDotDotPathSegment(path) {
-			ctx.Logger().Printf("cannot serve rewritten path with '..' path segment due to security reasons: %q", path)
+			ctx.Logger().Printf("cannot serve path with '..' path segment due to security reasons: %q", path)
 			ctx.Error("Internal Server Error", StatusInternalServerError)
 			return
 		}

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -1233,10 +1233,11 @@ func TestFSPathRewriteRejectsDotDotSegments(t *testing.T) {
 	}
 }
 
-// On Windows a '\' also separates path components, but ctx.Path()'s
-// normalization only collapses '/'-delimited '..' segments, so backslash
-// traversal such as `\..\` and `\../` reaches the file system handler even
-// without a PathRewrite. See https://github.com/valyala/fasthttp/issues/1691.
+// On Windows a '\' also separates path components. ctx.Path()'s normalization
+// rewrites some backslash '..' sequences (`\..\`, `/..\`), but a `\../` segment
+// survives it, so without the guard filepath.FromSlash later turns it into a
+// real parent-directory jump outside Root.
+// See https://github.com/valyala/fasthttp/issues/1691.
 func TestFSServeRejectsBackslashDotDotSegments(t *testing.T) {
 	if filepath.Separator != '\\' {
 		t.Skip("backslash path separator is Windows only")
@@ -1256,9 +1257,9 @@ func TestFSServeRejectsBackslashDotDotSegments(t *testing.T) {
 	}
 
 	requestURIs := []string{
-		`http://localhost/\..\secret.txt`,
 		`http://localhost/\../secret.txt`,
-		`http://localhost/public\..\..\secret.txt`,
+		`http://localhost/\../\../secret.txt`,
+		`http://localhost/public/\../\../secret.txt`,
 	}
 
 	stop := make(chan struct{})

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -1232,3 +1232,58 @@ func TestFSPathRewriteRejectsDotDotSegments(t *testing.T) {
 		})
 	}
 }
+
+// On Windows a '\' also separates path components, but ctx.Path()'s
+// normalization only collapses '/'-delimited '..' segments, so backslash
+// traversal such as `\..\` and `\../` reaches the file system handler even
+// without a PathRewrite. See https://github.com/valyala/fasthttp/issues/1691.
+func TestFSServeRejectsBackslashDotDotSegments(t *testing.T) {
+	if filepath.Separator != '\\' {
+		t.Skip("backslash path separator is Windows only")
+	}
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	publicDir := filepath.Join(tmpDir, "public")
+	if err := os.MkdirAll(publicDir, 0o755); err != nil {
+		t.Fatalf("cannot create public dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(publicDir, "index.html"), []byte("<h1>Public</h1>"), 0o644); err != nil {
+		t.Fatalf("cannot create public index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "secret.txt"), []byte("TOP_SECRET"), 0o644); err != nil {
+		t.Fatalf("cannot create secret file: %v", err)
+	}
+
+	requestURIs := []string{
+		`http://localhost/\..\secret.txt`,
+		`http://localhost/\../secret.txt`,
+		`http://localhost/public\..\..\secret.txt`,
+	}
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	fs := &FS{
+		Root:      publicDir,
+		CleanStop: stop,
+	}
+	h := fs.NewRequestHandler()
+
+	for _, uri := range requestURIs {
+		t.Run(uri, func(t *testing.T) {
+			var ctx RequestCtx
+			ctx.Init(&Request{}, nil, TestLogger{t: t})
+			ctx.Request.SetRequestURI(uri)
+
+			h(&ctx)
+
+			if ctx.Response.StatusCode() != StatusInternalServerError {
+				t.Fatalf("unexpected status code for %q: %d. Expecting %d", uri, ctx.Response.StatusCode(), StatusInternalServerError)
+			}
+			if bytes.Contains(ctx.Response.Body(), []byte("TOP_SECRET")) {
+				t.Fatalf("unexpected secret disclosure for %q", uri)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Repro: on Windows, `GET /foo/\..\..\windows/win.ini` against a default `FS`/`FSHandler` (no `PathRewrite`) serves a file outside `Root` (#1691).
Expected: rejected as a `..` traversal, the same as the `/`-separator case.
Actual: `ctx.Path()` normalisation only collapses `/`-delimited `..`, so `\..\` and `\../` pass through unchanged, and `handleRequest` only ran its `hasDotDotPathSegment` guard for rewritten paths. `pathToFilePath` then feeds the backslashes to `filepath.FromSlash`, producing a real parent-directory escape.
Fix: run the `..`-segment guard for every path on Windows, not just rewritten ones. `hasDotDotPathSegment` already treats `\` as a separator there, so any `..` segment is rejected whatever the separator. The regression test is Windows-only since `\` only separates path components there.