### PR TITLE
fix: consume informational responses before the final response

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -404,6 +404,96 @@ func testPipelineClientDoOnce(t *testing.T, c *PipelineClient) {
 	}
 }
 
+func TestPipelineClientSkipsEarlyHints(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	firstRequestRead := make(chan struct{})
+	serverDone := make(chan error, 1)
+	go func() {
+		defer serverConn.Close()
+
+		br := bufio.NewReader(serverConn)
+		for i := range 2 {
+			var req Request
+			if err := req.Read(br); err != nil {
+				serverDone <- fmt.Errorf("read request %d: %w", i, err)
+				return
+			}
+			if i == 0 {
+				close(firstRequestRead)
+			}
+		}
+
+		_, err := io.WriteString(serverConn,
+			"HTTP/1.1 103 Early Hints\r\nLink: </style.css>; rel=preload\r\n\r\n"+
+				"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nFIRST"+
+				"HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nSECOND")
+		serverDone <- err
+	}()
+
+	var dialMu sync.Mutex
+	dialed := false
+	c := &PipelineClient{
+		Dial: func(string) (net.Conn, error) {
+			dialMu.Lock()
+			defer dialMu.Unlock()
+			if dialed {
+				return nil, errors.New("unexpected second dial")
+			}
+			dialed = true
+			return clientConn, nil
+		},
+		MaxPendingRequests:  2,
+		MaxIdleConnDuration: time.Second,
+		Logger:              &testLogger{},
+	}
+
+	type result struct {
+		index  int
+		status int
+		body   string
+		err    error
+	}
+	results := make(chan result, 2)
+	do := func(index int, uri string) {
+		go func() {
+			var req Request
+			var resp Response
+			req.SetRequestURI(uri)
+			err := c.DoTimeout(&req, &resp, time.Second)
+			results <- result{index: index, status: resp.StatusCode(), body: string(resp.Body()), err: err}
+		}()
+	}
+
+	do(0, "http://example.test/first")
+	select {
+	case <-firstRequestRead:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive first request")
+	}
+	do(1, "http://example.test/second")
+
+	got := make([]result, 2)
+	for range 2 {
+		r := <-results
+		got[r.index] = r
+	}
+	for i, want := range []string{"FIRST", "SECOND"} {
+		if got[i].err != nil {
+			t.Fatalf("request %d failed: %v", i, got[i].err)
+		}
+		if got[i].status != StatusOK || got[i].body != want {
+			t.Fatalf("request %d received status %d and body %q; want 200 and %q", i, got[i].status, got[i].body, want)
+		}
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatalf("server failed: %v", err)
+	}
+}
+
 func TestPipelineClientTLSMalformedAddrFailsBeforeDial(t *testing.T) {
 	t.Parallel()
 

--- a/http.go
+++ b/http.go
@@ -1564,8 +1564,15 @@ func (resp *Response) Read(r *bufio.Reader) error {
 	return resp.ReadLimitBody(r, 0)
 }
 
+const maxInterimResponses = 100
+
+var errTooManyInterimResponses = errors.New("fasthttp: too many 1xx informational responses received")
+
 // ReadLimitBody reads response headers from the given r,
 // then reads the body using the ReadBody function and limiting the body size.
+//
+// Informational responses other than "101 Switching Protocols" are consumed
+// before the final response is read.
 //
 // If resp.SkipBody is true then it skips reading the response body.
 //
@@ -1579,8 +1586,12 @@ func (resp *Response) ReadLimitBody(r *bufio.Reader, maxBodySize int) error {
 	if err != nil {
 		return err
 	}
-	if resp.Header.statusCode == StatusContinue {
-		// Read the next response according to http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html .
+
+	for n := 0; resp.Header.statusCode >= 100 && resp.Header.statusCode <= 199 &&
+		resp.Header.statusCode != StatusSwitchingProtocols; n++ {
+		if n >= maxInterimResponses {
+			return errTooManyInterimResponses
+		}
 		if err = resp.Header.Read(r); err != nil {
 			return err
 		}

--- a/http.go
+++ b/http.go
@@ -1564,6 +1564,8 @@ func (resp *Response) Read(r *bufio.Reader) error {
 	return resp.ReadLimitBody(r, 0)
 }
 
+// maxInterimResponses limits the number of consecutive informational responses
+// accepted before ReadLimitBody returns errTooManyInterimResponses.
 const maxInterimResponses = 100
 
 var errTooManyInterimResponses = errors.New("fasthttp: too many 1xx informational responses received")
@@ -1587,8 +1589,12 @@ func (resp *Response) ReadLimitBody(r *bufio.Reader, maxBodySize int) error {
 		return err
 	}
 
-	for n := 0; resp.Header.statusCode >= 100 && resp.Header.statusCode <= 199 &&
-		resp.Header.statusCode != StatusSwitchingProtocols; n++ {
+	for n := 0; ; n++ {
+		if resp.Header.statusCode < 100 ||
+			resp.Header.statusCode > 199 ||
+			resp.Header.statusCode == StatusSwitchingProtocols {
+			break
+		}
 		if n >= maxInterimResponses {
 			return errTooManyInterimResponses
 		}

--- a/http_test.go
+++ b/http_test.go
@@ -2286,8 +2286,8 @@ func TestResponseReadWithoutBody(t *testing.T) {
 	testResponseReadWithoutBody(t, &resp, "HTTP/1.1 204 Foo Bar\r\nContent-Type: aab\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n", false,
 		204, -1, "aab")
 
-	testResponseReadWithoutBody(t, &resp, "HTTP/1.1 123 AAA\r\nContent-Type: xxx\r\nContent-Length: 3434\r\n\r\n", false,
-		123, 3434, "xxx")
+	testResponseReadWithoutBody(t, &resp, "HTTP/1.1 123 AAA\r\nContent-Type: xxx\r\n\r\nHTTP/1.1 250 BBB\r\nContent-Type: yyy\r\nContent-Length: 0\r\n\r\n", false,
+		250, 0, "yyy")
 
 	testResponseReadWithoutBody(t, &resp, "HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\nContent-Length: 123\r\n\r\nfoobar\r\n", true,
 		200, 123, "text/xml")
@@ -2295,6 +2295,44 @@ func TestResponseReadWithoutBody(t *testing.T) {
 	// '100 Continue' must be skipped.
 	testResponseReadWithoutBody(t, &resp, "HTTP/1.1 100 Continue\r\nFoo-bar: baz\r\n\r\nHTTP/1.1 329 aaa\r\nContent-Type: qwe\r\nContent-Length: 894\r\n\r\n", true,
 		329, 894, "qwe")
+}
+
+func TestResponseReadSwitchingProtocolsIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	r := bufio.NewReader(strings.NewReader(
+		"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\nUPGRADE-DATA",
+	))
+	var resp Response
+	if err := resp.Read(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode() != StatusSwitchingProtocols {
+		t.Fatalf("unexpected status code %d; want %d", resp.StatusCode(), StatusSwitchingProtocols)
+	}
+	remaining, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read upgrade data: %v", err)
+	}
+	if string(remaining) != "UPGRADE-DATA" {
+		t.Fatalf("unexpected upgrade data %q", remaining)
+	}
+}
+
+func TestResponseReadLimitsInterimResponses(t *testing.T) {
+	t.Parallel()
+
+	var s strings.Builder
+	for range maxInterimResponses + 1 {
+		s.WriteString("HTTP/1.1 103 Early Hints\r\n\r\n")
+	}
+	s.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+
+	var resp Response
+	err := resp.Read(bufio.NewReader(strings.NewReader(s.String())))
+	if !errors.Is(err, errTooManyInterimResponses) {
+		t.Fatalf("unexpected error %v; want %v", err, errTooManyInterimResponses)
+	}
 }
 
 func testResponseReadWithoutBody(t *testing.T, resp *Response, s string, skipBody bool,


### PR DESCRIPTION
## Summary

`Response.ReadLimitBody` previously treated only `100 Continue` as interim. Other informational responses, such as `103 Early Hints`, were returned as final responses. With `PipelineClient`, this left the real final response unread and assigned it to the next queued request.

This change:

- consumes all `1xx` informational responses except `101 Switching Protocols` before reading the final response;
- keeps `101` terminal so upgraded-protocol bytes remain untouched;
- caps processing at 100 interim responses; and
- adds a focused two-request `PipelineClient` regression that proves each final response stays with its request.

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run --new-from-rev origin/master` (0 issues)
