### PR TITLE
only treat "//" in URI.Update as an authority after a scheme

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -404,6 +404,24 @@ func isValidScheme(scheme []byte) bool {
 	return true
 }
 
+// isAuthorityDelimiter reports whether the "//" at index n in uri introduces an
+// authority. Per RFC 3986 that is only the case for a network-path reference,
+// which starts with "//", or when the "//" is preceded by a scheme and a colon.
+// Anywhere else the "//" belongs to a path or to a query, so "a//b" is a
+// relative path and not scheme "a" with host "b".
+func isAuthorityDelimiter(uri []byte, n int) bool {
+	if n == 0 {
+		return true
+	}
+	scheme := uri[:n]
+	if scheme[len(scheme)-1] != ':' {
+		return false
+	}
+	// splitHostURI also accepts the empty scheme in "://host".
+	scheme = scheme[:len(scheme)-1]
+	return len(scheme) == 0 || isValidScheme(scheme)
+}
+
 // parseHost parses host as an authority without user
 // information. That is, as host[:port].
 //
@@ -807,7 +825,7 @@ func (u *URI) updateBytes(newURI, buf []byte) []byte {
 	}
 
 	n := bytes.Index(newURI, strSlashSlash)
-	if n >= 0 {
+	if n >= 0 && isAuthorityDelimiter(newURI, n) {
 		// absolute uri
 		var b [32]byte
 		schemeOriginal := b[:0]

--- a/uri_test.go
+++ b/uri_test.go
@@ -201,6 +201,12 @@ func TestURIUpdate(t *testing.T) {
 	testURIUpdate(t, "http://example.net/dir/path1.html", "//example.com/dir/path2.html", "http://example.com/dir/path2.html")
 	// host with port
 	testURIUpdate(t, "http://example.net/", "//example.com:8080/", "http://example.com:8080/")
+
+	// "//" that isn't preceded by a scheme stays part of the reference
+	testURIUpdate(t, "http://example.net/dir/path1.html", "https//example.com/x", "http://example.net/dir/https/example.com/x")
+	testURIUpdate(t, "http://example.net/dir/path1.html", "a//b", "http://example.net/dir/a/b")
+	testURIUpdate(t, "http://example.net/dir/path1.html", "/a//b", "http://example.net/a/b")
+	testURIUpdate(t, "http://example.net/dir/path1.html?p=1", "?q=//example.com", "http://example.net/dir/path1.html?q=//example.com")
 }
 
 func TestURIRejectsMixedBracketHost(t *testing.T) {


### PR DESCRIPTION
Repro: `ctx.Redirect("https//evil.com/", 302)` on a request to `http://good.example/dir/page`.
Expected: `Location: http://good.example/dir/https/evil.com/`, which is what `net/url` `ResolveReference` gives for the same pair.
Actual: `Location: https://evil.com/`.

Cause: `updateBytes` calls a reference absolute whenever `bytes.Index(newURI, strSlashSlash)` matches anywhere in it, so a relative reference holding no colon at all is re-parsed as scheme plus authority. `/a//b` and `?q=//x` land in the same branch and come back as `http:///a/b` and `http:///`, with the base host dropped. `getRedirectURL` resolves `Location` headers through the same call, so the client sees it too.

Fix: only take the `//` as an authority delimiter at index 0 or directly after a valid scheme and a colon.

`splitHostURI` is left as is. Its callers hand it something they already assert is a URI, and its behaviour for `://host` and for a malformed scheme is pinned by existing tests.