### PR TITLE
fix: don't close the shutdown done channel twice

### DIFF
--- a/server.go
+++ b/server.go
@@ -247,6 +247,10 @@ type Server struct {
 	idleConns map[net.Conn]*atomic.Int64
 	done      chan struct{}
 
+	// Whether done was already closed. A ShutdownWithContext that gives up on
+	// its context leaves it closed but in place, and it must not be closed twice.
+	doneClosed bool
+
 	// Server name for sending in response headers.
 	//
 	// Default server name is used if left blank.
@@ -2068,8 +2072,9 @@ func (s *Server) ShutdownWithContext(ctx context.Context) (err error) {
 
 	lnerr := s.closeListenersLocked()
 
-	if s.done != nil {
+	if s.done != nil && !s.doneClosed {
 		close(s.done)
+		s.doneClosed = true
 	}
 
 	// Closing the listener will make Serve() call Stop on the worker pool.
@@ -2084,6 +2089,7 @@ func (s *Server) ShutdownWithContext(ctx context.Context) (err error) {
 		if open := s.open.Load(); open == 0 {
 			// There may be a pending request to call ctx.Done(). Therefore, we only set it to nil when open == 0.
 			s.done = nil
+			s.doneClosed = false
 			return lnerr
 		}
 		// This is not an optimal solution but using a sync.WaitGroup

--- a/server_test.go
+++ b/server_test.go
@@ -4429,6 +4429,75 @@ func TestCloseIdleConnsKeepsTimestampOwnedByItsConn(t *testing.T) {
 	}
 }
 
+func TestShutdownWithContextTimeoutThenShutdownAgain(t *testing.T) {
+	t.Parallel()
+
+	ln := fasthttputil.NewInmemoryListener()
+	firstInHandler := make(chan struct{})
+	release := make(chan struct{})
+	doneChanged := make(chan bool, 1)
+
+	var served atomic.Int32
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			if served.Add(1) == 1 {
+				done := ctx.Done()
+				close(firstInHandler)
+				<-release
+				doneChanged <- done != ctx.Done()
+
+				return
+			}
+			ctx.Success("aaa/bbb", []byte("real response"))
+		},
+		Logger: &testLogger{},
+	}
+	go func() {
+		_ = s.Serve(ln)
+	}()
+
+	conn, err := ln.Dial()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	<-firstInHandler
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout(100*time.Millisecond))
+	defer cancel()
+	if err := s.ShutdownWithContext(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("unexpected error: %v. Expecting %v", err, context.DeadlineExceeded)
+	}
+
+	// Serving again must not change what the request that is still running
+	// observes, so done stays in place rather than being replaced.
+	ln = fasthttputil.NewInmemoryListener()
+	go func() {
+		_ = s.Serve(ln)
+	}()
+
+	conn, err = ln.Dial()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	verifyResponse(t, bufio.NewReader(conn), StatusOK, "aaa/bbb", "real response")
+
+	close(release)
+	if <-doneChanged {
+		t.Fatal("RequestCtx.Done() changed for the request still running after shutdown timed out")
+	}
+
+	// done is already closed at this point, so this must not close it twice.
+	if err := s.Shutdown(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestShutdownDone(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`ShutdownWithContext` closes `s.done`, then waits for the open connections to drain. When it gives up on its context it returns without clearing `s.done`, so the channel stays closed and still in place.

`Serve` then keeps that closed channel, since it only creates one when `s.done` is nil, and the next `ShutdownWithContext` closes it a second time:

```
panic: close of closed channel
    (*Server).ShutdownWithContext  server.go:2072
    (*Server).Shutdown             server.go:2044
```

The `Serve` in between is required. Without it the retry hits the `s.ln == nil` early return and reports success while a connection is still running.

The fix tracks whether the channel was already closed, so the second close is skipped. The success path clears the flag along with the channel, so a shutdown that does drain leaves the server as it was. All of it sits under `s.mu`, which already guards every write to `s.done`.

`s.done` itself is deliberately left in place rather than replaced. The request that caused the timeout is still running, and `RequestCtx.Done()` reads `ctx.s.done`, so swapping the channel would hand that request a different one on its next call. The test pins both ends: it panics if the second close comes back, and it fails the `Done()` stability check if `Serve` swaps the channel.

Deliberately left open, all older than this change: a `Serve` after a timed out shutdown still hands new requests the already closed channel; the retry without a `Serve` returns nil while a connection is still running; and `s.done = nil` on the success path races with the post-release `Done()` that `RequestCtx.reset()` explicitly permits. Those need a done channel that is stable per request instead of read live from the server.

Full suite green under `-race -shuffle=on` and without `-race`, lint clean with v2.10.1, the new test 40x green under `-race -shuffle=on`.