### PR TITLE
fix: don't recycle an idle timestamp its connection still owns

### DIFF
--- a/server.go
+++ b/server.go
@@ -3147,8 +3147,9 @@ func (s *Server) closeIdleConns() {
 		t := ict.Load()
 		if t != 0 && now-t >= 0 {
 			_ = c.Close()
+			// Don't recycle ict: the connection's own goroutine still holds it
+			// and stores into it, so only that goroutine may return it.
 			delete(s.idleConns, c)
-			idleConnTimePool.Put(ict)
 		}
 	}
 	s.idleConnsMu.Unlock()

--- a/server_test.go
+++ b/server_test.go
@@ -4364,6 +4364,43 @@ func TestShutdownReuse(t *testing.T) {
 	}
 }
 
+func TestCloseIdleConnsKeepsTimestampOwnedByItsConn(t *testing.T) {
+	// Drain the pool so a hit below is unambiguous, and hand everything back
+	// afterwards so concurrent tests keep their pooled counters.
+	var drained []any
+	for {
+		v := idleConnTimePool.Get()
+		if v == nil {
+			break
+		}
+		drained = append(drained, v)
+	}
+	defer func() {
+		for _, v := range drained {
+			idleConnTimePool.Put(v)
+		}
+	}()
+
+	c, peer := net.Pipe()
+	defer c.Close()
+	defer peer.Close()
+
+	// serveConnCounted keeps storing into this counter after closeIdleConns
+	// reaps the connection, so closeIdleConns must not hand it out again.
+	ict := &atomic.Int64{}
+	ict.Store(time.Now().Unix() - 10)
+
+	s := &Server{idleConns: map[net.Conn]*atomic.Int64{c: ict}}
+	s.closeIdleConns()
+
+	if _, ok := s.idleConns[c]; ok {
+		t.Fatal("closeIdleConns did not drop the reaped connection")
+	}
+	if v := idleConnTimePool.Get(); v == any(ict) {
+		t.Fatal("closeIdleConns recycled a timestamp that its connection still owns")
+	}
+}
+
 func TestShutdownDone(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`serveConnCounted` takes an `*atomic.Int64` out of `idleConnTimePool` and keeps it in a local as well as in `s.idleConns` (`server.go:2340-2348`). It then stores into that local **without** holding `idleConnsMu`, at `server.go:2435` and `server.go:2728`.

`closeIdleConns` reaps the map entry and returns the very same object to the pool:

```go
if t != 0 && now-t >= 0 {
    _ = c.Close()
    delete(s.idleConns, c)
    idleConnTimePool.Put(ict)   // the serving goroutine still holds ict
}
```

From that point two goroutines own it. If another connection `Get`s it in between, the first goroutine's next store lands in the new connection's counter:

- `Store(0)` at `:2435` makes that connection look permanently active, so the `t != 0` guard never passes and `Shutdown` waits for it until it dies of `ReadTimeout`/`IdleTimeout`
- `Store(ctx.time.Unix())` at `:2728` writes an already-past timestamp, so the connection is closed on the next 100ms tick, possibly mid-request, which contradicts shutting down "without interrupting any active connections"

Only the owning goroutine may return the counter, so the `Put` here has to go. The object is then reachable only from that goroutine's local and simply becomes garbage; its own cleanup at `:2749` no longer finds the map entry, so nothing is returned twice either. The cost is one unrecycled 8 byte counter per connection reaped during shutdown.

### Honest scoping

`closeIdleConns` has exactly one caller, `ShutdownWithContext`, so the window is shutdown-only, and doing damage needs a second connection to claim the object in the same instant. It is quite possibly never been hit in practice. What makes it worth a patch is that the line being defended only recycles 8 bytes while the process is tearing down.

Worth stating for whoever reads this next: **the race detector cannot see this class of bug**, because every conflicting access goes through `atomic.Int64`. That is why it has been here since #1986 (2025-04-02) without a single red CI run.

I did not go further and remove the pool entirely, even though that is the more thorough deletion. It is free on time but takes `BenchmarkServerGet1ReqPerConn` from 0 allocs/op to 1 allocs/op, which is its own discussion.

### Test

`TestCloseIdleConnsKeepsTimestampOwnedByItsConn` asserts the ownership invariant directly rather than trying to win the race: after `closeIdleConns` reaps a connection, its counter must not come back out of the pool. It drains the pool first so a hit is unambiguous and hands everything back afterwards, so the `TestAllocation*` tests that also exercise this pool are unaffected. Verified: fails with the `Put` restored, and the suite is green with and without `-race`, shuffled, repeatedly.