### PR TITLE
fix: reject Windows alternate data stream paths in FS

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -1302,6 +1302,14 @@ func (h *fsHandler) handleRequest(ctx *RequestCtx) {
 		ctx.Error("Are you a hacker?", StatusBadRequest)
 		return
 	}
+	// Prevent request paths from reaching NTFS alternate data streams through
+	// the default osFS. Custom filesystems may define their own colon syntax.
+	if _, ok := h.filesystem.(*osFS); ok && hasWindowsReservedPathColon(path, h.root == "") {
+		ctx.Logger().Printf("cannot serve path with a Windows-reserved ':' character: %q", path)
+		ctx.Error("Forbidden", StatusForbidden)
+		return
+	}
+
 	// Rewritten paths bypass ctx.Path()'s normalization, so they must be
 	// checked for '..' segments here. On Windows every path is checked
 	// regardless: ctx.Path() normalization only treats '/' as a separator,

--- a/fs_unix.go
+++ b/fs_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package fasthttp
+
+func hasWindowsReservedPathColon(_ []byte, _ bool) bool {
+	return false
+}

--- a/fs_windows.go
+++ b/fs_windows.go
@@ -1,0 +1,13 @@
+package fasthttp
+
+import "bytes"
+
+// hasWindowsReservedPathColon reports whether path contains a ':' byte
+// that cannot be a legitimate Windows drive letter.
+func hasWindowsReservedPathColon(path []byte, rootIsEmpty bool) bool {
+	rest := path
+	if rootIsEmpty && len(path) >= 2 && isASCIILetter(path[0]) && path[1] == ':' {
+		rest = path[2:]
+	}
+	return bytes.IndexByte(rest, ':') >= 0
+}

--- a/fs_windows_test.go
+++ b/fs_windows_test.go
@@ -1,0 +1,51 @@
+package fasthttp
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFSWindowsRejectsAlternateDataStream(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	publicPath := filepath.Join(root, "public.txt")
+	publicBody := []byte("public")
+	privateBody := []byte("private")
+	if err := os.WriteFile(publicPath, publicBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(publicPath+":secret", privateBody, 0o600); err != nil {
+		t.Skipf("filesystem does not support alternate data streams: %v", err)
+	}
+
+	h := (&FS{Root: root, SkipCache: true}).NewRequestHandler()
+	request := func(path string) (int, []byte) {
+		var ctx RequestCtx
+		ctx.Init(&Request{}, nil, TestLogger{t: t})
+		ctx.Request.SetRequestURI(path)
+		h(&ctx)
+		return ctx.Response.StatusCode(), bytes.Clone(ctx.Response.Body())
+	}
+
+	if status, body := request("/public.txt"); status != StatusOK || !bytes.Equal(body, publicBody) {
+		t.Fatalf("public file: status=%d body=%q", status, body)
+	}
+	if status, body := request("/public.txt:secret"); status != StatusForbidden || bytes.Contains(body, privateBody) {
+		t.Fatalf("alternate data stream: status=%d body=%q", status, body)
+	}
+}
+
+func TestFSWindowsServeFileAllowsDriveLetter(t *testing.T) {
+	t.Parallel()
+
+	var ctx RequestCtx
+	ctx.Init(&Request{}, nil, TestLogger{t: t})
+	ctx.Request.SetRequestURI("http://localhost/")
+	ServeFile(&ctx, "fs.go")
+	if ctx.Response.StatusCode() != StatusOK {
+		t.Fatalf("unexpected status %d; want %d", ctx.Response.StatusCode(), StatusOK)
+	}
+}


### PR DESCRIPTION
## Summary

On Windows, the default `osFS` passed request-path colons to `os.Open`. On NTFS, a path such as `public.txt:secret` opens a named alternate data stream instead of the file's normal content.

This change:

- rejects Windows-reserved colons before the default `osFS` is used;
- leaves caller-supplied filesystems unchanged;
- preserves the leading drive-letter colon required by `ServeFile` absolute paths; and
- adds a focused Windows test that creates a real NTFS alternate data stream and proves it is rejected.

The branch is rebased after the merged Windows backslash-traversal fix in PR #2327. Its adjacent traversal controls remain intact and pass.

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run --new-from-rev origin/master` (0 issues)
