### PR TITLE
fix: drop zeroed entries from the perIPConnCounter map

### DIFF
--- a/peripconn.go
+++ b/peripconn.go
@@ -31,8 +31,12 @@ func (cc *perIPConnCounter) Unregister(ip uint32) {
 		// developer safeguard
 		panic("BUG: perIPConnCounter.Register() wasn't called")
 	}
-	n := max(cc.m[ip]-1, 0)
-	cc.m[ip] = n
+	// Drop the entry, otherwise the map keeps a key per distinct client IP forever.
+	if n := cc.m[ip] - 1; n > 0 {
+		cc.m[ip] = n
+	} else {
+		delete(cc.m, ip)
+	}
 }
 
 type perIPConn struct {

--- a/peripconn_test.go
+++ b/peripconn_test.go
@@ -22,6 +22,11 @@ func TestPerIPConnCounter(t *testing.T) {
 		t.Fatalf("Unexpected counter value=%d. Expected 1", n)
 	}
 
+	cc.Unregister(123)
+	if n := cc.Register(123); n != 99 {
+		t.Fatalf("Unexpected counter value=%d. Expected 99", n)
+	}
+
 	for i := 1; i < 100; i++ {
 		cc.Unregister(123)
 	}
@@ -32,4 +37,8 @@ func TestPerIPConnCounter(t *testing.T) {
 		t.Fatalf("Unexpected counter value=%d. Expected 1", n)
 	}
 	cc.Unregister(123)
+
+	if len(cc.m) != 0 {
+		t.Fatalf("Unexpected counter map size=%d. Expected 0", len(cc.m))
+	}
 }


### PR DESCRIPTION
`perIPConnCounter.Unregister` wrote a 0 count back into the map instead of deleting the entry:

```go
n := max(cc.m[ip]-1, 0)
cc.m[ip] = n
```

With `Server.MaxConnsPerIP > 0` the map therefore gains a key for every distinct client IP the server has ever seen, and never loses one. Go maps do not shrink their bucket array on delete either, but this at least bounds the table by the peak number of concurrently connected distinct IPs instead of by every IP ever seen.

After the change `Register` still reads a missing key as 0, both paths hold `cc.lock`, and the nil-map developer safeguard still sees a map created by `Register`. A spurious extra `Unregister` used to *create* a phantom zero entry (`max(-1, 0)` stored back); now it deletes an absent key, which is a no-op.

`TestPerIPConnCounter` pins both halves of the behaviour: that a single `Unregister` decrements by exactly one, and that the map is empty once all connections are gone. The first assertion matters because a bare `delete(cc.m, ip)` would satisfy the second one while silently breaking `MaxConnsPerIP` for any IP with more than one live connection.