### PR TITLE
consume the rest of the declared body in readMultipartForm

### DIFF
--- a/http.go
+++ b/http.go
@@ -71,6 +71,13 @@ type Request struct {
 
 	keepBodyBuffer bool
 
+	// Set when a streamed request body could not be fully drained, e.g. a
+	// malformed chunk was hit while discarding the multipart epilogue. The
+	// connection is then left mid-body, so the server must close it rather
+	// than reuse it, otherwise the leftover bytes are read back as the start
+	// of the next request.
+	bodyStreamDrainErr bool
+
 	// Used by Server to indicate the request was received on a HTTPS endpoint.
 	// Client/HostClient shouldn't use this field but should depend on the uri.scheme instead.
 	isTLS bool
@@ -1126,7 +1133,13 @@ func (req *Request) MultipartFormWithLimit(maxBodySize int) (*multipart.Form, er
 	// dynamic type set through SetBodyStream.
 	if req.bodyStream != nil {
 		defer func() {
-			_, _ = copyZeroAlloc(io.Discard, req.bodyStream)
+			if _, drainErr := copyZeroAlloc(io.Discard, req.bodyStream); drainErr != nil {
+				// The declared body could not be fully consumed, so the
+				// connection is left mid-body. Mark it so the server closes the
+				// connection instead of parsing the leftover as the next
+				// request.
+				req.bodyStreamDrainErr = true
+			}
 		}()
 	}
 
@@ -1304,6 +1317,7 @@ func (req *Request) resetSkipHeader() {
 	req.postArgs.Reset()
 	req.parsedPostArgs = false
 	req.isTLS = false
+	req.bodyStreamDrainErr = false
 }
 
 // RemoveMultipartFormFiles removes multipart/form-data temporary files

--- a/http.go
+++ b/http.go
@@ -1144,21 +1144,26 @@ func (req *Request) MultipartFormWithLimit(maxBodySize int) (*multipart.Form, er
 
 		mr := multipart.NewReader(bodyStream, req.multipartFormBoundary)
 		req.multipartForm, err = mr.ReadForm(8 * 1024)
-		if err != nil {
-			if lr != nil && lr.N <= 0 {
-				return nil, fmt.Errorf("cannot read multipart/form-data body: %w", ErrBodyTooLarge)
+
+		// ReadForm stops at the closing boundary, and on a parse error it stops
+		// wherever it gave up, so either way the rest of the declared body is
+		// still pending. Discard it through bodyStream so the leftover keeps
+		// counting towards maxBodySize, then off the raw stream so none of the
+		// declared body is left behind to be read back as the beginning of the
+		// next request on a keep-alive connection.
+		_, drainErr := copyZeroAlloc(io.Discard, bodyStream)
+		if bodyStream != req.bodyStream {
+			if _, rawErr := copyZeroAlloc(io.Discard, req.bodyStream); drainErr == nil {
+				drainErr = rawErr
 			}
-			return nil, fmt.Errorf("cannot read multipart/form-data body: %w", err)
+		}
+		if err == nil {
+			err = drainErr
 		}
 		if lr != nil && lr.N <= 0 {
-			req.RemoveMultipartFormFiles()
-			return nil, fmt.Errorf("cannot read multipart/form-data body: %w", ErrBodyTooLarge)
+			err = ErrBodyTooLarge
 		}
-		// ReadForm stops at the closing boundary, so the rest of the declared
-		// body is still pending on the stream. Discard it, otherwise those
-		// bytes are read back as the beginning of the next request on a
-		// keep-alive connection.
-		if _, err = copyZeroAlloc(io.Discard, req.bodyStream); err != nil {
+		if err != nil {
 			req.RemoveMultipartFormFiles()
 			return nil, fmt.Errorf("cannot read multipart/form-data body: %w", err)
 		}

--- a/http.go
+++ b/http.go
@@ -1116,6 +1116,20 @@ func (req *Request) MultipartFormWithLimit(maxBodySize int) (*multipart.Form, er
 		return req.multipartForm, nil
 	}
 
+	// Every declared body byte has to come off req.bodyStream before we
+	// return, on the error paths as much as the success one. ReadForm stops at
+	// the closing boundary and the early errors (missing boundary, unsupported
+	// content-encoding, bad gzip header) stop even sooner, so without this the
+	// leftover bytes are read back as the start of the next request on a
+	// keep-alive connection. Draining req.bodyStream directly also avoids
+	// comparing reader interface values, which panics for an uncomparable
+	// dynamic type set through SetBodyStream.
+	if req.bodyStream != nil {
+		defer func() {
+			_, _ = copyZeroAlloc(io.Discard, req.bodyStream)
+		}()
+	}
+
 	req.multipartFormBoundary = string(req.Header.MultipartFormBoundary())
 	if req.multipartFormBoundary == "" {
 		return nil, ErrNoMultipartForm
@@ -1145,19 +1159,11 @@ func (req *Request) MultipartFormWithLimit(maxBodySize int) (*multipart.Form, er
 		mr := multipart.NewReader(bodyStream, req.multipartFormBoundary)
 		req.multipartForm, err = mr.ReadForm(8 * 1024)
 
-		// ReadForm stops at the closing boundary, and on a parse error it stops
-		// wherever it gave up, so either way the rest of the declared body is
-		// still pending. Discard it through bodyStream so the leftover keeps
-		// counting towards maxBodySize, then off the raw stream so none of the
-		// declared body is left behind to be read back as the beginning of the
-		// next request on a keep-alive connection.
-		_, drainErr := copyZeroAlloc(io.Discard, bodyStream)
-		if bodyStream != req.bodyStream {
-			if _, rawErr := copyZeroAlloc(io.Discard, req.bodyStream); drainErr == nil {
-				drainErr = rawErr
-			}
-		}
-		if err == nil {
+		// Drain the rest of the declared body through bodyStream so the
+		// leftover keeps counting towards maxBodySize; the deferred drain then
+		// clears whatever remains on the raw stream so the connection stays
+		// framed.
+		if _, drainErr := copyZeroAlloc(io.Discard, bodyStream); err == nil {
 			err = drainErr
 		}
 		if lr != nil && lr.N <= 0 {

--- a/http.go
+++ b/http.go
@@ -1176,8 +1176,17 @@ func (req *Request) MultipartFormWithLimit(maxBodySize int) (*multipart.Form, er
 		// leftover keeps counting towards maxBodySize; the deferred drain then
 		// clears whatever remains on the raw stream so the connection stays
 		// framed.
-		if _, drainErr := copyZeroAlloc(io.Discard, bodyStream); err == nil {
-			err = drainErr
+		if _, drainErr := copyZeroAlloc(io.Discard, bodyStream); drainErr != nil {
+			// The stream stopped short of the end of the declared body, so the
+			// connection is mid-body. Mark it sticky here rather than leaving it
+			// to the deferred drain: that retry can resume past the bad byte at
+			// a valid terminating chunk and return nil, which would otherwise
+			// leave the connection reusable and the leftover parsed as the next
+			// request.
+			req.bodyStreamDrainErr = true
+			if err == nil {
+				err = drainErr
+			}
 		}
 		if lr != nil && lr.N <= 0 {
 			err = ErrBodyTooLarge

--- a/http.go
+++ b/http.go
@@ -1249,6 +1249,14 @@ func readMultipartForm(r io.Reader, boundary string, size, maxInMemoryFileSize i
 	if err != nil {
 		return nil, fmt.Errorf("cannot read multipart/form-data body: %w", err)
 	}
+	// ReadForm stops at the closing boundary, so anything the sender placed
+	// between it and Content-Length is still unread on r. Discard it, since
+	// on a keep-alive connection those bytes are otherwise read back as the
+	// beginning of the next request.
+	if _, err = copyZeroAlloc(io.Discard, lr); err != nil {
+		f.RemoveAll() //nolint:errcheck
+		return nil, fmt.Errorf("cannot read multipart/form-data body: %w", err)
+	}
 	return f, nil
 }
 

--- a/http.go
+++ b/http.go
@@ -1154,6 +1154,14 @@ func (req *Request) MultipartFormWithLimit(maxBodySize int) (*multipart.Form, er
 			req.RemoveMultipartFormFiles()
 			return nil, fmt.Errorf("cannot read multipart/form-data body: %w", ErrBodyTooLarge)
 		}
+		// ReadForm stops at the closing boundary, so the rest of the declared
+		// body is still pending on the stream. Discard it, otherwise those
+		// bytes are read back as the beginning of the next request on a
+		// keep-alive connection.
+		if _, err = copyZeroAlloc(io.Discard, req.bodyStream); err != nil {
+			req.RemoveMultipartFormFiles()
+			return nil, fmt.Errorf("cannot read multipart/form-data body: %w", err)
+		}
 	} else {
 		body := req.bodyBytes()
 		if bytes.Equal(ce, strGzip) {
@@ -1243,7 +1251,7 @@ func readMultipartForm(r io.Reader, boundary string, size, maxInMemoryFileSize i
 	if size <= 0 {
 		return nil, fmt.Errorf("form size must be greater than 0: given %d", size)
 	}
-	lr := io.LimitReader(r, int64(size))
+	lr := &io.LimitedReader{R: r, N: int64(size)}
 	mr := multipart.NewReader(lr, boundary)
 	f, err := mr.ReadForm(int64(maxInMemoryFileSize))
 	if err != nil {
@@ -1253,7 +1261,11 @@ func readMultipartForm(r io.Reader, boundary string, size, maxInMemoryFileSize i
 	// between it and Content-Length is still unread on r. Discard it, since
 	// on a keep-alive connection those bytes are otherwise read back as the
 	// beginning of the next request.
-	if _, err = copyZeroAlloc(io.Discard, lr); err != nil {
+	if _, err = copyZeroAlloc(io.Discard, lr); err == nil && lr.N > 0 {
+		// r ended before the declared body size was reached.
+		err = io.ErrUnexpectedEOF
+	}
+	if err != nil {
 		f.RemoveAll() //nolint:errcheck
 		return nil, fmt.Errorf("cannot read multipart/form-data body: %w", err)
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -1705,6 +1705,36 @@ func TestRequestMultipartForm(t *testing.T) {
 	testRequestMultipartForm(t, "foobar", req.Body(), 3)
 }
 
+func TestRequestMultipartFormEpilogue(t *testing.T) {
+	t.Parallel()
+
+	// Bytes the sender put between the closing boundary and Content-Length.
+	// They belong to this request's body, so they must not show up as the
+	// next request on the connection.
+	body := "--foobar\r\nContent-Disposition: form-data; name=\"key\"\r\n\r\nvalue\r\n--foobar--\r\n" +
+		strings.Repeat("z", 8*1024)
+	next := "GET /next HTTP/1.1\r\nHost: aaa\r\n\r\n"
+
+	s := fmt.Sprintf("POST /first HTTP/1.1\r\nHost: aaa\r\nContent-Type: multipart/form-data; boundary=foobar\r\nContent-Length: %d\r\n\r\n%s%s",
+		len(body), body, next)
+
+	br := bufio.NewReader(bytes.NewBufferString(s))
+
+	var req Request
+	if err := req.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req.RemoveMultipartFormFiles()
+
+	var req2 Request
+	if err := req2.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(req2.URI().Path()) != "/next" {
+		t.Fatalf("unexpected path %q; expecting %q", req2.URI().Path(), "/next")
+	}
+}
+
 func testRequestMultipartForm(t *testing.T, boundary string, formData []byte, partsCount int) []byte {
 	s := fmt.Sprintf("POST / HTTP/1.1\r\nHost: aaa\r\nContent-Type: multipart/form-data; boundary=%s\r\nContent-Length: %d\r\n\r\n%s",
 		boundary, len(formData), formData)

--- a/http_test.go
+++ b/http_test.go
@@ -1735,6 +1735,46 @@ func TestRequestMultipartFormEpilogue(t *testing.T) {
 	}
 }
 
+// uncomparableReader is passed by value and holds a slice, so its dynamic type
+// is not comparable and `reader == reader` panics at runtime.
+type uncomparableReader struct {
+	data []byte
+	off  *int
+}
+
+func (r uncomparableReader) Read(p []byte) (int, error) {
+	if *r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[*r.off:])
+	*r.off += n
+	return n, nil
+}
+
+func TestRequestMultipartFormUncomparableBodyStream(t *testing.T) {
+	t.Parallel()
+
+	// SetBodyStream accepts any io.Reader, so the drain must not compare the
+	// stream against another reader value: an uncomparable dynamic type would
+	// panic with "comparing uncomparable type".
+	body := "--foobar\r\nContent-Disposition: form-data; name=\"key\"\r\n\r\nvalue\r\n--foobar--\r\n"
+
+	var req Request
+	req.Header.SetContentType("multipart/form-data; boundary=foobar")
+	req.Header.SetContentLength(len(body))
+	req.SetBodyStream(uncomparableReader{data: []byte(body), off: new(int)}, len(body))
+
+	form, err := req.MultipartForm()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer req.RemoveMultipartFormFiles()
+
+	if v := form.Value["key"]; len(v) != 1 || v[0] != "value" {
+		t.Fatalf("unexpected form value %q; expecting %q", form.Value["key"], []string{"value"})
+	}
+}
+
 func testRequestMultipartForm(t *testing.T, boundary string, formData []byte, partsCount int) []byte {
 	s := fmt.Sprintf("POST / HTTP/1.1\r\nHost: aaa\r\nContent-Type: multipart/form-data; boundary=%s\r\nContent-Length: %d\r\n\r\n%s",
 		boundary, len(formData), formData)

--- a/server.go
+++ b/server.go
@@ -2653,6 +2653,7 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		connectionClose = connectionClose ||
 			(s.MaxRequestsPerConn > 0 && connRequestNum >= uint64(s.MaxRequestsPerConn)) || // #nosec G115
 			ctx.Response.Header.ConnectionClose() ||
+			ctx.Request.bodyStreamDrainErr ||
 			(s.CloseOnShutdown && s.stop.Load() == 1)
 		if connectionClose {
 			ctx.Response.Header.SetConnectionClose()

--- a/server.go
+++ b/server.go
@@ -2621,6 +2621,11 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 			s.Handler(ctx)
 		}
 
+		// A failed multipart drain leaves the connection mid-body. Capture it
+		// now, before timeoutResponse swaps out ctx below and before ctx.Request
+		// can be reset, so the close decision still sees it.
+		bodyStreamDrainErr := ctx.Request.bodyStreamDrainErr
+
 		timeoutResponse = ctx.timeoutResponse
 		if timeoutResponse != nil {
 			// Acquire a new ctx because the old one will still be in use by the timeout out handler.
@@ -2653,7 +2658,7 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		connectionClose = connectionClose ||
 			(s.MaxRequestsPerConn > 0 && connRequestNum >= uint64(s.MaxRequestsPerConn)) || // #nosec G115
 			ctx.Response.Header.ConnectionClose() ||
-			ctx.Request.bodyStreamDrainErr ||
+			bodyStreamDrainErr ||
 			(s.CloseOnShutdown && s.stop.Load() == 1)
 		if connectionClose {
 			ctx.Response.Header.SetConnectionClose()

--- a/server_test.go
+++ b/server_test.go
@@ -1658,6 +1658,121 @@ func TestServerRejectsTruncatedMultipartBody(t *testing.T) {
 	}
 }
 
+func TestServerDoesNotParseMalformedStreamedMultipartAsRequest(t *testing.T) {
+	t.Parallel()
+
+	// ReadForm gives up on the malformed part header, well before the end of
+	// the declared body.
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := "--x\r\nMalformed-Header\r\n" + smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Content-Length: %d\r\n\r\n%s",
+		len(body), body,
+	)
+
+	var paths []string
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1, // Force RequestBodyStream.
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			if string(ctx.Path()) == "/first" {
+				if _, err := ctx.MultipartForm(); err == nil {
+					t.Error("expecting error for a malformed multipart body")
+				}
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
+func TestServerRejectsTruncatedStreamedMultipartBody(t *testing.T) {
+	t.Parallel()
+
+	body := "--x\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--x--\r\n"
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST / HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Content-Length: %d\r\n\r\n%s",
+		len(body)+1, body,
+	)
+
+	var err error
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1, // Force RequestBodyStream.
+		Handler: func(ctx *RequestCtx) {
+			_, err = ctx.MultipartForm()
+		},
+	}
+
+	_ = s.ServeConn(rw)
+
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("MultipartForm error = %v; want unexpected EOF", err)
+	}
+}
+
+func TestServerStreamedMultipartEpilogueCountsTowardsLimit(t *testing.T) {
+	t.Parallel()
+
+	// The epilogue is request body too, so it has to be charged to maxBodySize
+	// the same way the buffered path charges it, and it still has to leave the
+	// connection framed once the limit is hit.
+	form := "--x\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--x--\r\n"
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := form + strings.Repeat("z", 1024) + smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Content-Length: %d\r\n\r\n%s",
+		len(body), body,
+	)
+
+	var (
+		err   error
+		paths []string
+	)
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1, // Force RequestBodyStream.
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			if string(ctx.Path()) == "/first" {
+				_, err = ctx.Request.MultipartFormWithLimit(len(form) + 1)
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+
+	if !errors.Is(err, ErrBodyTooLarge) {
+		t.Errorf("MultipartFormWithLimit error = %v; want %v", err, ErrBodyTooLarge)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
 func TestServerGetWithContent(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -1578,6 +1578,86 @@ Connection: close
 	}
 }
 
+// oneByteReadWriter hands out a single byte per Read, so the multipart reader
+// cannot buffer past the closing boundary.
+type oneByteReadWriter struct{ readWriter }
+
+func (rw *oneByteReadWriter) Read(p []byte) (int, error) {
+	if len(p) > 1 {
+		p = p[:1]
+	}
+	return rw.readWriter.Read(p)
+}
+
+func TestServerDoesNotParseStreamedMultipartEpilogueAsRequest(t *testing.T) {
+	t.Parallel()
+
+	form := "--x\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--x--\r\n"
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := form + smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Content-Length: %d\r\n\r\n%s",
+		len(body), body,
+	)
+
+	var paths []string
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1, // Force RequestBodyStream.
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			if string(ctx.Path()) == "/first" {
+				if _, err := ctx.MultipartForm(); err != nil {
+					t.Error(err)
+				}
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
+func TestServerRejectsTruncatedMultipartBody(t *testing.T) {
+	t.Parallel()
+
+	body := "--x\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--x--\r\n"
+
+	rw := &readWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST / HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Content-Length: %d\r\n\r\n%s",
+		len(body)+1, body,
+	)
+
+	called := false
+	s := Server{
+		Handler: func(*RequestCtx) {
+			called = true
+		},
+	}
+
+	err := s.ServeConn(rw)
+
+	if called {
+		t.Error("handler was called for a truncated request body")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("ServeConn error = %v; want unexpected EOF", err)
+	}
+}
+
 func TestServerGetWithContent(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -1892,6 +1892,47 @@ func TestServerDoesNotParseStreamedMultipartBadGzipAsRequest(t *testing.T) {
 	}
 }
 
+func TestServerDoesNotParseStreamedMultipartMalformedChunkAsRequest(t *testing.T) {
+	t.Parallel()
+
+	// The epilogue drain gives up on a malformed chunk size partway through the
+	// declared body, leaving the connection mid-body. The leftover bytes must
+	// not be read back as the next request, so the connection has to close.
+	form := "--x\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--x--\r\n"
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	// One valid chunk carrying the whole form, then a chunk whose size line is
+	// invalid, followed by the smuggled request.
+	body := fmt.Sprintf("%x\r\n%s\r\n", len(form), form) + "\x00" + smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Transfer-Encoding: chunked\r\n\r\n%s",
+		body,
+	)
+
+	var paths []string
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1, // Force RequestBodyStream.
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			if string(ctx.Path()) == "/first" {
+				_ = ctx.FormValue("x")
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
 func TestServerGetWithContent(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -1773,6 +1773,125 @@ func TestServerStreamedMultipartEpilogueCountsTowardsLimit(t *testing.T) {
 	}
 }
 
+func TestServerDoesNotParseStreamedMultipartMissingBoundaryAsRequest(t *testing.T) {
+	t.Parallel()
+
+	// multipart/form-data with no boundary returns ErrNoMultipartForm before a
+	// single body byte is read, so the whole declared body is the smuggled
+	// request.
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data\r\n"+
+			"Content-Length: %d\r\n\r\n%s",
+		len(body), body,
+	)
+
+	var paths []string
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1, // Force RequestBodyStream.
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			if string(ctx.Path()) == "/first" {
+				if _, err := ctx.MultipartForm(); err == nil {
+					t.Error("expecting error for a multipart body without a boundary")
+				}
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
+func TestServerDoesNotParseStreamedMultipartBadContentEncodingAsRequest(t *testing.T) {
+	t.Parallel()
+
+	// An unsupported Content-Encoding returns before any body byte is read.
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Content-Encoding: br\r\n"+
+			"Content-Length: %d\r\n\r\n%s",
+		len(body), body,
+	)
+
+	var paths []string
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1, // Force RequestBodyStream.
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			if string(ctx.Path()) == "/first" {
+				if _, err := ctx.MultipartForm(); err == nil {
+					t.Error("expecting error for an unsupported content-encoding")
+				}
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
+func TestServerDoesNotParseStreamedMultipartBadGzipAsRequest(t *testing.T) {
+	t.Parallel()
+
+	// gzip.NewReader reads the 10-byte header before it rejects the bad magic,
+	// so the smuggled request starts right after those 10 bytes.
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := "0123456789" + smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\n"+
+			"Host: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Content-Encoding: gzip\r\n"+
+			"Content-Length: %d\r\n\r\n%s",
+		len(body), body,
+	)
+
+	var paths []string
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1, // Force RequestBodyStream.
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			if string(ctx.Path()) == "/first" {
+				if _, err := ctx.MultipartForm(); err == nil {
+					t.Error("expecting error for a malformed gzip body")
+				}
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
 func TestServerGetWithContent(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -1933,6 +1933,84 @@ func TestServerDoesNotParseStreamedMultipartMalformedChunkAsRequest(t *testing.T
 	}
 }
 
+func TestServerClosesAfterAnyStreamedMultipartDrainError(t *testing.T) {
+	t.Parallel()
+
+	// The inline drain fails on the invalid chunk-size byte, but the terminating
+	// chunk right after it lets the deferred drain resume and return cleanly.
+	// The first framing failure has to stay sticky, otherwise the connection is
+	// reused and the bytes after the terminator run as the next request.
+	form := "--x\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--x--\r\n"
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := fmt.Sprintf("%x\r\n%s\r\n", len(form), form) +
+		"\x00" + "0\r\n\r\n" + smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\nHost: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Transfer-Encoding: chunked\r\n\r\n%s",
+		body,
+	)
+
+	var paths []string
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1,
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			if string(ctx.Path()) == "/first" {
+				_ = ctx.FormValue("x")
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
+func TestServerPreservesMultipartDrainErrorAcrossTimeoutResponse(t *testing.T) {
+	t.Parallel()
+
+	// TimeoutErrorWithCode swaps out ctx after the handler, so the drain error
+	// has to be read off the original request before the swap; otherwise the
+	// close decision sees a fresh context and reuses the connection.
+	form := "--x\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--x--\r\n"
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := fmt.Sprintf("%x\r\n%s\r\n", len(form), form) + "\x00" + smuggled
+
+	rw := &oneByteReadWriter{}
+	fmt.Fprintf(&rw.r,
+		"POST /first HTTP/1.1\r\nHost: x\r\n"+
+			"Content-Type: multipart/form-data; boundary=x\r\n"+
+			"Transfer-Encoding: chunked\r\n\r\n%s",
+		body,
+	)
+
+	var paths []string
+	s := Server{
+		StreamRequestBody:            true,
+		DisablePreParseMultipartForm: true,
+		MaxRequestBodySize:           1,
+		Handler: func(ctx *RequestCtx) {
+			path := string(ctx.Path())
+			paths = append(paths, path)
+			if path == "/first" {
+				_ = ctx.FormValue("x")
+				ctx.TimeoutErrorWithCode("timeout", StatusRequestTimeout)
+			}
+		},
+	}
+
+	_ = s.ServeConn(rw)
+	if len(paths) != 1 {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+}
+
 func TestServerGetWithContent(t *testing.T) {
 	t.Parallel()
 

--- a/streaming.go
+++ b/streaming.go
@@ -77,6 +77,10 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 	n, err = rs.reader.Read(p)
 	rs.totalBytesRead += n
 	if err != nil {
+		if err == io.EOF && rs.totalBytesRead < rs.header.ContentLength() {
+			// The peer stopped sending before Content-Length was reached.
+			err = io.ErrUnexpectedEOF
+		}
 		return n, err
 	}
 


### PR DESCRIPTION
`Repro`: a `multipart/form-data` POST whose declared body carries on past the closing boundary, with a second request line padded to land exactly where the parser stops reading.

`POST /first HTTP/1.1\r\nHost: x\r\nContent-Type: multipart/form-data; boundary=X\r\nContent-Length: 6100\r\n\r\n--X\r\nContent-Disposition: form-data; name="a"\r\n\r\n1\r\n--X--\r\n<pad>GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n`

`Expected`: one request. Everything inside `Content-Length` is body, not a message.

`Actual`: a `Server` with default settings runs the handler twice, for `/first` and then for `/smuggled`.

1. `readMultipartForm` gives `io.LimitReader(r, contentLength)` to `mime/multipart`, but `ReadForm` returns the moment it sees `--X--`, leaving the remaining declared body bytes in the connection reader. Nothing consumed them, so the serve loop parsed the next request straight out of the epilogue. The stop offset is deterministic, which is what makes the padding above line up.
2. The framing checks all sit in the header parsers, and the headers here are unambiguous: one `Content-Length`, no `Transfer-Encoding`. So a front end sees a single well-formed request while fasthttp executes two. Draining belongs in `readMultipartForm` because that is where the declared size is known.

Not reachable with `DisablePreParseMultipartForm`, or when `Content-Encoding` is set.
