### PR TITLE
feat(server): deferred 100-continue via ExpectHandler

### DIFF
--- a/server.go
+++ b/server.go
@@ -146,6 +146,28 @@ type ServeHandler func(c net.Conn) error
 // instead.
 //
 // It is safe to call Server methods from concurrently running goroutines.
+
+// StatusContinueDeferred may be returned by Server.ExpectHandler to defer the
+// "100 Continue" response instead of sending it eagerly before the request
+// handler runs.
+//
+// When ExpectHandler returns StatusContinueDeferred the request handler is
+// invoked immediately, but the request body is NOT read and no "100 Continue"
+// response is sent yet. The handler must call RequestCtx.ContinueRequestBody
+// before it reads the body: that call sends the pending "100 Continue" response
+// and reads the body. If the handler responds without calling
+// ContinueRequestBody (for example, to reject the request after authentication),
+// "100 Continue" is never sent, so a well-behaved client never uploads the body.
+//
+// This realizes the purpose of the Expect: 100-continue mechanism — letting the
+// server reject a request before the client transmits a (potentially large)
+// body — for decisions that can only be made inside the request handler (after
+// routing, authentication, etc.) rather than from request headers alone.
+//
+// The value is intentionally not a valid HTTP status code so it cannot collide
+// with a real status returned by ExpectHandler to reject the request.
+const StatusContinueDeferred = -1
+
 type Server struct {
 	noCopy noCopy
 
@@ -203,6 +225,11 @@ type Server struct {
 	// StatusContinue (100) to accept the request and proceed to read the body,
 	// or any other status code to reject it and close the connection since the
 	// client may have already started sending the request body.
+	//
+	// Returning StatusContinueDeferred defers the "100 Continue" response until
+	// the request handler asks for the body via RequestCtx.ContinueRequestBody,
+	// so a handler can reject a request after routing/authentication without the
+	// client ever uploading the body. See StatusContinueDeferred for details.
 	//
 	// The ctx provides access to request headers and connection metadata (e.g.
 	// RemoteAddr for IP-based filtering). The response must not be modified.
@@ -645,6 +672,52 @@ type RequestCtx struct {
 	connID           uint64
 	connRequestNum   uint64
 	hijackNoResponse bool
+
+	// deferredContinue is armed by the connection loop when ExpectHandler
+	// returns StatusContinueDeferred. It carries the reader/writer the handler
+	// needs so ContinueRequestBody can send the pending "100 Continue" response
+	// and read the body on demand. It is nil for non-deferred requests.
+	deferredContinue *deferredContinue
+}
+
+// deferredContinue holds the state required to send a deferred "100 Continue"
+// response and read the request body from inside the request handler.
+type deferredContinue struct {
+	br                    *bufio.Reader
+	bw                    *bufio.Writer
+	maxBodySize           int
+	preParseMultipartForm bool
+	sent                  bool
+}
+
+// ContinueRequestBody sends the pending "100 Continue" response and reads the
+// request body. It must be called by the request handler before reading the
+// body of a request whose ExpectHandler returned StatusContinueDeferred.
+//
+// It is a no-op (returning nil) when the request did not defer continue or when
+// the body was already requested, so it is safe to call unconditionally. For a
+// deferred request that the handler rejects, simply not calling
+// ContinueRequestBody means "100 Continue" is never sent and a well-behaved
+// client never uploads the body.
+func (ctx *RequestCtx) ContinueRequestBody() error {
+	dc := ctx.deferredContinue
+	if dc == nil || dc.sent {
+		return nil
+	}
+	dc.sent = true
+
+	// Send the deferred "HTTP/1.1 100 Continue" response, then read the body.
+	if _, err := dc.bw.Write(strResponseContinue); err != nil {
+		return err
+	}
+	if err := dc.bw.Flush(); err != nil {
+		return err
+	}
+
+	if ctx.s.StreamRequestBody {
+		return ctx.Request.ContinueReadBodyStream(dc.br, dc.maxBodySize, dc.preParseMultipartForm)
+	}
+	return ctx.Request.ContinueReadBody(dc.br, dc.maxBodySize, dc.preParseMultipartForm)
 }
 
 // EarlyHints allows the server to hint to the browser what resources a page would need
@@ -892,6 +965,7 @@ func (ctx *RequestCtx) reset() {
 	ctx.Request.Reset()
 	ctx.Response.Reset()
 	ctx.fbr.reset()
+	ctx.deferredContinue = nil
 
 	ctx.connID = 0
 	ctx.connRequestNum = 0
@@ -2478,9 +2552,18 @@ func (s *Server) serveConn(c net.Conn) error {
 		// 'Expect: 100-continue' request handling.
 		// See https://www.rfc-editor.org/rfc/rfc9110.html#field.expect for details.
 		if ctx.Request.MayContinue() {
+			deferContinue := false
+
 			// Allow the ability to deny reading the incoming request body.
 			if s.ExpectHandler != nil {
-				if expectStatus := s.ExpectHandler(ctx); expectStatus != StatusContinue {
+				switch expectStatus := s.ExpectHandler(ctx); expectStatus {
+				case StatusContinue:
+					// Accept the body: send 100-continue eagerly below.
+				case StatusContinueDeferred:
+					// Defer 100-continue: run the handler first and send it (and
+					// read the body) only if the handler calls ContinueRequestBody.
+					deferContinue = true
+				default:
 					continueReadingRequest = false
 					if br != nil {
 						br.Reset(ctx.c)
@@ -2499,7 +2582,24 @@ func (s *Server) serveConn(c net.Conn) error {
 				}
 			}
 
-			if continueReadingRequest {
+			if continueReadingRequest && deferContinue {
+				// Arm ContinueRequestBody with the reader/writer it needs. Nothing
+				// is written or read until the handler requests the body, so a
+				// handler that rejects the request never sends 100-continue and a
+				// well-behaved client never uploads the body.
+				if bw == nil {
+					bw = acquireWriter(ctx)
+				}
+				if br == nil {
+					br = acquireReader(ctx)
+				}
+				ctx.deferredContinue = &deferredContinue{
+					br:                    br,
+					bw:                    bw,
+					maxBodySize:           maxRequestBodySize,
+					preParseMultipartForm: !s.DisablePreParseMultipartForm,
+				}
+			} else if continueReadingRequest {
 				if bw == nil {
 					bw = acquireWriter(ctx)
 				}
@@ -2587,7 +2687,12 @@ func (s *Server) serveConn(c net.Conn) error {
 		connectionClose = connectionClose ||
 			(s.MaxRequestsPerConn > 0 && connRequestNum >= uint64(s.MaxRequestsPerConn)) || // #nosec G115
 			ctx.Response.Header.ConnectionClose() ||
-			(s.CloseOnShutdown && s.stop.Load() == 1)
+			(s.CloseOnShutdown && s.stop.Load() == 1) ||
+			// A deferred-continue request whose handler never asked for the body:
+			// 100-continue was not sent, so a well-behaved client uploaded nothing
+			// and the socket can be closed gracefully. Closing also protects
+			// against a client that started uploading after its expect timeout.
+			(ctx.deferredContinue != nil && !ctx.deferredContinue.sent)
 		if connectionClose {
 			ctx.Response.Header.SetConnectionClose()
 		} else if !ctx.Request.Header.IsHTTP11() {
@@ -2662,6 +2767,7 @@ func (s *Server) serveConn(c net.Conn) error {
 		s.setState(c, StateIdle)
 		ctx.Request.Reset()
 		ctx.Response.Reset()
+		ctx.deferredContinue = nil
 
 		if s.stop.Load() == 1 {
 			err = nil

--- a/server_test.go
+++ b/server_test.go
@@ -2409,6 +2409,69 @@ func TestServerExpectHandlerRemoteAddr(t *testing.T) {
 	verifyResponse(t, br, StatusForbidden, string(defaultContentType), "")
 }
 
+func TestServerExpectHandlerDeferredContinue(t *testing.T) {
+	t.Parallel()
+
+	const body = "hello world"
+	const continuePrefix = "HTTP/1.1 100 Continue\r\n\r\n"
+
+	s := &Server{
+		ExpectHandler: func(_ *RequestCtx) int {
+			// Defer the 100-continue decision to the request handler.
+			return StatusContinueDeferred
+		},
+		Handler: func(ctx *RequestCtx) {
+			if string(ctx.Path()) == "/reject" {
+				// Reject without reading the body: 100-continue must not be sent.
+				ctx.SetStatusCode(StatusNotFound)
+				return
+			}
+			// Accept: request the body (sends 100-continue), then echo it.
+			if err := ctx.ContinueRequestBody(); err != nil {
+				t.Errorf("ContinueRequestBody: %v", err)
+				return
+			}
+			ctx.Write(ctx.PostBody()) //nolint:errcheck
+		},
+	}
+
+	// Accept path: 100-continue is sent, the body is read and echoed.
+	rw := &readWriter{}
+	rw.r.WriteString("POST /accept HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 11\r\nContent-Type: a/b\r\n\r\n" + body)
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from serveConn: %v", err)
+	}
+	out := rw.w.String()
+	if !strings.HasPrefix(out, continuePrefix) {
+		t.Fatalf("accepted deferred request must start with a 100-continue response, got %q", out)
+	}
+	br := bufio.NewReader(strings.NewReader(strings.TrimPrefix(out, continuePrefix)))
+	verifyResponse(t, br, StatusOK, string(defaultContentType), body)
+
+	// Reject path: no 100-continue is sent, the response is 404 with
+	// Connection: close, and the body is never consumed.
+	rw = &readWriter{}
+	rw.r.WriteString("POST /reject HTTP/1.1\r\nHost: gle.com\r\nExpect: 100-continue\r\nContent-Length: 11\r\nContent-Type: a/b\r\n\r\n" + body)
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from serveConn: %v", err)
+	}
+	out = rw.w.String()
+	if strings.Contains(out, "100 Continue") {
+		t.Fatalf("rejected deferred request must not send 100-continue, got %q", out)
+	}
+	br = bufio.NewReader(strings.NewReader(out))
+	var resp Response
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("Unexpected error when reading response: %v", err)
+	}
+	if resp.StatusCode() != StatusNotFound {
+		t.Fatalf("unexpected status code: %d. Expecting %d", resp.StatusCode(), StatusNotFound)
+	}
+	if !resp.Header.ConnectionClose() {
+		t.Fatal("rejected deferred request should close the connection")
+	}
+}
+
 func TestCompressHandler(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add an opt-in way for a request handler to decide whether to send the "100 Continue" interim response, instead of fasthttp always sending it eagerly before the handler runs.

Motivation
----------
The purpose of the Expect: 100-continue mechanism is to let a server reject a request BEFORE the client transmits a (potentially large) body. Today, when a request carries "Expect: 100-continue" and neither ExpectHandler nor ContinueHandler denies it, fasthttp writes the "100 Continue" response and begins reading the body before invoking the request handler. That means the client has already started (or completed) uploading the body by the time the handler gets to run, so a handler that rejects the request — e.g. after routing, authentication or an existence check that cannot be performed from request headers alone — cannot avoid the upload. Closing such a connection with an unread body in flight also risks a TCP RST that races the client's read of the response, surfacing as a transport error instead of the intended status code.

ExpectHandler already lets a server reject from the headers, but the decision often depends on state that is only available inside the request handler (after the routing/auth middleware has run). There was no way to defer the "100 Continue" decision that far.

What this adds
--------------
- StatusContinueDeferred: a sentinel that Server.ExpectHandler may return. Returning it invokes the request handler immediately WITHOUT sending "100 Continue" and WITHOUT reading the body. The value (-1) is not a valid HTTP status, so it cannot collide with a real rejection status.

- RequestCtx.ContinueRequestBody(): called by the handler when it wants the body. It sends the pending "100 Continue" response and then reads the body (honoring StreamRequestBody). It is a no-op when the request did not defer continue or when the body was already requested, so it is safe to call unconditionally.

Behavior:
- Accept: the handler calls ContinueRequestBody(); "100 Continue" is sent and the body is read, exactly as in the eager path.
- Reject: the handler responds without calling ContinueRequestBody(); "100 Continue" is never sent, so a well-behaved client never uploads the body. The connection is marked for close, which is graceful because there is no in-flight body to leave unread. This also guards against a client that begins uploading after its expect-continue timeout.

The feature is fully backward compatible: ExpectHandler returning StatusContinue (or any rejection status), ContinueHandler, and the default auto-accept behavior are all unchanged. The deferred path is only taken when ExpectHandler explicitly returns StatusContinueDeferred.

Includes TestServerExpectHandlerDeferredContinue covering both the accept (100-continue sent, body read and echoed) and reject (no 100-continue, 404 with Connection: close, body not consumed) paths.