### PR TITLE
perf: skip the unusable per-call file cache in ServeFS

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -209,6 +209,10 @@ func serveFS(ctx *RequestCtx, filesystem fs.FS, path string, literal bool) {
 		CompressBrotli:     true,
 		CompressZstd:       true,
 		AcceptByteRange:    true,
+		// This FS serves exactly one request, so its cache can never be hit
+		// again. Skipping it drops a cleaner goroutine per call and releases the
+		// file when the response body closes instead of at GC time.
+		SkipCache: true,
 	}
 	handler := f.NewRequestHandler()
 
@@ -602,6 +606,12 @@ func (fs *FS) initRequestHandler() {
 
 	if h.filesystem == nil {
 		h.filesystem = &osFS{} // It provides os.Open and os.Stat
+	}
+
+	if fs.SkipCache {
+		// noopCacheManager.Close is a no-op, so there is nothing to stop.
+		fs.h = h.handleRequest
+		return
 	}
 
 	// Use a >16-byte backing array so the cleanup owner doesn't fall under

--- a/fs_fs_test.go
+++ b/fs_fs_test.go
@@ -56,7 +56,7 @@ func TestFSServeFileHead(t *testing.T) {
 	}
 }
 
-func TestServeFSDoesNotLeakCacheCleaner(t *testing.T) {
+func TestServeFSCreatesNoCacheCleaner(t *testing.T) {
 	testFS := fstest.MapFS{
 		"index.txt": {Data: []byte("body")},
 	}
@@ -77,22 +77,52 @@ func TestServeFSDoesNotLeakCacheCleaner(t *testing.T) {
 		}
 	}
 
+	// ServeFS skips the cache, so the expected delta is 0 without any GC. The
+	// slack absorbs unrelated test goroutines dying around the sample.
+	if leaked := runtime.NumGoroutine() - before; leaked > 3 {
+		t.Fatalf("ServeFS started %d cache cleaner goroutines; expected none", leaked)
+	}
+}
+
+func TestFSCacheCleanerIsReclaimed(t *testing.T) {
+	testFS := fstest.MapFS{
+		"index.txt": {Data: []byte("body")},
+	}
+
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	const handlers = 25
+	for range handlers {
+		h := (&FS{FS: testFS, AllowEmptyRoot: true}).NewRequestHandler()
+
+		var ctx RequestCtx
+		var req Request
+		req.SetRequestURI("http://foobar.com/index.txt")
+		ctx.Init(&req, nil, TestLogger{t})
+
+		h(&ctx)
+		if ctx.Response.StatusCode() != StatusOK {
+			t.Fatalf("unexpected status code %d. expecting %d", ctx.Response.StatusCode(), StatusOK)
+		}
+	}
+
+	// A cached FS does start a cleaner, so this one has to wait for the cleanup
+	// registered in initRequestHandler to run.
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		runtime.GC()
 		runtime.Gosched()
 
-		after := runtime.NumGoroutine()
-		if leaked := after - before; leaked <= 3 {
+		if leaked := runtime.NumGoroutine() - before; leaked <= 3 {
 			return
 		}
 
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	after := runtime.NumGoroutine()
-	if leaked := after - before; leaked > 3 {
-		t.Fatalf("ServeFS left %d persistent goroutines; expected no cache cleaner goroutine leak", leaked)
+	if leaked := runtime.NumGoroutine() - before; leaked > 3 {
+		t.Fatalf("cache cleaners of %d discarded handlers were not reclaimed; %d goroutines left", handlers, leaked)
 	}
 }
 


### PR DESCRIPTION
`serveFS`, the shared body of `ServeFS` and `ServeFSLiteral`, builds a fresh `FS` per call and serves exactly one request with it, so the cache that `FS` sets up can never be hit again. Every call still paid for an `inMemoryCacheManager`: four maps, a channel, and a cleaner goroutine with a ticker.

`runtime.AddCleanup` did stop them, so this was never an unbounded leak, but it only happens at GC time, so under load they accumulate between collections.

The second effect matters more than the allocations: `inMemoryCacheManager.DecReadersCount` only releases a file once the manager is closed, so the served file's descriptor stayed open until GC. `noopCacheManager` releases at `readersCount == 0`, i.e. when the response body stream closes.

While here, `initRequestHandler` no longer registers a cleanup when `SkipCache` is set, since `noopCacheManager.Close` is a no-op. That drops the cleanup owner allocation and the `KeepAlive` wrapper for the four pre-existing `SkipCache` users as well. The guard sits after the `h.filesystem == nil` default, so `&FS{SkipCache: true}` with a nil `FS` keeps working.

`ServeFile` is deliberately unchanged: it uses the shared package-level `rootFS` behind a `sync.Once`, where the cache is genuinely reused across requests.

### Numbers

A `ServeFS` benchmark over `fstest.MapFS`, benchstat n=10, Apple M2 Pro:

```
sec/op      3.832µ ± 2%   ->  1.963µ ± 7%   -48.78% (p=0.000)
B/op        4.055Ki ± 0%  ->  3.039Ki ± 0%  -25.05% (p=0.000)
allocs/op   47.00 ± 0%    ->  31.00 ± 0%    -34.04% (p=0.000)
```

The benchmark was a temporary harness and is not part of this PR; happy to add it if you want it in the tree.

### Tests

`TestServeFSDoesNotLeakCacheCleaner` is renamed to `TestServeFSCreatesNoCacheCleaner` and no longer needs its GC retry loop, since no cleaner goroutine is created at all.

Because that test can no longer observe the `runtime.AddCleanup` reclamation path, a sibling `TestFSCacheCleanerIsReclaimed` was added that builds real cached handlers and keeps the GC loop, so that machinery stays covered for every user-built `FS`.

Verified by mutation: removing the `AddCleanup` call fails the new test, and removing `SkipCache` fails the renamed one.