### PR TITLE
test: return after a failed Dial instead of dereferencing a nil conn

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -272,6 +272,8 @@ func TestServerConnState(t *testing.T) {
 		c, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		br := bufio.NewReader(c)
 		// Send 2 requests on the same connection.
@@ -640,6 +642,8 @@ func TestServerResponseServerHeader(t *testing.T) {
 		c, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		if _, err = c.Write([]byte("GET / HTTP/1.1\r\nHost: aa\r\n\r\n")); err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -721,6 +725,8 @@ func TestServerResponseBodyStream(t *testing.T) {
 		c, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		if _, err = c.Write([]byte("GET / HTTP/1.1\r\nHost: aa\r\n\r\n")); err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -798,6 +804,8 @@ func TestServerDisableKeepalive(t *testing.T) {
 		c, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		if _, err = c.Write([]byte("GET / HTTP/1.1\r\nHost: aa\r\n\r\n")); err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -875,10 +883,14 @@ func TestServerMaxConnsPerIPLimit(t *testing.T) {
 		c1, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		c2, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		br := bufio.NewReader(c2)
 		var resp Response
@@ -976,10 +988,14 @@ func TestServerConcurrencyLimit(t *testing.T) {
 		c1, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		c2, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		br := bufio.NewReader(c2)
 		var resp Response
@@ -1053,6 +1069,8 @@ func TestRejectedRequestsCount(t *testing.T) {
 			_, err := ln.Dial()
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
+
+				return
 			}
 		}
 
@@ -3438,6 +3456,8 @@ func TestTimeoutHandlerSuccess(t *testing.T) {
 			conn, err := ln.Dial()
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
+
+				return
 			}
 			if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -3496,6 +3516,8 @@ func TestTimeoutHandlerTimeout(t *testing.T) {
 			conn, err := ln.Dial()
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
+
+				return
 			}
 			if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -4213,6 +4235,8 @@ func TestShutdown(t *testing.T) {
 		conn, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -4277,6 +4301,8 @@ func TestCloseOnShutdown(t *testing.T) {
 		conn, err := ln.Dial()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+
+			return
 		}
 		if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
 			t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
Thirteen client goroutines in `server_test.go` report a failed `ln.Dial()` with `t.Errorf` and then carry on, so the very next statement writes to a nil `net.Conn`:

```go
conn, err := ln.Dial()
if err != nil {
    t.Errorf("unexpected error: %v", err)
}
if _, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")); err != nil {
```

That is a SIGSEGV, which takes down the whole test binary and hides whatever actually made the Dial fail. `t.Errorf` rather than `t.Fatalf` is correct there, since these run in goroutines, but it needs the matching `return`.

Every one of these goroutines is waited on by a `select` that already carries a `time.After` guard, so returning early turns the crash into the bounded failure the test was written to report, with no risk of hanging on the missing channel send.

Verified by forcing the Dial to fail (closing the listener up front) in `TestShutdown`:

- before: `panic: runtime error: invalid memory address or nil pointer dereference / [signal SIGSEGV]`, entire binary dies
- after: `--- FAIL: TestShutdown (2.10s) server_test.go:4262: shutdown took too long`, the rest of the suite still runs

Affected tests: `TestServerConnState`, `TestServerResponseServerHeader`, `TestServerResponseBodyStream`, `TestServerDisableKeepalive`, `TestServerMaxConnsPerIPLimit`, `TestServerConcurrencyLimit`, `TestRejectedRequestsCount`, `TestTimeoutHandlerSuccess`, `TestTimeoutHandlerTimeout`, `TestShutdown`, `TestCloseOnShutdown`.

Full suite green under `-race -shuffle=on`; the affected tests run 10x green under `-race`.