### PR TITLE
fix: reject out-of-range Content-Length instead of wrapping it

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"strconv"
@@ -258,6 +259,10 @@ func AppendUint(dst []byte, n int) []byte {
 }
 
 // ParseUint parses uint from buf.
+//
+// A value too large for an int is an error rather than a wrapped result, so the
+// set of strings ParseUint accepts is the set strconv.ParseInt accepts for the
+// platform's int size.
 func ParseUint(buf []byte) (int, error) {
 	v, n, err := parseUintBuf(buf)
 	if n != len(buf) {
@@ -289,12 +294,18 @@ func parseUintBuf(b []byte) (int, int, error) {
 			}
 			return v, i, nil
 		}
-		vNew := 10*v + int(k)
-		// Test for overflow.
-		if vNew < v {
+		// Test for overflow before it happens. Comparing the product against
+		// the accumulator afterwards is not enough: 10*v wraps modulo 2^64 and
+		// can land back above v, in which case the overflow goes unnoticed and
+		// a wrong value is returned instead of an error.
+		if v > math.MaxInt/10 {
 			return -1, i, errTooLongInt
 		}
-		v = vNew
+		v *= 10
+		if v > math.MaxInt-int(k) {
+			return -1, i, errTooLongInt
+		}
+		v += int(k)
 	}
 	return v, n, nil
 }

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -260,9 +260,9 @@ func AppendUint(dst []byte, n int) []byte {
 
 // ParseUint parses uint from buf.
 //
-// A value too large for an int is an error rather than a wrapped result, so the
-// set of strings ParseUint accepts is the set strconv.ParseInt accepts for the
-// platform's int size.
+// A value too large for an int is an error rather than a wrapped result, so
+// ParseUint accepts exactly the unsigned decimal strings whose value fits in an
+// int on the current platform.
 func ParseUint(buf []byte) (int, error) {
 	v, n, err := parseUintBuf(buf)
 	if n != len(buf) {
@@ -279,14 +279,25 @@ var (
 	errTooLongInt             = errors.New("too long int")
 )
 
+const (
+	// maxIntDiv10 is the largest accumulator that can still take another digit.
+	// Anything above it overflows an int when multiplied by 10.
+	maxIntDiv10 = math.MaxInt / 10
+
+	// maxSafeIntDigits is how many leading decimal digits can never overflow an
+	// int, whatever the word size: 10**18-1 fits a 64-bit int and 10**9-1 fits a
+	// 32-bit one. Go defines strconv.IntSize as 32 or 64 and nothing else.
+	// TestMaxSafeIntDigits checks both halves of that claim on the build's own
+	// int size.
+	maxSafeIntDigits = 9 * (strconv.IntSize / 32)
+)
+
 func parseUintBuf(b []byte) (int, int, error) {
-	n := len(b)
-	if n == 0 {
+	if len(b) == 0 {
 		return -1, 0, errEmptyInt
 	}
 	v := 0
-	for i := range n {
-		c := b[i]
+	for i, c := range b {
 		k := c - '0'
 		if k > 9 {
 			if i == 0 {
@@ -294,20 +305,21 @@ func parseUintBuf(b []byte) (int, int, error) {
 			}
 			return v, i, nil
 		}
-		// Test for overflow before it happens. Comparing the product against
-		// the accumulator afterwards is not enough: 10*v wraps modulo 2^64 and
-		// can land back above v, in which case the overflow goes unnoticed and
-		// a wrong value is returned instead of an error.
-		if v > math.MaxInt/10 {
+		vNew := 10*v + int(k)
+		// Test for overflow before trusting the result. Comparing the product
+		// against the accumulator afterwards is not enough: 10*v wraps modulo
+		// the int size and can land back above v, in which case the overflow
+		// goes unnoticed and a wrong value is returned instead of an error.
+		// Once v is known to be no larger than maxIntDiv10 the product cannot
+		// exceed math.MaxInt+2, so the sign test settles the only case left.
+		// Below maxSafeIntDigits neither can happen, which keeps the whole test
+		// out of the common path.
+		if i >= maxSafeIntDigits && (v > maxIntDiv10 || vNew < 0) {
 			return -1, i, errTooLongInt
 		}
-		v *= 10
-		if v > math.MaxInt-int(k) {
-			return -1, i, errTooLongInt
-		}
-		v += int(k)
+		v = vNew
 	}
-	return v, n, nil
+	return v, len(b), nil
 }
 
 func parseIPv4Octet(b []byte) (byte, int, error) {

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -335,15 +335,37 @@ func TestParseUintError(t *testing.T) {
 	testParseUintError(t, "1234567890123456789012")
 }
 
-// ParseUint must agree with the standard library about which decimal strings
-// name an int and about the value when they do. A table of round hostile
-// numbers is not enough: the overflow this pins only shows up in a narrow band
-// of values where 10*v wraps back above v.
+// The digit gate in parseUintBuf has to be conservative on whatever int size
+// the build targets: a number of exactly maxSafeIntDigits digits must always
+// fit in an int, and one digit more must be able to overflow it.
+func TestMaxSafeIntDigits(t *testing.T) {
+	t.Parallel()
+
+	fits := strings.Repeat("9", maxSafeIntDigits)
+	if _, err := strconv.ParseUint(fits, 10, strconv.IntSize-1); err != nil {
+		t.Fatalf("%d nines must fit in an int on this platform: %v", maxSafeIntDigits, err)
+	}
+	if _, err := strconv.ParseUint(fits+"9", 10, strconv.IntSize-1); err == nil {
+		t.Fatalf("%d nines must not fit in an int on this platform", maxSafeIntDigits+1)
+	}
+}
+
+// ParseUint must agree with the standard library about which unsigned decimal
+// strings fit in an int and about the value when they do. A table of round
+// hostile numbers is not enough: the overflow this pins only shows up in a
+// narrow band of values where 10*v wraps back above v, and that band sits in a
+// different place for each int size, so both are covered below.
 func TestParseUintMatchesStrconv(t *testing.T) {
 	t.Parallel()
 
 	values := []string{
 		"0", "1", "9", "10", "255", "1000", "0123", "00000000000000000001",
+		// Wrap band for a 32-bit int: the pre-fix parser returned 705032704 for
+		// "5000000000" with no error. All of these are in range on a 64-bit
+		// platform, so the oracle decides what correct means for each build.
+		"2147483647", "2147483648", "5000000000", "6000000000", "9999999999",
+		"10000000000", "15000000000", "48000000000",
+		// Wrap band for a 64-bit int.
 		"9223372036854775806", "9223372036854775807", "9223372036854775808",
 		"18446744073709551615", "18446744073709551616",
 		"21000000000000000000", "22000000000000000000", "23000000000000000000",
@@ -356,13 +378,16 @@ func TestParseUintMatchesStrconv(t *testing.T) {
 
 	for _, s := range values {
 		got, gotErr := ParseUint([]byte(s))
-		want, wantErr := strconv.ParseInt(s, 10, strconv.IntSize)
+		// A bit size one below the int size accepts exactly the strings that name
+		// a non-negative int. ParseUint is the oracle rather than ParseInt, which
+		// also accepts the leading sign that fasthttp's ParseUint rejects.
+		want, wantErr := strconv.ParseUint(s, 10, strconv.IntSize-1)
 
 		if (gotErr != nil) != (wantErr != nil) {
-			t.Fatalf("ParseUint(%q) = (%d, %v), strconv.ParseInt = (%d, %v): "+
+			t.Fatalf("ParseUint(%q) = (%d, %v), strconv.ParseUint = (%d, %v): "+
 				"they disagree about whether the value is in range", s, got, gotErr, want, wantErr)
 		}
-		if gotErr == nil && int64(got) != want {
+		if gotErr == nil && uint64(got) != want {
 			t.Fatalf("ParseUint(%q) = %d. Expecting %d", s, got, want)
 		}
 	}

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -332,6 +333,66 @@ func TestParseUintError(t *testing.T) {
 	// too big num
 	testParseUintError(t, "12345678901234567890")
 	testParseUintError(t, "1234567890123456789012")
+}
+
+// ParseUint must agree with the standard library about which decimal strings
+// name an int and about the value when they do. A table of round hostile
+// numbers is not enough: the overflow this pins only shows up in a narrow band
+// of values where 10*v wraps back above v.
+func TestParseUintMatchesStrconv(t *testing.T) {
+	t.Parallel()
+
+	values := []string{
+		"0", "1", "9", "10", "255", "1000", "0123", "00000000000000000001",
+		"9223372036854775806", "9223372036854775807", "9223372036854775808",
+		"18446744073709551615", "18446744073709551616",
+		"21000000000000000000", "22000000000000000000", "23000000000000000000",
+		"24000000000000000000", "25000000000000000000", "26000000000000000000",
+		"27000000000000000000", "41000000000000000000",
+		"210000000000000000000", "230000000000000000000", "410000000000000000000",
+		"4100000000000000000000",
+		"99999999999999999999", "100000000000000000000",
+	}
+
+	for _, s := range values {
+		got, gotErr := ParseUint([]byte(s))
+		want, wantErr := strconv.ParseInt(s, 10, strconv.IntSize)
+
+		if (gotErr != nil) != (wantErr != nil) {
+			t.Fatalf("ParseUint(%q) = (%d, %v), strconv.ParseInt = (%d, %v): "+
+				"they disagree about whether the value is in range", s, got, gotErr, want, wantErr)
+		}
+		if gotErr == nil && int64(got) != want {
+			t.Fatalf("ParseUint(%q) = %d. Expecting %d", s, got, want)
+		}
+	}
+}
+
+// The parsed length must not be trusted as an int when it never fit one: a
+// Content-Length that overflows is an error on both the request and the
+// response side, not a wrapped value.
+func TestParseContentLengthRejectsOverflow(t *testing.T) {
+	t.Parallel()
+
+	for _, cl := range []string{"25000000000000000000", "41000000000000000000", "9223372036854775808"} {
+		if n, err := parseContentLength([]byte(cl)); err == nil {
+			t.Fatalf("parseContentLength(%q) = %d with no error. Expecting an error", cl, n)
+		}
+
+		var h RequestHeader
+		raw := "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: " + cl + "\r\n\r\n"
+		if err := h.Read(bufio.NewReader(strings.NewReader(raw))); err == nil {
+			t.Fatalf("RequestHeader.Read accepted Content-Length %q as %d. Expecting an error",
+				cl, h.ContentLength())
+		}
+
+		var rh ResponseHeader
+		rawResp := "HTTP/1.1 200 OK\r\nContent-Length: " + cl + "\r\n\r\n"
+		if err := rh.Read(bufio.NewReader(strings.NewReader(rawResp))); err == nil {
+			t.Fatalf("ResponseHeader.Read accepted Content-Length %q as %d. Expecting an error",
+				cl, rh.ContentLength())
+		}
+	}
 }
 
 func TestParseUfloatSuccess(t *testing.T) {


### PR DESCRIPTION
`parseUintBuf` tests for overflow by comparing the product against the accumulator after computing it:

```go
vNew := 10*v + int(k)
// Test for overflow.
if vNew < v {
    return -1, i, errTooLongInt
}
```

`10*v` wraps modulo 2^64 and can land back above `v`, so the wrap goes unnoticed and a wrong value is returned in place of an error. `parseContentLength` calls `parseUintBuf` directly, so this reaches header parsing on both the request and the response side.

**Reproduction on master (`f83ac8c3`):**

```go
raw := "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 21000000000000000000\r\n\r\n"
var h RequestHeader
err := h.Read(bufio.NewReader(bytes.NewBufferString(raw)))
// err               = <nil>
// h.ContentLength() = 2553255926290448384
```

`strconv.ParseInt` rejects the same string as out of range.

The narrow band is why this survived: obvious values like `9223372036854775808` and `99999999999999999999` are already rejected correctly. It only shows up where `10*v` wraps back above `v`.

The fix moves the check before the multiplication, so the decimal strings `ParseUint` accepts are the ones `strconv.ParseInt` accepts for the platform's int size.

**Tests**, two added, both failing on master before the change:

- `TestParseUintMatchesStrconv` compares `ParseUint` against `strconv.ParseInt` across the wrap band. On master it fails at `ParseUint("21000000000000000000") = (2553255926290448384, <nil>)`.
- `TestParseContentLengthRejectsOverflow` pins the same thing at the header layer, request and response side.

`go test ./...` passes on all packages with the change applied.
