### PR TITLE
reject Transfer-Encoding on HTTP/1.0 requests

### DIFF
--- a/header.go
+++ b/header.go
@@ -3180,6 +3180,14 @@ func (h *RequestHeader) parseHeaders(buf []byte, blockEnd int) (int, error) {
 		case 't':
 			if caseInsensitiveCompare(s.key, strTransferEncoding) {
 				isTransferEncoding = true
+				// RFC 9112 section 6.1 requires an HTTP/1.0 message carrying
+				// Transfer-Encoding to be treated as having faulty framing,
+				// even if Content-Length is present, and the connection to be
+				// closed afterwards.
+				if h.noHTTP11 {
+					h.connectionClose = true
+					return 0, ErrUnsupportedTransferEncoding
+				}
 				if transferEncodingSeen {
 					h.connectionClose = true
 					if h.secureErrorLogMessage {

--- a/header_test.go
+++ b/header_test.go
@@ -3428,6 +3428,10 @@ func TestRequestHeaderReadSuccess(t *testing.T) {
 		t.Fatalf("unexpected 'connection: close' for ancient http protocol")
 	}
 
+	// HTTP/1.1 still frames a chunked body.
+	testRequestHeaderReadSuccess(t, h, "POST /te HTTP/1.1\r\nHost: aa\r\nTransfer-Encoding: chunked\r\n\r\n",
+		-1, "/te", "aa", "", "")
+
 	// complex headers with body
 	testRequestHeaderReadSuccess(t, h, "GET /aabar HTTP/1.1\r\nAAA: bbb\r\nHost: ole.com\r\nAA: bb\r\n\r\nzzz",
 		-2, "/aabar", "ole.com", "", "")
@@ -3620,6 +3624,10 @@ func TestRequestHeaderReadError(t *testing.T) {
 
 	// post with duplicate transfer-encoding
 	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
+
+	// transfer-encoding on http/1.0, with and without content-length
+	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.0\r\nHost: aa\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
+	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.0\r\nHost: aa\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\nhello")
 
 	// invalid Content-Length with Transfer-Encoding
 	testRequestHeaderReadError(t, h, "POST /xx HTTP/1.1\r\nHost: aa\r\nContent-Length: nope\r\nTransfer-Encoding: chunked\r\n\r\n")


### PR DESCRIPTION
Repro: send `POST / HTTP/1.0\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHELLO\r\n0\r\n\r\n`. `RequestHeader.parseHeaders` frames it as chunked and swallows `HELLO` as the body.
Expected: per [RFC 9112 section 6.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1), a server that receives an HTTP/1.0 message containing `Transfer-Encoding` must treat the framing as faulty, even if a `Content-Length` is present, and close the connection.
Actual: the request parser honours chunked regardless of version. A chunked-unaware 1.0 hop then treats the request as bodyless and forwards `5\r\nHELLO...` as the next request, while fasthttp consumes it as the first request's body (request smuggling).
Fix: reject the request in `RequestHeader.parseHeaders` when `noHTTP11` is set. The check sits before the `disableSpecialHeader` early-continue so that path is covered too, and `connectionClose` plus the usual header-error handling closes the connection.

`Transfer-Encoding` on HTTP/1.1 is unaffected; regression cases cover the 1.0 rejection with and without `Content-Length`, and the 1.1 chunked control.
