### PR TITLE
test: scale short timeouts with testTimeout to reduce -race flakiness

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -87,7 +87,7 @@ func TestServerCRNLAfterPost(t *testing.T) {
 		Handler: func(ctx *RequestCtx) {
 		},
 		Logger:      &testLogger{},
-		ReadTimeout: time.Millisecond * 100,
+		ReadTimeout: testTimeout(time.Millisecond * 100),
 	}
 
 	ln := fasthttputil.NewInmemoryListener()
@@ -479,7 +479,7 @@ func TestServerErrSmallBuffer(t *testing.T) {
 	var serverErr error
 	select {
 	case serverErr = <-ch:
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(testTimeout(200 * time.Millisecond)):
 		t.Fatal("timeout")
 	}
 
@@ -3262,8 +3262,10 @@ func testRequestCtxHijack(t *testing.T, s *Server) {
 
 				return
 			}
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(testTimeout(200 * time.Millisecond)):
 			t.Errorf("timeout")
+
+			return
 		}
 	}
 
@@ -3356,7 +3358,7 @@ func TestRequestCtxHijackNoResponse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error from hijack: %v", err)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(testTimeout(100 * time.Millisecond)):
 		t.Fatal("timeout")
 	}
 
@@ -3656,7 +3658,7 @@ func TestServerGetOnly(t *testing.T) {
 		if err != ErrGetOnly {
 			t.Fatalf("Unexpected error from serveConn: %v. Expecting %v", err, ErrGetOnly)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(testTimeout(100 * time.Millisecond)):
 		t.Fatal("timeout")
 	}
 
@@ -4324,7 +4326,7 @@ func TestShutdownReuse(t *testing.T) {
 		Handler: func(ctx *RequestCtx) {
 			ctx.Success("aaa/bbb", []byte("real response"))
 		},
-		ReadTimeout: time.Millisecond * 100,
+		ReadTimeout: testTimeout(time.Millisecond * 100),
 		Logger:      &testLogger{}, // Ignore log output.
 	}
 	go func() {
@@ -4664,7 +4666,7 @@ func TestStreamRequestBody(t *testing.T) {
 
 	select {
 	case <-next:
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(testTimeout(500 * time.Millisecond)):
 		t.Fatal("part1 timeout")
 	}
 
@@ -4680,7 +4682,7 @@ func TestStreamRequestBody(t *testing.T) {
 		if err != nil && err.Error() != fasthttputil.ErrConnectionClosed.Error() {
 			t.Fatalf("Unexpected error from serveConn: %v", err)
 		}
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(testTimeout(500 * time.Millisecond)):
 		t.Fatal("part2 timeout")
 	}
 }
@@ -4716,7 +4718,7 @@ func TestStreamRequestBodyExceedMaxSize(t *testing.T) {
 
 	select {
 	case <-next:
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(testTimeout(500 * time.Millisecond)):
 		t.Fatal("part1 timeout")
 	}
 
@@ -4729,7 +4731,7 @@ func TestStreamRequestBodyExceedMaxSize(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(testTimeout(500 * time.Millisecond)):
 		t.Fatal("part2 timeout")
 	}
 }


### PR DESCRIPTION
The `test (1.26.x, windows-latest)` job runs `go test -race -shuffle=on ./...` and intermittently fails on hardcoded sub-second budgets that account for neither the race detector nor a slow runner. It has hit at least three unrelated PRs recently, on different tests each time.

### Root cause, for `TestShutdownReuse`

This one is provable rather than guessed.

`InmemoryListener.DialWithLocalAddr` returns only once the server has accepted the connection: it blocks on `<-accepted`, and only `Accept` closes that channel. The worker that received the connection then arms the first-byte read deadline immediately, `SetReadDeadline(now + s.ReadTimeout)`, with `ReadTimeout: 100ms` from the test.

So from a point the test cannot observe, it has 100ms of wall clock to reach its `conn.Write`. When it loses that race the server's read returns `ErrTimeout`, `serveConn` returns, the worker closes the connection, `PipeConns.Close` closes the shared `stopCh`, and the client's `Write` takes the `<-c.pc.stopCh` branch and returns `ErrConnectionClosed`.

That is exactly the reported string, `fasthttputil: connection closed`, and it explains why it is not `ErrInmemoryListenerClosed`: `Accept` is not on that path at all.

Inserting a 150ms stall between `Dial` and `Write` reproduces the CI failure verbatim. With the timeout scaled, the same stall passes under `-race` and still fails without it, which is the expected behaviour of the fix.

`TestServerCRNLAfterPost` has the identical Dial-then-Write shape with the same `ReadTimeout`, so it carries the same exposure and is fixed here too.

### The change

`testTimeout` already exists in the tree and multiplies by 5 under `-race` and by 2 on Windows, so these budgets grow 10x in exactly the job that fails and are unchanged everywhere else. It was only used at six call sites; this adds ten more:

- `TestShutdownReuse`, `TestServerCRNLAfterPost`: the `ReadTimeout` values
- `TestServerGetOnly`, `TestRequestCtxHijackNoResponse`: 100ms
- `TestServerErrSmallBuffer`, `testRequestCtxHijack`: 200ms
- `TestStreamRequestBody`, `TestStreamRequestBodyExceedMaxSize`: 500ms, two sites each

Every site touched is a "wait for something that should arrive" deadline, so the branch is never taken on a passing run and the suite does not get slower. Measured on the affected tests: 1.586s with the change versus 1.502s without, i.e. noise.

Deliberately left alone: the ~112 sites at `time.After(time.Second)` and above, every site that asserts a timeout *does* fire (scaling those would invert their meaning), the benchmark in `server_timing_test.go` (the CI test job never runs it), and `fasthttputil`/`tcplisten` (`testTimeout` is package-local and neither has flaked).

### One unrelated line

`testRequestCtxHijack`'s timeout branch calls `t.Errorf` without returning, and does not increment `count`, so `for count != totalConns` spun and flooded the log instead of failing once. Its two sibling error branches in the same `select` already return. Added the missing `return`.

Full suite green under `-race -shuffle=on`; the affected tests run 25x green under the same flags.