### PR TITLE
Add native experimental HTTP/2 client and server

### DIFF
--- a/.github/workflows/h2spec.yml
+++ b/.github/workflows/h2spec.yml
@@ -1,0 +1,34 @@
+name: HTTP/2 conformance
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  h2spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: 1.26.x
+      - name: Download h2spec 2.6.0
+        run: |
+          curl --fail --location --silent --show-error \
+            https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz \
+            --output /tmp/h2spec.tar.gz
+          tar -xzf /tmp/h2spec.tar.gz -C /tmp
+      - name: Run applicable RFC 7540 and RFC 7541 cases
+        run: |
+          go run ./http2/h2specserver -addr 127.0.0.1:8080 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+          for attempt in $(seq 1 50); do
+            if (echo > /dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+              break
+            fi
+            sleep 0.1
+          done
+          /tmp/h2spec --host 127.0.0.1 --port 8080 --strict

--- a/README.md
+++ b/README.md
@@ -40,6 +40,51 @@ connections per physical server.
 
 [FAQ](#faq)
 
+## Experimental HTTP/2
+
+The `github.com/valyala/fasthttp/http2` package provides opt-in, native
+HTTP/2 server and client support. Its API remains experimental for at least
+two fasthttp minor releases. Programs that don't configure the package stay
+on the existing HTTP/1 path.
+
+```go
+server := &fasthttp.Server{Handler: handler}
+if err := http2.ConfigureServer(server, http2.ServerConfig{}); err != nil {
+    log.Fatal(err)
+}
+log.Fatal(server.ListenAndServeTLS(":8443", "cert.pem", "key.pem"))
+```
+
+`ConfigureServer` enables TLS ALPN `h2` and cleartext prior-knowledge
+detection on the same listener. A dedicated cleartext HTTP/2 listener can use
+`http2.ServeConn`. The obsolete `h2c` HTTP/1 Upgrade handshake is deliberately
+not supported.
+
+```go
+client := &fasthttp.HostClient{
+    Addr:  "example.com:443",
+    IsTLS: true,
+}
+if err := http2.ConfigureHostClient(client, http2.ClientConfig{}); err != nil {
+    log.Fatal(err)
+}
+```
+
+TLS clients prefer HTTP/2 by default and reuse the already negotiated
+connection when the server selects HTTP/1.1. `RequireHTTP2` rejects that
+fallback. Cleartext HTTP/2 must be explicitly enabled with `PriorKnowledge`;
+it is never probed against an ordinary cleartext HTTP/1 origin.
+
+Server push and RFC 8441 extended CONNECT are implemented but disabled by
+default. Extended CONNECT uses `RequestCtx.AcceptStream` and
+`HostClient.OpenStream`; it doesn't change `Hijack`'s physical TCP semantics.
+HTTP/3 is not implemented. The protocol lifecycle and stream APIs avoid
+exposing TCP, HTTP/2 frames, HPACK, or HTTP/2 flow-control details so a future
+QUIC/QPACK transport can remain independent.
+
+The connection ownership, security limits, codec provenance, and HTTP/3
+boundary are documented in [`http2/DESIGN.md`](http2/DESIGN.md).
+
 ## HTTP server performance comparison with [net/http](https://pkg.go.dev/net/http)
 
 In short, fasthttp server is up to 6 times faster than net/http.
@@ -587,7 +632,7 @@ This is an **unsafe** way, the result string and `[]byte` buffer share the same 
   helpers for projects based on fasthttp.
 - [fasthttp-routing](https://github.com/qiangxue/fasthttp-routing) - fast and
   powerful routing package for fasthttp servers.
-- [http2](https://github.com/dgrr/http2) - HTTP/2 implementation for fasthttp.
+- [dgrr/http2](https://github.com/dgrr/http2) - legacy third-party HTTP/2 implementation for fasthttp.
 - [router](https://github.com/fasthttp/router) - a high
   performance fasthttp request router that scales well.
 - [fasthttp-auth](https://github.com/casbin/fasthttp-auth) - Authorization middleware for fasthttp using Casbin.
@@ -637,9 +682,11 @@ This is an **unsafe** way, the result string and `[]byte` buffer share the same 
   - Compare [net/http Request.Body reading](https://pkg.go.dev/net/http#Request)
     to [fasthttp request body reading](https://pkg.go.dev/github.com/valyala/fasthttp#RequestCtx.PostBody).
 
-- _Why fasthttp doesn't support HTTP/2.0 and WebSockets?_
+- _Does fasthttp support HTTP/2.0 and WebSockets?_
 
-  [HTTP/2.0 support](https://github.com/fasthttp/http2) is in progress. [WebSockets](https://github.com/fasthttp/websockets) has been done already.
+  Native, experimental HTTP/2 support is available in the opt-in
+  [`http2`](https://pkg.go.dev/github.com/valyala/fasthttp/http2) package.
+  [WebSockets](https://github.com/fasthttp/websockets) has been done already.
   Third parties also may use [RequestCtx.Hijack](https://pkg.go.dev/github.com/valyala/fasthttp#RequestCtx.Hijack)
   for implementing these goodies.
 
@@ -647,7 +694,7 @@ This is an **unsafe** way, the result string and `[]byte` buffer share the same 
 
   Yes:
 
-  - net/http supports [HTTP/2.0 starting from go1.6](https://pkg.go.dev/golang.org/x/net/http2).
+  - net/http enables its mature HTTP/2 support with less explicit configuration.
   - net/http API is stable, while fasthttp API constantly evolves.
   - net/http handles more HTTP corner cases.
   - net/http can stream both request and response bodies

--- a/client.go
+++ b/client.go
@@ -892,7 +892,9 @@ type HostClient struct {
 
 	connsCount int
 
-	connsLock sync.Mutex
+	connsLock         sync.Mutex
+	connSlotAvailable chan struct{}
+	protocolTransport ProtocolRoundTripper
 
 	addrsLock        sync.Mutex
 	tlsConfigMapLock sync.Mutex
@@ -1597,6 +1599,18 @@ func (c *HostClient) do(req *Request, resp *Response) (bool, error) {
 }
 
 func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error) {
+	if err := c.prepareRequestResponse(req, resp); err != nil {
+		return false, err
+	}
+
+	if c.protocolTransport != nil {
+		ctx := c.newProtocolClientContext(req)
+		return c.protocolTransport.RoundTripWithContext(&ctx, c, req, resp)
+	}
+	return c.transport().RoundTrip(c, req, resp)
+}
+
+func (c *HostClient) prepareRequestResponse(req *Request, resp *Response) error {
 	if req == nil {
 		// for debugging purposes
 		panic("BUG: req cannot be nil")
@@ -1613,7 +1627,7 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 	req.Header.secureErrorLogMessage = c.SecureErrorLogMessage
 
 	if c.IsTLS != req.URI().isHTTPS() {
-		return false, ErrHostClientRedirectToDifferentScheme
+		return ErrHostClientRedirectToDifferentScheme
 	}
 
 	atomic.StoreUint32(&c.lastUseTime, uint32(time.Now().Unix()-startTimeUnix)) // #nosec G115
@@ -1641,7 +1655,7 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 		}
 	}
 
-	return c.transport().RoundTrip(c, req, resp)
+	return nil
 }
 
 func (c *HostClient) transport() RoundTripper {
@@ -1695,6 +1709,7 @@ var ErrTimeout = &timeoutError{}
 func (c *HostClient) SetMaxConns(newMaxConns int) {
 	c.connsLock.Lock()
 	c.MaxConns = newMaxConns
+	c.signalConnSlotAvailableLocked()
 	c.connsLock.Unlock()
 }
 
@@ -1840,6 +1855,9 @@ func (c *HostClient) CloseIdleConnections() {
 	for _, cc := range scratch {
 		c.CloseConn(cc)
 	}
+	if closer, ok := c.protocolTransport.(ProtocolTransportCloser); ok {
+		closer.CloseIdleConnections(c)
+	}
 }
 
 func (c *HostClient) connsCleaner() {
@@ -1908,6 +1926,7 @@ func (c *HostClient) decConnsCount() {
 	if c.MaxConnWaitTimeout <= 0 {
 		c.connsLock.Lock()
 		c.connsCount--
+		c.signalConnSlotAvailableLocked()
 		c.connsLock.Unlock()
 		return
 	}
@@ -1927,6 +1946,7 @@ func (c *HostClient) decConnsCount() {
 	}
 	if !dialed {
 		c.connsCount--
+		c.signalConnSlotAvailableLocked()
 	}
 }
 
@@ -3187,22 +3207,33 @@ func (c *pipelineConnClient) PendingRequests() int {
 
 var errPipelineConnStopped = errors.New("pipeline connection has been stopped")
 
-var DefaultTransport RoundTripper = &transport{}
+var defaultTransport = &transport{}
+
+// DefaultTransport is the transport used by HostClient when Transport is nil.
+var DefaultTransport RoundTripper = defaultTransport
 
 type transport struct{}
 
 func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (retry bool, err error) {
+	cc, err := hc.AcquireConn(req.timeout, req.ConnectionClose())
+	if err != nil {
+		return false, err
+	}
+	return t.roundTripConn(hc, cc, req, resp)
+}
+
+func (t *transport) roundTripConn(
+	hc *HostClient,
+	cc *clientConn,
+	req *Request,
+	resp *Response,
+) (retry bool, err error) {
 	customSkipBody := resp.SkipBody
 	customStreamBody := resp.StreamBody
 
 	var deadline time.Time
 	if req.timeout > 0 {
 		deadline = time.Now().Add(req.timeout)
-	}
-
-	cc, err := hc.AcquireConn(req.timeout, req.ConnectionClose())
-	if err != nil {
-		return false, err
 	}
 	conn := cc.c
 

--- a/header.go
+++ b/header.go
@@ -72,10 +72,11 @@ type RequestHeader struct {
 
 	noCopy noCopy
 
-	method     []byte
-	requestURI []byte
-	host       []byte
-	userAgent  []byte
+	method          []byte
+	requestURI      []byte
+	host            []byte
+	userAgent       []byte
+	connectProtocol []byte
 
 	// stores an immutable copy of headers as they were received from the
 	// wire.
@@ -781,6 +782,31 @@ func (h *RequestHeader) SetProtocolBytes(protocol []byte) {
 	h.noHTTP11 = !bytes.Equal(h.protocol, strHTTP11)
 }
 
+// ConnectProtocol returns the extended CONNECT protocol. It is empty for a
+// regular request.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (h *RequestHeader) ConnectProtocol() []byte {
+	return h.connectProtocol
+}
+
+// SetConnectProtocol sets the extended CONNECT protocol.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (h *RequestHeader) SetConnectProtocol(protocol string) {
+	h.connectProtocol = initHeaderValueString(h.connectProtocol, protocol)
+}
+
+// SetConnectProtocolBytes sets the extended CONNECT protocol.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (h *RequestHeader) SetConnectProtocolBytes(protocol []byte) {
+	h.connectProtocol = initHeaderValueBytes(h.connectProtocol, protocol)
+}
+
 // RequestURI returns RequestURI from the first HTTP request line.
 func (h *RequestHeader) RequestURI() []byte {
 	requestURI := h.requestURI
@@ -1014,6 +1040,7 @@ func (h *RequestHeader) resetSkipNormalize() {
 	h.host = h.host[:0]
 	h.contentType = h.contentType[:0]
 	h.userAgent = h.userAgent[:0]
+	h.connectProtocol = h.connectProtocol[:0]
 	h.trailer = h.trailer[:0]
 	h.mulHeader = h.mulHeader[:0]
 
@@ -1062,6 +1089,7 @@ func (h *RequestHeader) CopyTo(dst *RequestHeader) {
 	dst.requestURI = append(dst.requestURI, h.requestURI...)
 	dst.host = append(dst.host, h.host...)
 	dst.userAgent = append(dst.userAgent, h.userAgent...)
+	dst.connectProtocol = append(dst.connectProtocol, h.connectProtocol...)
 	dst.cookiesCollected = h.cookiesCollected
 	dst.rawHeaders = append(dst.rawHeaders, h.rawHeaders...)
 }

--- a/http2/DESIGN.md
+++ b/http2/DESIGN.md
@@ -1,0 +1,102 @@
+# Native HTTP/2 design
+
+The `http2` package is an opt-in protocol implementation over fasthttp's
+request, response, and `RequestCtx` types. It does not convert through
+`net/http`. Its exported API is experimental for at least two fasthttp minor
+releases.
+
+## Connection ownership
+
+Each server connection has four execution roles:
+
+1. A frame reader blocks in `ReadFrame` and sends bounded, immutable events.
+2. The connection owner is the only goroutine that changes stream state,
+   SETTINGS, HPACK state, flow-control windows, GOAWAY state, or the response
+   schedule.
+3. Each accepted stream runs the fasthttp handler independently, so a slow
+   handler does not stop frame processing for other streams.
+4. Control frames, header blocks, and flow-controlled DATA are serialized by
+   one bounded writer path. RFC 9218 urgency and incremental scheduling are
+   applied there; the obsolete RFC 7540 dependency tree is not maintained.
+
+The client uses the same ownership rule for reads and HPACK state. Request
+goroutines reserve stream IDs and slots, then use a serialized writer. A
+request timeout resets only its stream and never changes the physical TCP
+deadline shared by other streams.
+
+## Codec boundary and provenance
+
+The implementation uses the MIT-compatible `golang.org/x/net/http2.Framer`
+and `hpack` packages for wire framing and compression primitives. A private
+codec decodes HEADERS and CONTINUATION blocks directly into bounded, pooled
+event storage. This avoids `net/http.Request`, header maps, and x/net's
+allocation-heavy `MetaHeadersFrame` while retaining its frame validation.
+
+The connection state machines, fasthttp mappings, flow control, scheduling,
+push, and stream APIs are original code in this repository. No code was copied
+from `dgrr/http2` or other third-party fasthttp HTTP/2 implementations.
+
+## Negotiation
+
+- TLS uses ALPN `h2`. `PreferHTTP2` advertises `h2` and `http/1.1`; when the
+  peer selects HTTP/1.1, that same negotiated connection is handed to the
+  built-in fasthttp HTTP/1 transport.
+- `RequireHTTP2` returns `ErrHTTP2Required` when ALPN does not select `h2`.
+- Cleartext HTTP/2 requires explicit `PriorKnowledge`. A configured server can
+  distinguish the 24-byte HTTP/2 preface from HTTP/1 on the same listener and
+  replays the first mismatching byte to the HTTP/1 parser.
+- The obsolete HTTP/1 `Upgrade: h2c` mechanism is intentionally unsupported.
+
+## HTTP semantics and extensions
+
+Pseudo-headers are validated and mapped directly to fasthttp headers. The
+implementation rejects connection-specific fields, invalid `TE`, malformed
+content lengths, invalid trailer fields, invalid CONNECT combinations, and
+body lengths that disagree with their headers. Header names on the wire are
+lowercase. Sensitive request and response fields are encoded as never-indexed.
+
+Server push is implemented but disabled by default. Push is same-origin,
+limited to GET and HEAD, bounded by depth and concurrent promise limits, and
+requires the client to install a `PushHandler`.
+
+Extended CONNECT is also disabled by default. The client waits for the peer's
+`SETTINGS_ENABLE_CONNECT_PROTOCOL=1` before sending `:protocol`.
+`RequestCtx.AcceptStream` and `HostClient.OpenStream` expose DATA as a virtual
+`fasthttp.StreamConn`; close, half-close, deadlines, and cancellation are
+stream-scoped.
+
+## Resource and shutdown boundaries
+
+Concurrent streams, handler admission, event and command queues, frame size,
+HPACK tables, decompressed header lists, cached header strings, push depth,
+pending priority updates, closed-stream tombstones, and connection/stream
+receive windows all have explicit bounds. A rapid-reset rate limit terminates
+abusive connections with `ENHANCE_YOUR_CALM`.
+
+Server shutdown sends an initial GOAWAY, uses a PING barrier to identify the
+last accepted stream, then sends the final GOAWAY and drains accepted work. If
+`ShutdownWithContext` expires, registered protocol connections are closed and
+remaining streams are canceled.
+
+## HTTP/3 boundary
+
+The root package abstracts only request lifecycle, cancellation, push,
+informational responses, and bidirectional stream semantics. TCP, HTTP/2
+frames, HPACK, and HTTP/2 flow control remain private to this package.
+
+A future HTTP/3 package can therefore use QUIC connections, control streams,
+QPACK, and QUIC flow control directly under RFC 9114 and RFC 9204. It will not
+need to emulate an HTTP/2 connection or add a closed HTTP-version enum to the
+root package.
+
+## Verification
+
+The test suite includes native/native and Go x/net interoperability, TLS ALPN,
+HTTP/1 fallback without a second dial, prior knowledge, same-port dispatch,
+streaming bodies, trailers, 103 responses, push, extended CONNECT, half-close,
+GOAWAY, flow control, rapid reset, and deterministic multiplexing tests.
+
+CI runs all applicable h2spec 2.6.0 cases in strict mode in addition to Go
+unit, race, shuffle, and fuzz targets. h2spec primarily tests RFC 7540/7541, so
+RFC 9113, RFC 9218, rapid-reset, and RFC 8441 behavior is covered by native
+tests rather than inferred from the h2spec score.

--- a/http2/PERFORMANCE.md
+++ b/http2/PERFORMANCE.md
@@ -17,7 +17,7 @@ Commands:
 ```sh
 go test -run '^$' \
   -bench '^(BenchmarkEndToEnd|BenchmarkClientsAgainstGoServer|BenchmarkServersWithFasthttpClient|BenchmarkHeaderCodec|BenchmarkTLSGET)$' \
-  -benchmem -count=10 ./http2
+  -benchtime=500ms -benchmem -count=10 ./http2
 
 go test -run '^$' -bench '^BenchmarkBodies$' \
   -benchtime=500ms -benchmem -count=10 ./http2
@@ -30,15 +30,15 @@ Median nanoseconds per operation are shown below. “Go” means
 
 | Scenario | Streams | fasthttp | Go | Throughput advantage |
 | --- | ---: | ---: | ---: | ---: |
-| Native client + native server, cleartext | 1 | 23,890 | 27,090 | 1.13x |
-| Native client + native server, cleartext | 10 | 5,799 | 7,409 | 1.28x |
-| Native client + native server, cleartext | 100 | 3,989 | 6,675 | 1.67x |
-| Native client + native server, cleartext | 1,000 | 6,844 | 9,460 | 1.38x |
-| Clients against the same Go server | 100 | 7,156 | 8,878 | 1.24x |
-| Servers behind the same fasthttp client | 100 | 3,585 | 6,534 | 1.82x |
-| Servers behind the same fasthttp client | 1,000 | 3,715 | 6,568 | 1.77x |
-| TLS client + native TLS server | 100 | 2,746 | 5,798 | 2.11x |
-| HEADERS/HPACK codec | 1 block | 169.3 | 315.9 | 1.87x |
+| Native client + native server, cleartext | 1 | 24,500 | 27,830 | 1.14x |
+| Native client + native server, cleartext | 10 | 6,244 | 7,815 | 1.25x |
+| Native client + native server, cleartext | 100 | 3,969 | 6,596 | 1.66x |
+| Native client + native server, cleartext | 1,000 | 4,284 | 6,929 | 1.62x |
+| Clients against the same Go server | 100 | 7,294 | 9,887 | 1.36x |
+| Servers behind the same fasthttp client | 100 | 3,988 | 7,460 | 1.87x |
+| Servers behind the same fasthttp client | 1,000 | 4,271 | 7,496 | 1.76x |
+| TLS client + native TLS server | 100 | 3,064 | 6,695 | 2.19x |
+| HEADERS/HPACK codec | 1 block | 168.2 | 279.3 | 1.66x |
 
 The 100- and 1,000-stream end-to-end samples have more scheduler variance
 than the isolated server samples. The individual raw benchmark output should
@@ -48,9 +48,9 @@ be retained in the Draft PR when performance decisions are made.
 
 | Scenario | fasthttp | Go | Reduction |
 | --- | ---: | ---: | ---: |
-| Cleartext, 100 streams | 4 allocs / 163 B | 32 allocs / 3.51 KiB | 8x allocations, about 22x bytes |
-| Server comparison, 100 streams | 4 allocs / 160 B | 28 allocs / 2.48 KiB | 7x allocations, about 16x bytes |
-| TLS, 100 streams | 4 allocs / 163 B | 32 allocs / 3.47 KiB | 8x allocations, about 22x bytes |
+| Cleartext, 100 streams | 4 allocs / 164 B | 32 allocs / 3.52 KiB | 8x allocations, about 22x bytes |
+| Server comparison, 100 streams | 4 allocs / 165 B | 28 allocs / 2.53 KiB | 7x allocations, about 16x bytes |
+| TLS, 100 streams | 4 allocs / 168 B | 33 allocs / 3.53 KiB | about 8x allocations, about 22x bytes |
 | HEADERS/HPACK codec | 2 allocs / 64 B | 10 allocs / 480 B | 5x allocations, 7.5x bytes |
 
 The private header codec, stream/context pooling, bounded string interning, and
@@ -62,19 +62,33 @@ Framer; the implementation deliberately keeps that dependency boundary.
 
 | Scenario | fasthttp | Go | Throughput advantage |
 | --- | ---: | ---: | ---: |
-| 4 KiB GET | 4.66 µs | 9.88 µs | 2.12x |
-| 1 MiB GET, fasthttp buffered | 357 µs | 497 µs | 1.39x |
-| 4 KiB POST | 7.18 µs | 9.27 µs | 1.29x |
-| 1 MiB POST | 325 µs | 367 µs | 1.13x |
-| 1 MiB streaming request | 552 µs | 777 µs | 1.41x |
-| 1 MiB streaming response | 366 µs | 776 µs | 2.12x |
+| 4 KiB GET | 4.71 µs | 9.84 µs | 2.09x |
+| 1 MiB GET, fasthttp buffered | 204 µs | 567 µs | 2.79x |
+| 4 KiB POST | 6.82 µs | 10.32 µs | 1.51x |
+| 1 MiB POST | 179 µs | 329 µs | 1.84x |
+| 1 MiB streaming request | 316 µs | 378 µs | 1.20x |
+| 1 MiB streaming response | 219 µs | 581 µs | 2.65x |
 
-The buffered 1 MiB fasthttp GET intentionally stores the entire response,
-while `net/http.Response.Body` is inherently streaming in this harness; its
-memory numbers are therefore not comparable. Streaming memory is bounded by
-the configured connection and stream receive windows and can be reduced by
-lowering `MaxResponseBufferPerConnection` and
-`MaxResponseBufferPerStream`.
+The buffered 1 MiB fasthttp GET intentionally stores the entire response and
+therefore reports about 1 MiB allocated per operation, while
+`net/http.Response.Body` is inherently streaming in this harness; those byte
+counts are not comparable. The native buffered path takes 12 allocations
+versus 341 for Go in this scenario. The streaming request and response paths
+use bounded, reusable frame segments and take 112 and 149 allocations versus
+178 and 484. Streaming memory is bounded by the configured connection and
+stream receive windows and can be reduced by lowering
+`MaxResponseBufferPerConnection` and `MaxResponseBufferPerStream`.
+
+## Profile-guided limits
+
+After allocation and batching work, a 100-stream small-GET CPU profile spent
+47% of samples in raw syscalls; most of the remainder was in kqueue and Go
+scheduler sleep/wakeup paths. Handler startup was not a significant sampled
+hotspot. A fixed handler worker pool was therefore not added: it would impose
+head-of-line blocking on slow handlers without evidence of improving this
+profile. The remaining high-value target is reducing flow-control wakeups on
+bidirectional streaming workloads while retaining per-stream cancellation and
+fairness.
 
 ## HTTP/1 regression guard
 
@@ -85,11 +99,13 @@ operation after the protocol bridge and HTTP/2 implementation. Ten-sample
 
 ## Current conclusion
 
-The current implementation clears the original acceptance gate of exceeding
-Go HTTP/2 throughput in the measured primary scenarios while allocating less.
-It does **not** demonstrate a 10x end-to-end throughput advantage. The large
-advantage is presently in allocation count and allocated bytes; network,
-TLS, scheduling, copying, and flow control dominate wall time. The pull
-request must remain Draft if a 10x throughput target is required, and future
-optimization should be justified by CPU, heap, mutex, and block profiles
-rather than by weakening protocol validation or resource limits.
+The current implementation exceeds Go HTTP/2 throughput in the measured
+primary scenarios while using substantially fewer allocations. It does
+**not** demonstrate a 10x end-to-end throughput advantage: the measured range
+is about 1.14x to 2.79x. HTTP/1's historical order-of-magnitude comparisons
+do not transfer directly to a multiplexed protocol whose physical connection,
+HPACK state, writer ordering, and flow-control feedback are serialized by the
+wire protocol. Network syscalls, TLS, scheduling, copying, and flow-control
+now dominate wall time. Future optimization must be justified by CPU, heap,
+mutex, and block profiles rather than by weakening protocol validation,
+fairness, or resource limits.

--- a/http2/PERFORMANCE.md
+++ b/http2/PERFORMANCE.md
@@ -1,0 +1,95 @@
+# HTTP/2 performance snapshot
+
+This is a local development snapshot, not a universal performance claim. The
+benchmarks run both endpoints in one process over loopback TCP, prewarm the
+connections, use one physical connection, and report ten samples through
+`benchstat`. TLS results use the same certificate and TLS implementation for
+both clients.
+
+Machine:
+
+- Apple M4, 10 logical CPUs, 32 GiB RAM
+- macOS 15.7.8 (24G824), arm64
+- Go 1.26.5
+
+Commands:
+
+```sh
+go test -run '^$' \
+  -bench '^(BenchmarkEndToEnd|BenchmarkClientsAgainstGoServer|BenchmarkServersWithFasthttpClient|BenchmarkHeaderCodec|BenchmarkTLSGET)$' \
+  -benchmem -count=10 ./http2
+
+go test -run '^$' -bench '^BenchmarkBodies$' \
+  -benchtime=500ms -benchmem -count=10 ./http2
+```
+
+## Small GET throughput
+
+Median nanoseconds per operation are shown below. “Go” means
+`golang.org/x/net/http2`/`net/http`.
+
+| Scenario | Streams | fasthttp | Go | Throughput advantage |
+| --- | ---: | ---: | ---: | ---: |
+| Native client + native server, cleartext | 1 | 23,890 | 27,090 | 1.13x |
+| Native client + native server, cleartext | 10 | 5,799 | 7,409 | 1.28x |
+| Native client + native server, cleartext | 100 | 3,989 | 6,675 | 1.67x |
+| Native client + native server, cleartext | 1,000 | 6,844 | 9,460 | 1.38x |
+| Clients against the same Go server | 100 | 7,156 | 8,878 | 1.24x |
+| Servers behind the same fasthttp client | 100 | 3,585 | 6,534 | 1.82x |
+| Servers behind the same fasthttp client | 1,000 | 3,715 | 6,568 | 1.77x |
+| TLS client + native TLS server | 100 | 2,746 | 5,798 | 2.11x |
+| HEADERS/HPACK codec | 1 block | 169.3 | 315.9 | 1.87x |
+
+The 100- and 1,000-stream end-to-end samples have more scheduler variance
+than the isolated server samples. The individual raw benchmark output should
+be retained in the Draft PR when performance decisions are made.
+
+## Small GET allocation profile
+
+| Scenario | fasthttp | Go | Reduction |
+| --- | ---: | ---: | ---: |
+| Cleartext, 100 streams | 4 allocs / 163 B | 32 allocs / 3.51 KiB | 8x allocations, about 22x bytes |
+| Server comparison, 100 streams | 4 allocs / 160 B | 28 allocs / 2.48 KiB | 7x allocations, about 16x bytes |
+| TLS, 100 streams | 4 allocs / 163 B | 32 allocs / 3.47 KiB | 8x allocations, about 22x bytes |
+| HEADERS/HPACK codec | 2 allocs / 64 B | 10 allocs / 480 B | 5x allocations, 7.5x bytes |
+
+The private header codec, stream/context pooling, bounded string interning, and
+targeted writer wakeups account for most of this reduction. The two remaining
+codec allocations are `HeadersFrame` objects created inside x/net's low-level
+Framer; the implementation deliberately keeps that dependency boundary.
+
+## Body throughput
+
+| Scenario | fasthttp | Go | Throughput advantage |
+| --- | ---: | ---: | ---: |
+| 4 KiB GET | 4.66 µs | 9.88 µs | 2.12x |
+| 1 MiB GET, fasthttp buffered | 357 µs | 497 µs | 1.39x |
+| 4 KiB POST | 7.18 µs | 9.27 µs | 1.29x |
+| 1 MiB POST | 325 µs | 367 µs | 1.13x |
+| 1 MiB streaming request | 552 µs | 777 µs | 1.41x |
+| 1 MiB streaming response | 366 µs | 776 µs | 2.12x |
+
+The buffered 1 MiB fasthttp GET intentionally stores the entire response,
+while `net/http.Response.Body` is inherently streaming in this harness; its
+memory numbers are therefore not comparable. Streaming memory is bounded by
+the configured connection and stream receive windows and can be reduced by
+lowering `MaxResponseBufferPerConnection` and
+`MaxResponseBufferPerStream`.
+
+## HTTP/1 regression guard
+
+The existing `BenchmarkClientGetEndToEnd100Inmemory` and
+`BenchmarkServerGet10KReqPerConn` benchmarks remained at zero allocations per
+operation after the protocol bridge and HTTP/2 implementation. Ten-sample
+`benchstat` output showed no throughput regression on this machine.
+
+## Current conclusion
+
+The current implementation clears the original acceptance gate of exceeding
+Go HTTP/2 throughput in the measured primary scenarios while allocating less.
+It does **not** demonstrate a 10x end-to-end throughput advantage. The large
+advantage is presently in allocation count and allocated bytes; network,
+TLS, scheduling, copying, and flow control dominate wall time. The pull
+request must remain Draft if a 10x throughput target is required, and future
+optimization should be justified by CPU, heap, mutex, and block profiles
+rather than by weakening protocol validation or resource limits.

--- a/http2/benchmark_test.go
+++ b/http2/benchmark_test.go
@@ -1,0 +1,620 @@
+package http2
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	stdhttp "net/http"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	xhttp2 "golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func BenchmarkEndToEnd(b *testing.B) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBodyString("ok")
+		},
+	}
+	testServer := newTestServer(b, server, ServerConfig{MaxConcurrentStreams: 1000})
+	client := &fasthttp.HostClient{Addr: testServer.listener.Addr().String()}
+	if err := ConfigureHostClient(client, ClientConfig{
+		Mode:                 PriorKnowledge,
+		MaxConcurrentStreams: 1000,
+	}); err != nil {
+		b.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	b.Cleanup(client.CloseIdleConnections)
+	client.MaxConns = 1
+	client.MaxConnWaitTimeout = time.Minute
+	warmRequest := fasthttp.AcquireRequest()
+	warmResponse := fasthttp.AcquireResponse()
+	warmRequest.SetRequestURI(testServer.URL("/"))
+	if err := client.Do(warmRequest, warmResponse); err != nil {
+		b.Fatalf("warming HTTP/2 connection: %v", err)
+	}
+	fasthttp.ReleaseRequest(warmRequest)
+	fasthttp.ReleaseResponse(warmResponse)
+
+	for _, concurrency := range []int{1, 10, 100, 1000} {
+		b.Run(fmt.Sprintf("fasthttp/streams-%d", concurrency), func(b *testing.B) {
+			benchmarkFasthttpClient(b, client, testServer.URL("/"), concurrency)
+		})
+		b.Run(fmt.Sprintf("net-http2/streams-%d", concurrency), func(b *testing.B) {
+			benchmarkNetHTTP2Client(b, testServer.client, testServer.URL("/"), concurrency)
+		})
+	}
+}
+
+func BenchmarkClientsAgainstGoServer(b *testing.B) {
+	server := newGoBenchmarkServer(b)
+	nativeClient := newBenchmarkHostClient(b, server.listener.Addr().String())
+	goClient := newGoBenchmarkClient(b)
+	warmFasthttpClient(b, nativeClient, server.URL("/"))
+	warmGoClient(b, goClient, server.URL("/"))
+
+	for _, concurrency := range []int{1, 10, 100, 1000} {
+		b.Run(fmt.Sprintf("fasthttp/streams-%d", concurrency), func(b *testing.B) {
+			benchmarkFasthttpClient(b, nativeClient, server.URL("/"), concurrency)
+		})
+		b.Run(fmt.Sprintf("net-http2/streams-%d", concurrency), func(b *testing.B) {
+			benchmarkNetHTTP2Client(b, goClient, server.URL("/"), concurrency)
+		})
+	}
+}
+
+func BenchmarkServersWithFasthttpClient(b *testing.B) {
+	nativeServer := newTestServer(b, &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBodyString("ok")
+		},
+	}, ServerConfig{MaxConcurrentStreams: 1000})
+	goServer := newGoBenchmarkServer(b)
+	nativeServerClient := newBenchmarkHostClient(b, nativeServer.listener.Addr().String())
+	goServerClient := newBenchmarkHostClient(b, goServer.listener.Addr().String())
+	warmFasthttpClient(b, nativeServerClient, nativeServer.URL("/"))
+	warmFasthttpClient(b, goServerClient, goServer.URL("/"))
+
+	for _, concurrency := range []int{1, 10, 100, 1000} {
+		b.Run(fmt.Sprintf("fasthttp-server/streams-%d", concurrency), func(b *testing.B) {
+			benchmarkFasthttpClient(b, nativeServerClient, nativeServer.URL("/"), concurrency)
+		})
+		b.Run(fmt.Sprintf("go-server/streams-%d", concurrency), func(b *testing.B) {
+			benchmarkFasthttpClient(b, goServerClient, goServer.URL("/"), concurrency)
+		})
+	}
+}
+
+func BenchmarkHeaderCodec(b *testing.B) {
+	wire := benchmarkRequestHeaderFrame(b)
+	b.Run("private-codec", func(b *testing.B) {
+		framer := xhttp2.NewFramer(io.Discard, &cyclingReader{data: wire})
+		codec := newHeaderCodec(defaultHeaderTableSize, 64<<10)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			frame, err := framer.ReadFrame()
+			if err != nil {
+				b.Fatal(err)
+			}
+			headers := frame.(*xhttp2.HeadersFrame) //nolint:forcetypeassert
+			fieldStorage := acquireIncomingHeaderFields(8)
+			fields, truncated, invalid, err := codec.decode(
+				framer,
+				headers.StreamID,
+				headers,
+				fieldStorage.fields,
+			)
+			event := incomingFrame{fields: fields, fieldStorage: fieldStorage}
+			releaseIncomingFrame(&event)
+			if err != nil || truncated || invalid != nil || len(fields) != 4 {
+				b.Fatalf("decode = (%d fields, truncated=%v, invalid=%v, err=%v)", len(fields), truncated, invalid, err)
+			}
+		}
+	})
+	b.Run("x-net-meta-headers", func(b *testing.B) {
+		framer := xhttp2.NewFramer(io.Discard, &cyclingReader{data: wire})
+		decoder := hpack.NewDecoder(defaultHeaderTableSize, nil)
+		framer.ReadMetaHeaders = decoder
+		framer.MaxHeaderListSize = 64 << 10
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			frame, err := framer.ReadFrame()
+			if err != nil {
+				b.Fatal(err)
+			}
+			headers := frame.(*xhttp2.MetaHeadersFrame) //nolint:forcetypeassert
+			if headers.Truncated || len(headers.Fields) != 4 {
+				b.Fatalf("decode = (%d fields, truncated=%v)", len(headers.Fields), headers.Truncated)
+			}
+		}
+	})
+}
+
+func BenchmarkBodies(b *testing.B) {
+	payload4KiB := bytes.Repeat([]byte("a"), 4<<10)
+	payload1MiB := bytes.Repeat([]byte("b"), 1<<20)
+	bufferedServer := newTestServer(b, &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			switch string(ctx.Path()) {
+			case "/get-4k":
+				ctx.Response.SetBodyRaw(payload4KiB)
+			case "/get-1m":
+				ctx.Response.SetBodyRaw(payload1MiB)
+			default:
+				ctx.SetBodyString("ok")
+			}
+		},
+	}, ServerConfig{MaxConcurrentStreams: 1000})
+	streamingServer := newTestServer(b, &fasthttp.Server{
+		StreamRequestBody: true,
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if string(ctx.Path()) == "/stream-response" {
+				ctx.Response.SetBodyStream(bytes.NewReader(payload1MiB), len(payload1MiB))
+				return
+			}
+			if body := ctx.RequestBodyStream(); body != nil {
+				_, _ = io.Copy(io.Discard, body)
+			}
+			ctx.SetBodyString("ok")
+		},
+	}, ServerConfig{MaxConcurrentStreams: 1000})
+	bufferedClient := newBenchmarkHostClient(b, bufferedServer.listener.Addr().String())
+	streamingRequestClient := newBenchmarkHostClient(b, streamingServer.listener.Addr().String())
+	streamingResponseClient := newBenchmarkHostClient(b, streamingServer.listener.Addr().String())
+	streamingResponseClient.StreamResponseBody = true
+	warmFasthttpClient(b, bufferedClient, bufferedServer.URL("/get-4k"))
+	warmFasthttpClient(b, streamingRequestClient, streamingServer.URL("/stream-request"))
+	warmFasthttpClient(b, streamingResponseClient, streamingServer.URL("/stream-response"))
+
+	scenarios := []struct {
+		name           string
+		client         *fasthttp.HostClient
+		goClient       *stdhttp.Client
+		requestURI     string
+		method         string
+		requestBody    []byte
+		responseSize   int
+		streamRequest  bool
+		streamResponse bool
+	}{
+		{"get-4k", bufferedClient, bufferedServer.client, bufferedServer.URL("/get-4k"), fasthttp.MethodGet, nil, len(payload4KiB), false, false},
+		{"get-1m", bufferedClient, bufferedServer.client, bufferedServer.URL("/get-1m"), fasthttp.MethodGet, nil, len(payload1MiB), false, false},
+		{"post-4k", bufferedClient, bufferedServer.client, bufferedServer.URL("/post-4k"), fasthttp.MethodPost, payload4KiB, 2, false, false},
+		{"post-1m", bufferedClient, bufferedServer.client, bufferedServer.URL("/post-1m"), fasthttp.MethodPost, payload1MiB, 2, false, false},
+		{"stream-request-1m", streamingRequestClient, streamingServer.client, streamingServer.URL("/stream-request"), fasthttp.MethodPost, payload1MiB, 2, true, false},
+		{"stream-response-1m", streamingResponseClient, streamingServer.client, streamingServer.URL("/stream-response"), fasthttp.MethodGet, nil, len(payload1MiB), false, true},
+	}
+	for _, scenario := range scenarios {
+		b.Run("fasthttp/"+scenario.name, func(b *testing.B) {
+			benchmarkFasthttpBody(
+				b,
+				scenario.client,
+				scenario.requestURI,
+				scenario.method,
+				scenario.requestBody,
+				scenario.responseSize,
+				scenario.streamRequest,
+				scenario.streamResponse,
+			)
+		})
+		b.Run("net-http2/"+scenario.name, func(b *testing.B) {
+			benchmarkNetHTTP2Body(
+				b,
+				scenario.goClient,
+				scenario.requestURI,
+				scenario.method,
+				scenario.requestBody,
+				scenario.responseSize,
+			)
+		})
+	}
+}
+
+func BenchmarkTLSGET(b *testing.B) {
+	server := newTLSBenchmarkServer(b)
+	nativeClient := newTLSBenchmarkHostClient(b, server.listener.Addr().String())
+	warmFasthttpClient(b, nativeClient, server.URL("/"))
+	warmGoClient(b, server.client, server.URL("/"))
+	for _, concurrency := range []int{1, 100} {
+		b.Run(fmt.Sprintf("fasthttp/streams-%d", concurrency), func(b *testing.B) {
+			benchmarkFasthttpClient(b, nativeClient, server.URL("/"), concurrency)
+		})
+		b.Run(fmt.Sprintf("net-http2/streams-%d", concurrency), func(b *testing.B) {
+			benchmarkNetHTTP2Client(b, server.client, server.URL("/"), concurrency)
+		})
+	}
+}
+
+func newTLSBenchmarkServer(b *testing.B) *testServer {
+	b.Helper()
+	certificateData, keyData, err := fasthttp.GenerateTestCertificate("localhost")
+	if err != nil {
+		b.Fatalf("generating benchmark certificate: %v", err)
+	}
+	certificate, err := tls.X509KeyPair(certificateData, keyData)
+	if err != nil {
+		b.Fatalf("loading benchmark certificate: %v", err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatalf("listening for TLS benchmark: %v", err)
+	}
+	server := &fasthttp.Server{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{certificate}},
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBodyString("ok")
+		},
+	}
+	if err := ConfigureServer(server, ServerConfig{MaxConcurrentStreams: 1000}); err != nil {
+		_ = listener.Close()
+		b.Fatalf("ConfigureServer() error: %v", err)
+	}
+	tlsListener := tls.NewListener(listener, server.TLSConfig.Clone())
+	transport := &xhttp2.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Benchmark-only certificate.
+		},
+	}
+	result := &testServer{
+		server:    server,
+		listener:  tlsListener,
+		scheme:    "https",
+		transport: transport,
+		client:    &stdhttp.Client{Transport: transport},
+		serveDone: make(chan error, 1),
+	}
+	go func() { result.serveDone <- server.Serve(tlsListener) }()
+	b.Cleanup(func() {
+		transport.CloseIdleConnections()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.ShutdownWithContext(ctx)
+		select {
+		case <-result.serveDone:
+		case <-time.After(time.Second):
+			b.Error("TLS benchmark server didn't stop")
+		}
+	})
+	return result
+}
+
+func newTLSBenchmarkHostClient(b *testing.B, addr string) *fasthttp.HostClient {
+	b.Helper()
+	client := &fasthttp.HostClient{
+		Addr:               addr,
+		IsTLS:              true,
+		MaxConns:           1,
+		MaxConnWaitTimeout: time.Minute,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Benchmark-only certificate.
+		},
+	}
+	if err := ConfigureHostClient(client, ClientConfig{MaxConcurrentStreams: 1000}); err != nil {
+		b.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	b.Cleanup(client.CloseIdleConnections)
+	return client
+}
+
+func benchmarkFasthttpBody(
+	b *testing.B,
+	client *fasthttp.HostClient,
+	requestURI string,
+	method string,
+	requestBody []byte,
+	responseSize int,
+	streamRequest bool,
+	streamResponse bool,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	var next atomic.Int64
+	var wait sync.WaitGroup
+	b.ResetTimer()
+	for range 100 {
+		wait.Go(func() {
+			request := fasthttp.AcquireRequest()
+			response := fasthttp.AcquireResponse()
+			defer fasthttp.ReleaseRequest(request)
+			defer fasthttp.ReleaseResponse(response)
+			request.Header.SetMethod(method)
+			request.SetRequestURI(requestURI)
+			if len(requestBody) != 0 && !streamRequest {
+				request.SetBodyRaw(requestBody)
+			}
+			for {
+				if next.Add(1) > int64(b.N) {
+					return
+				}
+				if streamRequest {
+					request.SetBodyStream(bytes.NewReader(requestBody), len(requestBody))
+				}
+				if err := client.Do(request, response); err != nil {
+					b.Errorf("Do() error: %v", err)
+					return
+				}
+				if streamResponse {
+					read, err := io.Copy(io.Discard, response.BodyStream())
+					closeErr := response.CloseBodyStream()
+					if err != nil || closeErr != nil || read != int64(responseSize) {
+						b.Errorf("stream response = (%d bytes, read=%v, close=%v)", read, err, closeErr)
+						return
+					}
+				} else if len(response.Body()) != responseSize {
+					b.Errorf("response length = %d, want %d", len(response.Body()), responseSize)
+					return
+				}
+				response.ResetBody()
+			}
+		})
+	}
+	wait.Wait()
+}
+
+func benchmarkNetHTTP2Body(
+	b *testing.B,
+	client *stdhttp.Client,
+	requestURI string,
+	method string,
+	requestBody []byte,
+	responseSize int,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	var next atomic.Int64
+	var wait sync.WaitGroup
+	b.ResetTimer()
+	for range 100 {
+		wait.Go(func() {
+			for {
+				if next.Add(1) > int64(b.N) {
+					return
+				}
+				var body io.Reader
+				if len(requestBody) != 0 {
+					body = bytes.NewReader(requestBody)
+				}
+				request, err := stdhttp.NewRequest(method, requestURI, body)
+				if err != nil {
+					b.Errorf("NewRequest() error: %v", err)
+					return
+				}
+				response, err := client.Do(request)
+				if err != nil {
+					b.Errorf("Do() error: %v", err)
+					return
+				}
+				read, readErr := io.Copy(io.Discard, response.Body)
+				closeErr := response.Body.Close()
+				if readErr != nil || closeErr != nil || read != int64(responseSize) {
+					b.Errorf("response = (%d bytes, read=%v, close=%v)", read, readErr, closeErr)
+					return
+				}
+			}
+		})
+	}
+	wait.Wait()
+}
+
+func benchmarkRequestHeaderFrame(b *testing.B) []byte {
+	b.Helper()
+	var block bytes.Buffer
+	encoder := hpack.NewEncoder(&block)
+	for _, field := range []hpack.HeaderField{
+		{Name: ":method", Value: "GET"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":authority", Value: "example.com", Sensitive: true},
+		{Name: ":path", Value: "/"},
+	} {
+		if err := encoder.WriteField(field); err != nil {
+			b.Fatal(err)
+		}
+	}
+	var wire bytes.Buffer
+	framer := xhttp2.NewFramer(&wire, nil)
+	if err := framer.WriteHeaders(xhttp2.HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: block.Bytes(),
+		EndStream:     true,
+		EndHeaders:    true,
+	}); err != nil {
+		b.Fatal(err)
+	}
+	return bytes.Clone(wire.Bytes())
+}
+
+type cyclingReader struct {
+	data   []byte
+	offset int
+}
+
+func (r *cyclingReader) Read(destination []byte) (int, error) {
+	written := 0
+	for written < len(destination) {
+		amount := copy(destination[written:], r.data[r.offset:])
+		written += amount
+		r.offset += amount
+		if r.offset == len(r.data) {
+			r.offset = 0
+		}
+	}
+	return written, nil
+}
+
+type goBenchmarkServer struct {
+	listener net.Listener
+}
+
+func newGoBenchmarkServer(b *testing.B) *goBenchmarkServer {
+	b.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatalf("listening for Go HTTP/2 benchmark: %v", err)
+	}
+	server := &xhttp2.Server{MaxConcurrentStreams: 1000}
+	result := &goBenchmarkServer{listener: listener}
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go server.ServeConn(conn, &xhttp2.ServeConnOpts{
+				Handler: stdhttp.HandlerFunc(func(writer stdhttp.ResponseWriter, _ *stdhttp.Request) {
+					_, _ = io.WriteString(writer, "ok")
+				}),
+			})
+		}
+	}()
+	b.Cleanup(func() { _ = listener.Close() })
+	return result
+}
+
+func (s *goBenchmarkServer) URL(path string) string {
+	return "http://" + s.listener.Addr().String() + path
+}
+
+func newBenchmarkHostClient(b *testing.B, addr string) *fasthttp.HostClient {
+	b.Helper()
+	client := &fasthttp.HostClient{
+		Addr:                addr,
+		MaxConns:            1,
+		MaxConnWaitTimeout:  time.Minute,
+		MaxIdleConnDuration: time.Minute,
+	}
+	if err := ConfigureHostClient(client, ClientConfig{
+		Mode:                 PriorKnowledge,
+		MaxConcurrentStreams: 1000,
+	}); err != nil {
+		b.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	b.Cleanup(client.CloseIdleConnections)
+	return client
+}
+
+func newGoBenchmarkClient(b *testing.B) *stdhttp.Client {
+	b.Helper()
+	transport := &xhttp2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+	b.Cleanup(transport.CloseIdleConnections)
+	return &stdhttp.Client{Transport: transport}
+}
+
+func warmFasthttpClient(b *testing.B, client *fasthttp.HostClient, requestURI string) {
+	b.Helper()
+	request := fasthttp.AcquireRequest()
+	response := fasthttp.AcquireResponse()
+	request.SetRequestURI(requestURI)
+	if err := client.Do(request, response); err != nil {
+		b.Fatalf("warming fasthttp HTTP/2 connection: %v", err)
+	}
+	fasthttp.ReleaseRequest(request)
+	fasthttp.ReleaseResponse(response)
+}
+
+func warmGoClient(b *testing.B, client *stdhttp.Client, requestURI string) {
+	b.Helper()
+	response, err := client.Get(requestURI)
+	if err != nil {
+		b.Fatalf("warming Go HTTP/2 connection: %v", err)
+	}
+	_, readErr := io.Copy(io.Discard, response.Body)
+	closeErr := response.Body.Close()
+	if readErr != nil || closeErr != nil {
+		b.Fatalf("warming Go HTTP/2 response: read=%v close=%v", readErr, closeErr)
+	}
+}
+
+func benchmarkFasthttpClient(
+	b *testing.B,
+	client *fasthttp.HostClient,
+	requestURI string,
+	concurrency int,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	var next atomic.Int64
+	var wait sync.WaitGroup
+	b.ResetTimer()
+	for range concurrency {
+		wait.Go(func() {
+			req := fasthttp.AcquireRequest()
+			resp := fasthttp.AcquireResponse()
+			defer fasthttp.ReleaseRequest(req)
+			defer fasthttp.ReleaseResponse(resp)
+			req.SetRequestURI(requestURI)
+			for {
+				iteration := next.Add(1)
+				if iteration > int64(b.N) {
+					return
+				}
+				if err := client.Do(req, resp); err != nil {
+					b.Errorf("Do() error: %v", err)
+					return
+				}
+				resp.ResetBody()
+			}
+		})
+	}
+	wait.Wait()
+	b.StopTimer()
+	runtime.KeepAlive(client)
+}
+
+func benchmarkNetHTTP2Client(
+	b *testing.B,
+	client *stdhttp.Client,
+	requestURI string,
+	concurrency int,
+) {
+	b.Helper()
+	b.ReportAllocs()
+	var next atomic.Int64
+	var wait sync.WaitGroup
+	b.ResetTimer()
+	for range concurrency {
+		wait.Go(func() {
+			req, err := stdhttp.NewRequest(stdhttp.MethodGet, requestURI, nil)
+			if err != nil {
+				b.Errorf("NewRequest() error: %v", err)
+				return
+			}
+			for {
+				iteration := next.Add(1)
+				if iteration > int64(b.N) {
+					return
+				}
+				resp, err := client.Do(req)
+				if err != nil {
+					b.Errorf("Do() error: %v", err)
+					return
+				}
+				_, err = io.Copy(io.Discard, resp.Body)
+				closeErr := resp.Body.Close()
+				if err != nil || closeErr != nil {
+					b.Errorf("reading response: %v, close: %v", err, closeErr)
+					return
+				}
+			}
+		})
+	}
+	wait.Wait()
+	b.StopTimer()
+	runtime.KeepAlive(client)
+}

--- a/http2/client.go
+++ b/http2/client.go
@@ -1,13 +1,13 @@
 package http2
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,11 +18,73 @@ import (
 )
 
 var (
-	errHTTP2Required        = errors.New("http2: server didn't negotiate h2")
-	errClientConnClosed     = errors.New("http2: client connection closed")
-	errClientStreamClosed   = errors.New("http2: client stream closed")
-	errResponseBodyTooLarge = errors.New("http2: response body too large")
+	// ErrHTTP2Required is returned when RequireHTTP2 is configured and TLS
+	// negotiation doesn't select h2.
+	ErrHTTP2Required      = errors.New("http2: server didn't negotiate h2")
+	errClientConnClosed   = errors.New("http2: client connection closed")
+	errClientStreamClosed = errors.New("http2: client stream closed")
 )
+
+type clientConnectionWriteError struct {
+	err error
+}
+
+func (e *clientConnectionWriteError) Error() string { return e.err.Error() }
+func (e *clientConnectionWriteError) Unwrap() error { return e.err }
+
+var clientResultChannelPool sync.Pool
+var clientStreamPool sync.Pool
+var clientHeaderWaiterPool sync.Pool
+
+type clientHeaderWaiter struct {
+	ready chan struct{}
+}
+
+func acquireClientHeaderWaiter() *clientHeaderWaiter {
+	if value := clientHeaderWaiterPool.Get(); value != nil {
+		waiter := value.(*clientHeaderWaiter) //nolint:forcetypeassert
+		select {
+		case <-waiter.ready:
+		default:
+		}
+		return waiter
+	}
+	return &clientHeaderWaiter{ready: make(chan struct{}, 1)}
+}
+
+func releaseClientHeaderWaiter(waiter *clientHeaderWaiter) {
+	select {
+	case <-waiter.ready:
+	default:
+	}
+	clientHeaderWaiterPool.Put(waiter)
+}
+
+func acquireClientResultChannel() chan clientResult {
+	if value := clientResultChannelPool.Get(); value != nil {
+		return value.(chan clientResult) //nolint:forcetypeassert
+	}
+	return make(chan clientResult, 1)
+}
+
+func releaseClientResultChannel(resultChannel chan clientResult) {
+	clientResultChannelPool.Put(resultChannel)
+}
+
+func acquireClientStream() *clientStream {
+	if value := clientStreamPool.Get(); value != nil {
+		return value.(*clientStream) //nolint:forcetypeassert
+	}
+	return &clientStream{}
+}
+
+func releaseClientStream(stream *clientStream) {
+	if stream.headerWaiter != nil {
+		releaseClientHeaderWaiter(stream.headerWaiter)
+	}
+	*stream = clientStream{}
+	clientStreamPool.Put(stream)
+}
 
 type clientResult struct {
 	streamConn fasthttp.StreamConn
@@ -36,11 +98,10 @@ type clientStream struct {
 	req  *fasthttp.Request
 	resp *fasthttp.Response
 
-	result     chan clientResult
-	done       chan struct{}
-	resultSent bool
-	doneClosed bool
-	timer      *time.Timer
+	result       chan clientResult
+	headerWaiter *clientHeaderWaiter
+	resultSent   bool
+	timer        *time.Timer
 
 	requestStarted bool
 	requestBytes   int64
@@ -51,18 +112,23 @@ type clientStream struct {
 	isOpenStream   bool
 	isStreaming    bool
 
-	sendWindow int64
-	recvWindow int64
+	sendWindow          int64
+	recvWindow          int64
+	pendingWindowUpdate int64
 
 	statusCode            int
 	expectedResponseBytes int64
 	responseBytes         int64
 	maxResponseBodySize   int
 	responseBody          *responseBody
+	discardResponseBody   bool
 	err                   error
 	isPush                bool
 	pushComplete          bool
 	promisedRequest       *fasthttp.Request
+	lifecycleReleased     bool
+	callerDone            bool
+	poolable              bool
 }
 
 type pendingPushBlock struct {
@@ -72,17 +138,19 @@ type pendingPushBlock struct {
 }
 
 type clientConn struct {
-	pool    *clientPool
-	hc      *fasthttp.HostClient
-	config  clientConfig
-	lease   *fasthttp.ProtocolClientConn
-	conn    net.Conn
-	framer  *xhttp2.Framer
-	decoder *hpack.Decoder
+	pool          *clientPool
+	hc            *fasthttp.HostClient
+	config        clientConfig
+	lease         *fasthttp.ProtocolClientConn
+	conn          net.Conn
+	framer        *xhttp2.Framer
+	headerDecoder *headerCodec
 
-	writeMu      sync.Mutex
-	encoder      *hpack.Encoder
-	headerBuffer bytes.Buffer
+	writeMu        sync.Mutex
+	bufferedWriter *bufio.Writer
+	encoder        *hpack.Encoder
+	headerBuffer   bytes.Buffer
+	headerStrings  headerStringCache
 
 	mu                       sync.Mutex
 	streams                  map[uint32]*clientStream
@@ -95,12 +163,15 @@ type clientConn struct {
 	peerMaxFrameSize         int
 	peerMaxHeaderListSize    uint64
 	receiveConnectionWindow  int64
+	pendingConnectionUpdate  int64
 	receivedSettings         bool
+	peerExtendedConnect      bool
 	goAway                   bool
 	goAwayLastStreamID       uint32
 	closed                   bool
 	err                      error
 	notify                   chan struct{}
+	waiters                  int
 	created                  time.Time
 	lastIdle                 time.Time
 	idleTimer                *time.Timer
@@ -113,12 +184,14 @@ type clientPool struct {
 	hc        *fasthttp.HostClient
 	config    clientConfig
 
-	mu      sync.Mutex
-	conns   []*clientConn
-	dialing bool
-	h1Only  bool
-	notify  chan struct{}
-	closed  bool
+	mu        sync.Mutex
+	conns     []*clientConn
+	dialing   bool
+	h1Only    bool
+	notify    chan struct{}
+	waiters   int
+	available chan struct{}
+	closed    bool
 }
 
 // Transport is a native fasthttp HTTP/2 client transport. A Transport may be
@@ -179,9 +252,6 @@ func ConfigureClient(c *fasthttp.Client, config ClientConfig) error {
 }
 
 func configureHostClientTransport(hc *fasthttp.HostClient, transport *Transport) error {
-	if hc.Transport != nil {
-		return errors.New("http2: cannot safely preserve a custom HostClient transport as an HTTP/1 fallback")
-	}
 	if transport.config.Mode == PriorKnowledge && hc.IsTLS {
 		return errors.New("http2: prior knowledge mode requires a cleartext HostClient")
 	}
@@ -212,6 +282,7 @@ func (t *Transport) poolFor(hc *fasthttp.HostClient) (*clientPool, error) {
 		hc:        hc,
 		config:    config,
 		notify:    make(chan struct{}),
+		available: make(chan struct{}, 1),
 	}
 	t.pools[hc] = pool
 	return pool, nil
@@ -312,8 +383,13 @@ func (p *clientPool) acquireStream(
 		}
 		if p.dialing {
 			notify := p.notify
+			p.waiters++
 			p.mu.Unlock()
-			if err := waitForClientEvent(notify, deadline, 0); err != nil {
+			err := waitForClientEvent(notify, deadline, 0)
+			p.mu.Lock()
+			p.waiters--
+			p.mu.Unlock()
+			if err != nil {
 				return nil, nil, err
 			}
 			continue
@@ -328,9 +404,9 @@ func (p *clientPool) acquireStream(
 				p.mu.Unlock()
 				return nil, nil, fasthttp.ErrNoFreeConns
 			}
-			notify := p.notify
 			p.mu.Unlock()
-			if err := waitForClientEvent(notify, deadline, p.hc.MaxConnWaitTimeout); err != nil {
+			err := waitForClientEvent(p.available, deadline, p.hc.MaxConnWaitTimeout)
+			if err != nil {
 				return nil, nil, err
 			}
 			continue
@@ -370,7 +446,7 @@ func (p *clientPool) dial(ctx *fasthttp.ProtocolClientContext) (*clientConn, *fa
 	if p.hc.IsTLS && lease.NegotiatedProtocol() != "h2" {
 		if p.config.mode == RequireHTTP2 {
 			_ = lease.Close()
-			return nil, nil, errHTTP2Required
+			return nil, nil, ErrHTTP2Required
 		}
 		return nil, lease, nil
 	}
@@ -383,14 +459,18 @@ func (p *clientPool) dial(ctx *fasthttp.ProtocolClientContext) (*clientConn, *fa
 }
 
 func (p *clientPool) signalLocked() {
+	if p.waiters == 0 {
+		return
+	}
 	close(p.notify)
 	p.notify = make(chan struct{})
 }
 
 func (p *clientPool) streamAvailable() {
-	p.mu.Lock()
-	p.signalLocked()
-	p.mu.Unlock()
+	select {
+	case p.available <- struct{}{}:
+	default:
+	}
 }
 
 func (p *clientPool) remove(conn *clientConn) {
@@ -444,6 +524,9 @@ func waitForClientEvent(notify <-chan struct{}, deadline time.Time, maxWait time
 }
 
 func newClientConn(pool *clientPool, lease *fasthttp.ProtocolClientConn) (*clientConn, error) {
+	if err := validateTLSConnection(lease.Conn()); err != nil {
+		return nil, err
+	}
 	conn := &clientConn{
 		pool:                     pool,
 		hc:                       pool.hc,
@@ -462,12 +545,14 @@ func newClientConn(pool *clientPool, lease *fasthttp.ProtocolClientConn) (*clien
 		notify:                   make(chan struct{}),
 		created:                  time.Now(),
 	}
-	conn.framer = xhttp2.NewFramer(conn.conn, conn.conn)
-	conn.decoder = hpack.NewDecoder(pool.config.maxDecoderTableSize, nil)
-	conn.decoder.SetAllowedMaxDynamicTableSize(pool.config.maxDecoderTableSize)
-	conn.decoder.SetMaxStringLength(int(pool.config.maxHeaderListSize))
-	conn.framer.ReadMetaHeaders = conn.decoder
-	conn.framer.MaxHeaderListSize = pool.config.maxHeaderListSize
+	writeBufferSize := pool.hc.WriteBufferSize
+	if writeBufferSize <= 0 {
+		writeBufferSize = defaultWriteBufferSize
+	}
+	conn.bufferedWriter = bufio.NewWriterSize(conn.conn, writeBufferSize)
+	conn.framer = xhttp2.NewFramer(conn.bufferedWriter, conn.conn)
+	conn.framer.SetReuseFrames()
+	conn.headerDecoder = newHeaderCodec(pool.config.maxDecoderTableSize, pool.config.maxHeaderListSize)
 	conn.framer.SetMaxReadFrameSize(pool.config.maxReadFrameSize)
 	conn.encoder = hpack.NewEncoder(&conn.headerBuffer)
 	conn.encoder.SetMaxDynamicTableSizeLimit(pool.config.maxEncoderTableSize)
@@ -500,9 +585,11 @@ func (c *clientConn) writePrefaceAndSettings() error {
 	}
 	increment := uint32(c.config.connectionWindowSize - 65535)
 	if increment != 0 {
-		return c.framer.WriteWindowUpdate(0, increment)
+		if err := c.framer.WriteWindowUpdate(0, increment); err != nil {
+			return err
+		}
 	}
-	return nil
+	return c.bufferedWriter.Flush()
 }
 
 func boolSetting(value bool) uint32 {
@@ -531,19 +618,20 @@ func (c *clientConn) reserveStream(
 		c.idleTimer.Stop()
 		c.idleTimer = nil
 	}
-	stream := &clientStream{
+	stream := acquireClientStream()
+	*stream = clientStream{
 		id:                    c.nextStreamID,
 		conn:                  c,
 		req:                   req,
 		resp:                  resp,
-		result:                make(chan clientResult, 1),
-		done:                  make(chan struct{}),
+		result:                acquireClientResultChannel(),
 		isOpenStream:          openStream,
 		isStreaming:           openStream || resp.StreamBody,
 		sendWindow:            c.peerInitialStreamWindow,
 		recvWindow:            int64(c.config.streamWindowSize),
 		expectedResponseBytes: -1,
 		maxResponseBodySize:   c.hc.MaxResponseBodySize,
+		poolable:              !openStream,
 	}
 	c.streams[stream.id] = stream
 	c.nextStreamID += 2
@@ -588,22 +676,46 @@ func (c *clientConn) openStream(
 }
 
 func (c *clientConn) waitResult(stream *clientStream, deadline time.Time) clientResult {
+	resultChannel := stream.result
 	if deadline.IsZero() {
-		return <-stream.result
+		result := <-resultChannel
+		releaseClientResultChannel(resultChannel)
+		if !stream.isOpenStream {
+			c.finishClientStreamUse(stream)
+		}
+		return result
 	}
 	timer := time.NewTimer(time.Until(deadline))
 	defer timer.Stop()
 	select {
-	case result := <-stream.result:
+	case result := <-resultChannel:
+		releaseClientResultChannel(resultChannel)
+		if !stream.isOpenStream {
+			c.finishClientStreamUse(stream)
+		}
 		return result
 	case <-timer.C:
 		c.resetStream(stream.id, xhttp2.ErrCodeCancel, fasthttp.ErrTimeout, false)
-		return <-stream.result
+		result := <-resultChannel
+		releaseClientResultChannel(resultChannel)
+		if !stream.isOpenStream {
+			c.finishClientStreamUse(stream)
+		}
+		return result
 	}
 }
 
 func (c *clientConn) writeRequest(stream *clientStream, keepOpen bool, deadline time.Time) error {
 	req := stream.req
+	if len(req.Header.ConnectProtocol()) != 0 {
+		enabled, err := c.waitForExtendedConnect(deadline)
+		if err != nil {
+			return err
+		}
+		if !enabled {
+			return fasthttp.ErrProtocolNotSupported
+		}
+	}
 	var body []byte
 	var reader io.Reader
 	if req.IsBodyStream() {
@@ -616,7 +728,10 @@ func (c *clientConn) writeRequest(stream *clientStream, keepOpen bool, deadline 
 		return errors.New("http2: request body length doesn't match content-length")
 	}
 	if err := c.writeRequestHeaders(stream, !keepOpen && !hasBody, req, deadline); err != nil {
-		c.fail(err)
+		var connectionError *clientConnectionWriteError
+		if errors.As(err, &connectionError) {
+			c.fail(connectionError.err)
+		}
 		return err
 	}
 	c.mu.Lock()
@@ -663,10 +778,12 @@ func (c *clientConn) writeRequestHeaders(
 		if c.nextHeaderStreamID == stream.id {
 			break
 		}
-		notify := c.notify
-		done := stream.done
+		if stream.headerWaiter == nil {
+			stream.headerWaiter = acquireClientHeaderWaiter()
+		}
+		headerReady := stream.headerWaiter.ready
 		c.mu.Unlock()
-		if err := waitForStreamEvent(notify, done, deadline); err != nil {
+		if err := waitForStreamEvent(headerReady, deadline); err != nil {
 			return err
 		}
 	}
@@ -678,6 +795,7 @@ func (c *clientConn) writeRequestHeaders(
 	block, err := encodeRequestHeaders(
 		c.encoder,
 		&c.headerBuffer,
+		&c.headerStrings,
 		req,
 		maxHeaderListSize,
 		c.config.enableExtendedConnect,
@@ -696,7 +814,7 @@ func (c *clientConn) writeRequestHeaders(
 	}); err != nil {
 		c.writeMu.Unlock()
 		c.advanceHeaderStream(stream, false)
-		return err
+		return &clientConnectionWriteError{err: err}
 	}
 	block = block[first:]
 	for len(block) != 0 {
@@ -704,12 +822,28 @@ func (c *clientConn) writeRequestHeaders(
 		if err := c.framer.WriteContinuation(stream.id, length == len(block), block[:length]); err != nil {
 			c.writeMu.Unlock()
 			c.advanceHeaderStream(stream, false)
-			return err
+			return &clientConnectionWriteError{err: err}
 		}
 		block = block[length:]
 	}
+	c.mu.Lock()
+	if c.streams[stream.id] == stream {
+		stream.requestStarted = true
+	}
+	if c.nextHeaderStreamID == stream.id {
+		c.nextHeaderStreamID += 2
+		c.skipUnavailableHeaderStreamsLocked()
+	}
+	pendingHeaders := c.nextHeaderStreamID < c.nextStreamID
+	c.wakeNextHeaderStreamLocked()
+	c.mu.Unlock()
+	if !pendingHeaders {
+		err = c.bufferedWriter.Flush()
+	}
 	c.writeMu.Unlock()
-	c.advanceHeaderStream(stream, true)
+	if err != nil {
+		return &clientConnectionWriteError{err: err}
+	}
 	return nil
 }
 
@@ -722,8 +856,21 @@ func (c *clientConn) advanceHeaderStream(stream *clientStream, started bool) {
 		c.nextHeaderStreamID += 2
 		c.skipUnavailableHeaderStreamsLocked()
 	}
-	c.signalLocked()
+	c.wakeNextHeaderStreamLocked()
+	flush := c.nextHeaderStreamID >= c.nextStreamID
 	c.mu.Unlock()
+	if flush {
+		c.flushBufferedWrites()
+	}
+}
+
+func (c *clientConn) flushBufferedWrites() {
+	c.writeMu.Lock()
+	err := c.bufferedWriter.Flush()
+	c.writeMu.Unlock()
+	if err != nil {
+		c.fail(err)
+	}
 }
 
 func (c *clientConn) skipUnavailableHeaderStreamsLocked() {
@@ -733,6 +880,17 @@ func (c *clientConn) skipUnavailableHeaderStreamsLocked() {
 			return
 		}
 		c.nextHeaderStreamID += 2
+	}
+}
+
+func (c *clientConn) wakeNextHeaderStreamLocked() {
+	stream := c.streams[c.nextHeaderStreamID]
+	if stream == nil || stream.headerWaiter == nil {
+		return
+	}
+	select {
+	case stream.headerWaiter.ready <- struct{}{}:
+	default:
 	}
 }
 
@@ -782,6 +940,83 @@ func (c *clientConn) sendRequestStream(
 
 func (c *clientConn) sendData(stream *clientStream, data []byte, endStream bool, deadline time.Time) error {
 	for len(data) != 0 || endStream {
+		if err := c.waitForSendWindow(stream, data, deadline); err != nil {
+			return err
+		}
+
+		c.writeMu.Lock()
+		framesWritten := 0
+		finished := false
+		var streamErr error
+		var writeErr error
+		for framesWritten < 16 && (len(data) != 0 || endStream) {
+			c.mu.Lock()
+			current := c.streams[stream.id]
+			if current != stream || stream.err != nil {
+				streamErr = stream.err
+				if streamErr == nil {
+					streamErr = errClientStreamClosed
+				}
+				c.mu.Unlock()
+				break
+			}
+			if stream.localClosed {
+				streamErr = errClientStreamClosed
+				c.mu.Unlock()
+				break
+			}
+			amount := 0
+			if len(data) != 0 && c.peerConnectionWindow > 0 && stream.sendWindow > 0 {
+				amount = min(len(data), c.peerMaxFrameSize, int(c.peerConnectionWindow), int(stream.sendWindow))
+			}
+			if len(data) != 0 && amount == 0 {
+				c.mu.Unlock()
+				break
+			}
+			last := amount == len(data) && endStream
+			c.peerConnectionWindow -= int64(amount)
+			stream.sendWindow -= int64(amount)
+			stream.requestBytes += int64(amount)
+			if last {
+				stream.localClosed = true
+			}
+			c.mu.Unlock()
+
+			writeErr = c.framer.WriteData(stream.id, last, data[:amount])
+			if writeErr != nil {
+				break
+			}
+			data = data[amount:]
+			framesWritten++
+			if last {
+				finished = true
+				break
+			}
+		}
+		if framesWritten != 0 && writeErr == nil {
+			writeErr = c.bufferedWriter.Flush()
+		}
+		c.writeMu.Unlock()
+
+		if writeErr != nil {
+			c.fail(writeErr)
+			return writeErr
+		}
+		if streamErr != nil {
+			return streamErr
+		}
+		if finished {
+			c.mu.Lock()
+			c.maybeFinishStreamLocked(stream)
+			c.mu.Unlock()
+			return nil
+		}
+	}
+	return nil
+}
+
+func (c *clientConn) waitForSendWindow(stream *clientStream, data []byte, deadline time.Time) error {
+	for {
 		c.mu.Lock()
 		current := c.streams[stream.id]
 		if current != stream || stream.err != nil {
@@ -796,73 +1031,79 @@ func (c *clientConn) sendData(stream *clientStream, data []byte, endStream bool,
 			c.mu.Unlock()
 			return errClientStreamClosed
 		}
-		amount := 0
-		if len(data) != 0 && c.peerConnectionWindow > 0 && stream.sendWindow > 0 {
-			amount = min(len(data), c.peerMaxFrameSize, int(c.peerConnectionWindow), int(stream.sendWindow))
-		}
-		if len(data) != 0 && amount == 0 {
-			notify := c.notify
-			done := stream.done
+		if len(data) == 0 || c.peerConnectionWindow > 0 && stream.sendWindow > 0 {
 			c.mu.Unlock()
-			if err := waitForStreamEvent(notify, done, deadline); err != nil {
-				return err
-			}
-			continue
+			return nil
 		}
-		last := amount == len(data) && endStream
-		c.peerConnectionWindow -= int64(amount)
-		stream.sendWindow -= int64(amount)
-		stream.requestBytes += int64(amount)
-		if last {
-			stream.localClosed = true
-		}
+		notify := c.notify
+		c.waiters++
 		c.mu.Unlock()
-
-		c.writeMu.Lock()
-		err := c.framer.WriteData(stream.id, last, data[:amount])
-		c.writeMu.Unlock()
+		err := waitForStreamEvent(notify, deadline)
+		c.mu.Lock()
+		c.waiters--
+		c.mu.Unlock()
 		if err != nil {
-			c.fail(err)
 			return err
 		}
-		data = data[amount:]
-		if last {
-			c.mu.Lock()
-			c.maybeFinishStreamLocked(stream)
-			c.mu.Unlock()
-			return nil
-		}
 	}
-	return nil
 }
 
-func waitForStreamEvent(notify, done <-chan struct{}, deadline time.Time) error {
+func waitForStreamEvent(notify <-chan struct{}, deadline time.Time) error {
 	if deadline.IsZero() {
-		select {
-		case <-notify:
-			return nil
-		case <-done:
-			return errClientStreamClosed
-		}
+		<-notify
+		return nil
 	}
 	timer := time.NewTimer(time.Until(deadline))
 	defer timer.Stop()
 	select {
 	case <-notify:
 		return nil
-	case <-done:
-		return errClientStreamClosed
 	case <-timer.C:
 		return fasthttp.ErrTimeout
 	}
 }
 
 func (c *clientConn) readLoop() {
+	waitingForPing := false
 	for {
+		readTimeout := c.config.readIdleTimeout
+		if waitingForPing {
+			readTimeout = c.config.pingTimeout
+		}
+		if readTimeout > 0 {
+			_ = c.conn.SetReadDeadline(time.Now().Add(readTimeout))
+		}
 		frame, err := c.framer.ReadFrame()
 		if err != nil {
+			if isTimeout(err) && c.config.readIdleTimeout > 0 && !waitingForPing {
+				if pingErr := c.writeControl(func() error {
+					return c.framer.WritePing(false, [8]byte{'f', 'a', 's', 't', 'h', '2', 0, 2})
+				}); pingErr != nil {
+					return
+				}
+				waitingForPing = true
+				continue
+			}
 			c.fail(err)
 			return
+		}
+		waitingForPing = false
+		c.mu.Lock()
+		firstFrame := !c.receivedSettings
+		c.mu.Unlock()
+		if firstFrame {
+			settings, ok := frame.(*xhttp2.SettingsFrame)
+			if !ok || settings.IsAck() {
+				c.fail(errors.New("http2: server's first frame isn't settings"))
+				return
+			}
+		}
+		if headers, ok := frame.(*xhttp2.HeadersFrame); ok {
+			if err := c.processDecodedResponseHeaders(headers); err != nil {
+				c.fail(err)
+				return
+			}
+			continue
 		}
 		if err := c.processFrame(frame); err != nil {
 			c.fail(err)
@@ -884,11 +1125,19 @@ func (c *clientConn) processFrame(frame xhttp2.Frame) error {
 	switch frame := frame.(type) {
 	case *xhttp2.SettingsFrame:
 		return c.processSettings(frame)
-	case *xhttp2.MetaHeadersFrame:
-		return c.processResponseHeaders(frame)
 	case *xhttp2.DataFrame:
 		return c.processResponseData(frame)
 	case *xhttp2.RSTStreamFrame:
+		c.countError("stream_" + strings.ToLower(frame.ErrCode.String()))
+		c.mu.Lock()
+		stream, idle := c.streamStateLocked(frame.StreamID)
+		c.mu.Unlock()
+		if stream == nil {
+			if idle {
+				return errors.New("http2: reset on idle stream")
+			}
+			return nil
+		}
 		retry := frame.ErrCode == xhttp2.ErrCodeRefusedStream
 		c.failStream(frame.StreamID, fmt.Errorf("http2: peer reset stream: %s", frame.ErrCode), retry)
 		return nil
@@ -906,9 +1155,52 @@ func (c *clientConn) processFrame(frame xhttp2.Frame) error {
 		return c.processPushPromise(frame)
 	case *xhttp2.ContinuationFrame:
 		return c.processPushContinuation(frame)
+	case *xhttp2.PriorityFrame:
+		if frame.StreamID == frame.PriorityParam.StreamDep {
+			c.resetStream(frame.StreamID, xhttp2.ErrCodeProtocol, errors.New("http2: stream depends on itself"), false)
+		}
+		return nil
 	default:
 		return nil
 	}
+}
+
+type decodedClientHeaders struct {
+	streamID  uint32
+	endStream bool
+	truncated bool
+	fields    []hpack.HeaderField
+}
+
+func (c *clientConn) processDecodedResponseHeaders(frame *xhttp2.HeadersFrame) error {
+	streamID := frame.StreamID
+	endStream := frame.StreamEnded()
+	selfDependent := frame.HasPriority() && frame.Priority.StreamDep == streamID
+	fieldStorage := acquireIncomingHeaderFields(8)
+	decoded, truncated, invalid, err := c.headerDecoder.decode(
+		c.framer,
+		streamID,
+		frame,
+		fieldStorage.fields,
+	)
+	header := decodedClientHeaders{
+		streamID:  streamID,
+		endStream: endStream,
+		truncated: truncated,
+		fields:    decoded,
+	}
+	event := incomingFrame{fields: decoded, fieldStorage: fieldStorage}
+	defer releaseIncomingFrame(&event)
+	if err != nil {
+		return err
+	}
+	if invalid != nil {
+		return c.rejectHeaderBlock(streamID, xhttp2.ErrCodeProtocol, invalid)
+	}
+	if selfDependent {
+		return c.rejectHeaderBlock(streamID, xhttp2.ErrCodeProtocol, errors.New("http2: stream depends on itself"))
+	}
+	return c.processResponseHeaders(&header)
 }
 
 func (c *clientConn) processSettings(frame *xhttp2.SettingsFrame) error {
@@ -920,6 +1212,10 @@ func (c *clientConn) processSettings(frame *xhttp2.SettingsFrame) error {
 	c.mu.Lock()
 	for i := range frame.NumSettings() {
 		setting := frame.Setting(i)
+		if err := setting.Valid(); err != nil {
+			c.mu.Unlock()
+			return err
+		}
 		switch setting.ID {
 		case xhttp2.SettingHeaderTableSize:
 			value := setting.Val
@@ -944,9 +1240,16 @@ func (c *clientConn) processSettings(frame *xhttp2.SettingsFrame) error {
 			c.peerMaxFrameSize = int(setting.Val)
 		case xhttp2.SettingMaxHeaderListSize:
 			c.peerMaxHeaderListSize = uint64(setting.Val)
+		case xhttp2.SettingEnableConnectProtocol:
+			c.peerExtendedConnect = setting.Val == 1
 		case xhttp2.SettingEnablePush:
 			c.mu.Unlock()
 			return errors.New("http2: server sent SETTINGS_ENABLE_PUSH")
+		case xhttp2.SettingNoRFC7540Priorities:
+			if setting.Val > 1 {
+				c.mu.Unlock()
+				return errors.New("http2: invalid SETTINGS_NO_RFC7540_PRIORITIES")
+			}
 		}
 	}
 	c.receivedSettings = true
@@ -957,6 +1260,9 @@ func (c *clientConn) processSettings(frame *xhttp2.SettingsFrame) error {
 		c.encoder.SetMaxDynamicTableSize(encoderTableSize)
 	}
 	err := c.framer.WriteSettingsAck()
+	if err == nil {
+		err = c.bufferedWriter.Flush()
+	}
 	c.writeMu.Unlock()
 	if err != nil {
 		c.fail(err)
@@ -964,59 +1270,100 @@ func (c *clientConn) processSettings(frame *xhttp2.SettingsFrame) error {
 	return err
 }
 
-func (c *clientConn) processResponseHeaders(frame *xhttp2.MetaHeadersFrame) error {
-	if frame.Truncated {
-		c.resetStream(frame.StreamID, xhttp2.ErrCodeEnhanceYourCalm, errInvalidResponseHeaders, false)
-		return nil
+func (c *clientConn) waitForExtendedConnect(deadline time.Time) (bool, error) {
+	for {
+		c.mu.Lock()
+		if c.closed {
+			err := c.err
+			if err == nil {
+				err = errClientConnClosed
+			}
+			c.mu.Unlock()
+			return false, err
+		}
+		if c.receivedSettings {
+			enabled := c.peerExtendedConnect
+			c.mu.Unlock()
+			return enabled, nil
+		}
+		notify := c.notify
+		c.waiters++
+		c.mu.Unlock()
+		err := waitForStreamEvent(notify, deadline)
+		c.mu.Lock()
+		c.waiters--
+		c.mu.Unlock()
+		if err != nil {
+			return false, err
+		}
+	}
+}
+
+func (c *clientConn) processResponseHeaders(frame *decodedClientHeaders) error {
+	if frame.truncated {
+		return c.rejectHeaderBlock(frame.streamID, xhttp2.ErrCodeEnhanceYourCalm, errInvalidResponseHeaders)
 	}
 	c.mu.Lock()
-	stream := c.streams[frame.StreamID]
+	stream := c.streams[frame.streamID]
 	if stream == nil {
+		_, idle := c.streamStateLocked(frame.streamID)
 		c.mu.Unlock()
+		if idle {
+			return errors.New("http2: response headers on idle stream")
+		}
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(frame.streamID, xhttp2.ErrCodeStreamClosed)
+		})
+	}
+	reject := func(cause error) error {
+		c.mu.Unlock()
+		c.resetStream(frame.streamID, xhttp2.ErrCodeProtocol, cause, false)
 		return nil
 	}
 	if stream.responseHeader {
-		if stream.remoteClosed || !frame.StreamEnded() {
-			c.mu.Unlock()
-			return errors.New("http2: invalid response trailers")
+		if stream.remoteClosed || !frame.endStream {
+			return reject(errors.New("http2: invalid response trailers"))
 		}
-		if err := populateResponseTrailers(stream.resp, frame.Fields); err != nil {
-			c.mu.Unlock()
-			return err
+		if err := populateResponseTrailers(stream.resp, frame.fields); err != nil {
+			return reject(err)
 		}
 		c.endResponseLocked(stream, nil)
 		c.mu.Unlock()
 		return nil
 	}
-	status, err := responseStatus(frame.Fields)
+	status, err := responseStatus(frame.fields)
 	if err != nil {
-		c.mu.Unlock()
-		return err
+		return reject(err)
 	}
 	if status >= 100 && status < 200 {
-		if status == 101 || frame.StreamEnded() {
-			c.mu.Unlock()
-			return errors.New("http2: invalid informational response")
+		if status == 101 || frame.endStream {
+			return reject(errors.New("http2: invalid informational response"))
 		}
 		c.mu.Unlock()
 		return nil
 	}
 	status, contentLength, err := populateResponse(
 		stream.resp,
-		frame.Fields,
+		frame.fields,
 		c.hc.DisableHeaderNamesNormalizing,
 	)
 	if err != nil {
-		c.mu.Unlock()
-		return err
+		return reject(err)
 	}
 	stream.statusCode = status
 	stream.expectedResponseBytes = contentLength
 	stream.responseHeader = true
 	c.lease.ApplyResponseMetadata(stream.resp)
 	if responseHasNoBody(stream) && contentLength > 0 && !stream.req.Header.IsHead() {
+		return reject(errors.New("http2: body-forbidden response has a positive content-length"))
+	}
+	if stream.maxResponseBodySize > 0 && contentLength > int64(stream.maxResponseBodySize) {
 		c.mu.Unlock()
-		return errors.New("http2: body-forbidden response has a positive content-length")
+		c.resetStream(frame.streamID, xhttp2.ErrCodeCancel, fasthttp.ErrBodyTooLarge, false)
+		return nil
+	}
+	if !stream.isStreaming && contentLength > 0 {
+		c.lease.PrepareResponseBody(stream.resp, int(min(contentLength, maxResponseBodyPreallocation)))
 	}
 	if stream.isStreaming {
 		body := newResponseBody(
@@ -1034,9 +1381,16 @@ func (c *clientConn) processResponseHeaders(frame *xhttp2.MetaHeadersFrame) erro
 			stream.resp.Header.Del(fasthttp.HeaderTransferEncoding)
 		}
 	}
+	rejectOpenStream := false
 	if stream.isOpenStream {
 		if status < 200 || status >= 300 {
-			c.sendResultLocked(stream, clientResult{err: fmt.Errorf("http2: extended connect failed with status %d", status)})
+			err := fmt.Errorf("http2: extended connect failed with status %d", status)
+			stream.err = err
+			stream.bodyDone = true
+			stream.localClosed = true
+			stream.responseBody.closeWithError(err)
+			c.sendResultLocked(stream, clientResult{err: err})
+			rejectOpenStream = !frame.endStream
 		} else {
 			streamConn := &clientStreamConn{stream: stream, read: stream.responseBody}
 			c.sendResultLocked(stream, clientResult{streamConn: streamConn})
@@ -1044,27 +1398,30 @@ func (c *clientConn) processResponseHeaders(frame *xhttp2.MetaHeadersFrame) erro
 	} else if stream.isStreaming {
 		c.sendResultLocked(stream, clientResult{})
 	}
-	if frame.StreamEnded() {
+	if frame.endStream {
 		c.endResponseLocked(stream, nil)
 	}
 	c.mu.Unlock()
+	if rejectOpenStream {
+		c.resetStream(frame.streamID, xhttp2.ErrCodeCancel, stream.err, false)
+	}
 	return nil
 }
 
-func responseStatus(fields []hpack.HeaderField) (int, error) {
-	for _, field := range fields {
-		if field.Name == ":status" {
-			if len(field.Value) != 3 {
-				return 0, errInvalidResponseHeaders
-			}
-			value, err := strconv.Atoi(field.Value)
-			if err != nil {
-				return 0, errInvalidResponseHeaders
-			}
-			return value, nil
-		}
+func (c *clientConn) rejectHeaderBlock(streamID uint32, code xhttp2.ErrCode, cause error) error {
+	c.mu.Lock()
+	stream, idle := c.streamStateLocked(streamID)
+	c.mu.Unlock()
+	if stream != nil {
+		c.resetStream(streamID, code, cause, false)
+		return nil
 	}
-	return 0, errInvalidResponseHeaders
+	if idle {
+		return fmt.Errorf("http2: invalid header block on idle stream: %w", cause)
+	}
+	return c.writeControl(func() error {
+		return c.framer.WriteRSTStream(streamID, xhttp2.ErrCodeStreamClosed)
+	})
 }
 
 func responseHasNoBody(stream *clientStream) bool {
@@ -1076,9 +1433,20 @@ func (c *clientConn) processResponseData(frame *xhttp2.DataFrame) error {
 	data := frame.Data()
 	c.mu.Lock()
 	stream := c.streams[frame.StreamID]
-	if stream == nil || !stream.responseHeader || stream.remoteClosed {
+	if stream == nil {
+		_, idle := c.streamStateLocked(frame.StreamID)
 		c.mu.Unlock()
-		return errors.New("http2: data on an invalid response stream")
+		if idle {
+			return errors.New("http2: data on idle response stream")
+		}
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(frame.StreamID, xhttp2.ErrCodeStreamClosed)
+		})
+	}
+	if !stream.responseHeader || stream.remoteClosed {
+		c.mu.Unlock()
+		c.resetStream(frame.StreamID, xhttp2.ErrCodeProtocol, errors.New("http2: data on an invalid response stream"), false)
+		return nil
 	}
 	c.receiveConnectionWindow -= flowLength
 	stream.recvWindow -= flowLength
@@ -1088,7 +1456,8 @@ func (c *clientConn) processResponseData(frame *xhttp2.DataFrame) error {
 	}
 	if responseHasNoBody(stream) && len(data) != 0 {
 		c.mu.Unlock()
-		return errors.New("http2: response body isn't permitted")
+		c.resetStream(frame.StreamID, xhttp2.ErrCodeProtocol, errors.New("http2: response body isn't permitted"), false)
+		return nil
 	}
 	stream.responseBytes += int64(len(data))
 	if stream.expectedResponseBytes >= 0 && stream.responseBytes > stream.expectedResponseBytes {
@@ -1098,17 +1467,20 @@ func (c *clientConn) processResponseData(frame *xhttp2.DataFrame) error {
 	}
 	if stream.maxResponseBodySize > 0 && stream.responseBytes > int64(stream.maxResponseBodySize) {
 		c.mu.Unlock()
-		c.resetStream(frame.StreamID, xhttp2.ErrCodeCancel, errResponseBodyTooLarge, false)
+		c.resetStream(frame.StreamID, xhttp2.ErrCodeCancel, fasthttp.ErrBodyTooLarge, false)
 		return nil
 	}
 	body := stream.responseBody
+	discardBody := stream.discardResponseBody
 	if body == nil {
 		stream.resp.AppendBody(data)
 	}
 	ended := frame.StreamEnded()
 	c.mu.Unlock()
 
-	if body != nil && len(data) != 0 {
+	if discardBody && len(data) != 0 {
+		c.consumeResponseBytes(frame.StreamID, len(data))
+	} else if body != nil && len(data) != 0 {
 		if err := body.write(data); err != nil {
 			c.closeResponseBody(frame.StreamID, len(data))
 			return nil
@@ -1157,17 +1529,36 @@ func (c *clientConn) consumeResponseBytes(streamID uint32, amount int) {
 	}
 	c.mu.Lock()
 	stream := c.streams[streamID]
-	c.receiveConnectionWindow += int64(amount)
+	c.pendingConnectionUpdate += int64(amount)
+	connectionIncrement := int64(0)
+	connectionThreshold := int64(c.config.connectionWindowSize) / 2
+	if c.pendingConnectionUpdate >= connectionThreshold {
+		connectionIncrement = c.pendingConnectionUpdate
+		c.pendingConnectionUpdate = 0
+		c.receiveConnectionWindow += connectionIncrement
+	}
+	streamIncrement := int64(0)
 	if stream != nil {
-		stream.recvWindow += int64(amount)
+		stream.pendingWindowUpdate += int64(amount)
+		streamThreshold := int64(c.config.streamWindowSize) / 2
+		if stream.pendingWindowUpdate >= streamThreshold {
+			streamIncrement = stream.pendingWindowUpdate
+			stream.pendingWindowUpdate = 0
+			stream.recvWindow += streamIncrement
+		}
 	}
 	c.mu.Unlock()
+	if connectionIncrement == 0 && streamIncrement == 0 {
+		return
+	}
 	_ = c.writeControl(func() error {
-		if err := c.framer.WriteWindowUpdate(0, uint32(amount)); err != nil {
-			return err
+		if connectionIncrement != 0 {
+			if err := c.framer.WriteWindowUpdate(0, uint32(connectionIncrement)); err != nil {
+				return err
+			}
 		}
-		if stream != nil {
-			return c.framer.WriteWindowUpdate(streamID, uint32(amount))
+		if streamIncrement != 0 {
+			return c.framer.WriteWindowUpdate(streamID, uint32(streamIncrement))
 		}
 		return nil
 	})
@@ -1180,6 +1571,10 @@ func (c *clientConn) closeResponseBody(streamID uint32, discarded int) {
 	c.mu.Lock()
 	stream := c.streams[streamID]
 	remoteOpen := stream != nil && !stream.remoteClosed
+	if stream != nil && stream.isOpenStream {
+		stream.discardResponseBody = true
+		remoteOpen = false
+	}
 	c.mu.Unlock()
 	if remoteOpen {
 		c.resetStream(streamID, xhttp2.ErrCodeCancel, errClientStreamClosed, false)
@@ -1200,7 +1595,11 @@ func (c *clientConn) processWindowUpdate(frame *xhttp2.WindowUpdateFrame) error 
 	defer c.mu.Unlock()
 	if frame.StreamID == 0 {
 		if c.peerConnectionWindow+int64(frame.Increment) > math.MaxInt32 {
-			return errors.New("http2: connection send window overflow")
+			return fmt.Errorf(
+				"http2: client connection send window overflow: current=%d increment=%d",
+				c.peerConnectionWindow,
+				frame.Increment,
+			)
 		}
 		c.peerConnectionWindow += int64(frame.Increment)
 		c.signalLocked()
@@ -1212,8 +1611,22 @@ func (c *clientConn) processWindowUpdate(frame *xhttp2.WindowUpdateFrame) error 
 		}
 		stream.sendWindow += int64(frame.Increment)
 		c.signalLocked()
+		return nil
+	}
+	if _, idle := c.streamStateLocked(frame.StreamID); idle {
+		return errors.New("http2: window update on idle stream")
 	}
 	return nil
+}
+
+func (c *clientConn) streamStateLocked(streamID uint32) (*clientStream, bool) {
+	if stream := c.streams[streamID]; stream != nil {
+		return stream, false
+	}
+	if streamID&1 == 1 {
+		return nil, streamID >= c.nextStreamID
+	}
+	return nil, streamID > c.lastPromisedStreamID
 }
 
 func (c *clientConn) processGoAway(frame *xhttp2.GoAwayFrame) {
@@ -1226,8 +1639,12 @@ func (c *clientConn) processGoAway(frame *xhttp2.GoAwayFrame) {
 		}
 	}
 	c.signalLocked()
+	closeNow := c.activeStreams == 0
 	c.mu.Unlock()
 	c.pool.streamAvailable()
+	if closeNow {
+		c.closeIfIdle()
+	}
 }
 
 func (c *clientConn) processPushPromise(frame *xhttp2.PushPromiseFrame) error {
@@ -1290,30 +1707,26 @@ func (c *clientConn) processPushContinuation(frame *xhttp2.ContinuationFrame) er
 }
 
 func (c *clientConn) finishPushPromise(pending *pendingPushBlock) error {
-	fields := make([]hpack.HeaderField, 0, 8)
-	headerSize := uint64(0)
-	c.decoder.SetEmitFunc(func(field hpack.HeaderField) {
-		headerSize += uint64(len(field.Name) + len(field.Value) + 32)
-		fields = append(fields, hpack.HeaderField{
-			Name:      strings.Clone(field.Name),
-			Value:     strings.Clone(field.Value),
-			Sensitive: field.Sensitive,
-		})
-	})
-	if _, err := c.decoder.Write(pending.block); err != nil {
+	fieldStorage := acquireIncomingHeaderFields(8)
+	decoded, truncated, invalid, err := c.headerDecoder.decodeComplete(pending.block, fieldStorage.fields)
+	event := incomingFrame{fields: decoded, fieldStorage: fieldStorage}
+	defer releaseIncomingFrame(&event)
+	if err != nil {
 		return err
 	}
-	if err := c.decoder.Close(); err != nil {
-		return err
-	}
-	if headerSize > uint64(c.config.maxHeaderListSize) {
+	if truncated {
 		return c.writeControl(func() error {
 			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeEnhanceYourCalm)
 		})
 	}
+	if invalid != nil {
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeProtocol)
+		})
+	}
 
 	promised := fasthttp.AcquireRequest()
-	if err := populatePromisedRequest(promised, fields); err != nil {
+	if err := populatePromisedRequest(promised, decoded); err != nil {
 		fasthttp.ReleaseRequest(promised)
 		return c.writeControl(func() error {
 			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeProtocol)
@@ -1350,13 +1763,12 @@ func (c *clientConn) finishPushPromise(pending *pendingPushBlock) error {
 			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeCancel)
 		})
 	}
-	stream := &clientStream{
+	stream := acquireClientStream()
+	*stream = clientStream{
 		id:                    pending.promisedID,
 		conn:                  c,
 		req:                   promised,
 		resp:                  response,
-		result:                make(chan clientResult, 1),
-		done:                  make(chan struct{}),
 		requestStarted:        true,
 		localClosed:           true,
 		bodyDone:              true,
@@ -1366,6 +1778,8 @@ func (c *clientConn) finishPushPromise(pending *pendingPushBlock) error {
 		maxResponseBodySize:   c.hc.MaxResponseBodySize,
 		isPush:                true,
 		promisedRequest:       promised,
+		callerDone:            true,
+		poolable:              true,
 	}
 	c.streams[stream.id] = stream
 	c.activeStreams++
@@ -1376,6 +1790,9 @@ func (c *clientConn) finishPushPromise(pending *pendingPushBlock) error {
 func (c *clientConn) writeControl(write func() error) error {
 	c.writeMu.Lock()
 	err := write()
+	if err == nil {
+		err = c.bufferedWriter.Flush()
+	}
 	c.writeMu.Unlock()
 	if err != nil {
 		c.fail(err)
@@ -1384,15 +1801,19 @@ func (c *clientConn) writeControl(write func() error) error {
 }
 
 func (c *clientConn) resetStream(streamID uint32, code xhttp2.ErrCode, cause error, retry bool) {
+	c.countError("stream_" + strings.ToLower(code.String()))
 	c.mu.Lock()
 	stream := c.streams[streamID]
 	if stream == nil {
 		c.mu.Unlock()
 		return
 	}
+	requestStarted := stream.requestStarted
 	c.failStreamLocked(stream, cause, retry)
 	c.mu.Unlock()
-	_ = c.writeControl(func() error { return c.framer.WriteRSTStream(streamID, code) })
+	if requestStarted {
+		_ = c.writeControl(func() error { return c.framer.WriteRSTStream(streamID, code) })
+	}
 }
 
 func (c *clientConn) failStream(streamID uint32, cause error, retry bool) {
@@ -1414,8 +1835,18 @@ func (c *clientConn) failStreamLocked(stream *clientStream, cause error, retry b
 	if !stream.isPush {
 		c.sendResultLocked(stream, clientResult{retry: retry && !stream.responseHeader, err: cause})
 	}
+	if stream.headerWaiter != nil {
+		select {
+		case stream.headerWaiter.ready <- struct{}{}:
+		default:
+		}
+	}
 	c.releaseStreamLocked(stream)
 	c.skipUnavailableHeaderStreamsLocked()
+	c.wakeNextHeaderStreamLocked()
+	if c.nextHeaderStreamID >= c.nextStreamID {
+		go c.flushBufferedWrites()
+	}
 }
 
 func (c *clientConn) sendResultLocked(stream *clientStream, result clientResult) {
@@ -1442,11 +1873,10 @@ func (c *clientConn) releaseStreamLocked(stream *clientStream) {
 	}
 	delete(c.streams, stream.id)
 	if stream.timer != nil {
-		stream.timer.Stop()
-	}
-	if !stream.doneClosed {
-		close(stream.done)
-		stream.doneClosed = true
+		if !stream.timer.Stop() {
+			stream.poolable = false
+		}
+		stream.timer = nil
 	}
 	if c.activeStreams > 0 {
 		c.activeStreams--
@@ -1469,19 +1899,39 @@ func (c *clientConn) releaseStreamLocked(stream *clientStream) {
 		stream.req = nil
 		stream.resp = nil
 	}
+	stream.lifecycleReleased = true
+	if stream.callerDone && stream.poolable {
+		releaseClientStream(stream)
+	}
 	c.lastIdle = time.Now()
 	c.signalLocked()
 	if c.activeStreams == 0 {
+		if c.goAway {
+			go c.closeIfIdle()
+			return
+		}
 		idleTimeout := c.hc.MaxIdleConnDuration
 		if idleTimeout <= 0 {
 			idleTimeout = fasthttp.DefaultMaxIdleConnDuration
 		}
 		c.idleTimer = time.AfterFunc(idleTimeout, c.closeIfIdle)
 	}
-	go c.pool.streamAvailable()
+	c.pool.streamAvailable()
+}
+
+func (c *clientConn) finishClientStreamUse(stream *clientStream) {
+	c.mu.Lock()
+	stream.callerDone = true
+	if stream.lifecycleReleased && stream.poolable {
+		releaseClientStream(stream)
+	}
+	c.mu.Unlock()
 }
 
 func (c *clientConn) signalLocked() {
+	if c.waiters == 0 {
+		return
+	}
 	close(c.notify)
 	c.notify = make(chan struct{})
 }
@@ -1502,8 +1952,15 @@ func (c *clientConn) fail(cause error) {
 	}
 	c.signalLocked()
 	c.mu.Unlock()
+	c.countError("connection_error")
 	_ = c.lease.Close()
 	c.pool.remove(c)
+}
+
+func (c *clientConn) countError(errorType string) {
+	if c.config.countError != nil {
+		c.config.countError(errorType)
+	}
 }
 
 func (c *clientConn) closeIfIdle() {

--- a/http2/client.go
+++ b/http2/client.go
@@ -1,0 +1,1523 @@
+package http2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	xhttp2 "golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+var (
+	errHTTP2Required        = errors.New("http2: server didn't negotiate h2")
+	errClientConnClosed     = errors.New("http2: client connection closed")
+	errClientStreamClosed   = errors.New("http2: client stream closed")
+	errResponseBodyTooLarge = errors.New("http2: response body too large")
+)
+
+type clientResult struct {
+	streamConn fasthttp.StreamConn
+	retry      bool
+	err        error
+}
+
+type clientStream struct {
+	id   uint32
+	conn *clientConn
+	req  *fasthttp.Request
+	resp *fasthttp.Response
+
+	result     chan clientResult
+	done       chan struct{}
+	resultSent bool
+	doneClosed bool
+	timer      *time.Timer
+
+	requestStarted bool
+	requestBytes   int64
+	localClosed    bool
+	remoteClosed   bool
+	responseHeader bool
+	bodyDone       bool
+	isOpenStream   bool
+	isStreaming    bool
+
+	sendWindow int64
+	recvWindow int64
+
+	statusCode            int
+	expectedResponseBytes int64
+	responseBytes         int64
+	maxResponseBodySize   int
+	responseBody          *responseBody
+	err                   error
+	isPush                bool
+	pushComplete          bool
+	promisedRequest       *fasthttp.Request
+}
+
+type pendingPushBlock struct {
+	parentID   uint32
+	promisedID uint32
+	block      []byte
+}
+
+type clientConn struct {
+	pool    *clientPool
+	hc      *fasthttp.HostClient
+	config  clientConfig
+	lease   *fasthttp.ProtocolClientConn
+	conn    net.Conn
+	framer  *xhttp2.Framer
+	decoder *hpack.Decoder
+
+	writeMu      sync.Mutex
+	encoder      *hpack.Encoder
+	headerBuffer bytes.Buffer
+
+	mu                       sync.Mutex
+	streams                  map[uint32]*clientStream
+	nextStreamID             uint32
+	nextHeaderStreamID       uint32
+	activeStreams            uint32
+	peerMaxConcurrentStreams uint32
+	peerInitialStreamWindow  int64
+	peerConnectionWindow     int64
+	peerMaxFrameSize         int
+	peerMaxHeaderListSize    uint64
+	receiveConnectionWindow  int64
+	receivedSettings         bool
+	goAway                   bool
+	goAwayLastStreamID       uint32
+	closed                   bool
+	err                      error
+	notify                   chan struct{}
+	created                  time.Time
+	lastIdle                 time.Time
+	idleTimer                *time.Timer
+	lastPromisedStreamID     uint32
+	pendingPush              *pendingPushBlock
+}
+
+type clientPool struct {
+	transport *Transport
+	hc        *fasthttp.HostClient
+	config    clientConfig
+
+	mu      sync.Mutex
+	conns   []*clientConn
+	dialing bool
+	h1Only  bool
+	notify  chan struct{}
+	closed  bool
+}
+
+// Transport is a native fasthttp HTTP/2 client transport. A Transport may be
+// shared by multiple HostClient values.
+type Transport struct {
+	config      ClientConfig
+	configError error
+
+	mu    sync.Mutex
+	pools map[*fasthttp.HostClient]*clientPool
+}
+
+// NewTransport constructs an HTTP/2 transport. ConfigureHostClient or
+// HostClient.RegisterProtocolTransport installs it without replacing the
+// existing HTTP/1 transport.
+func NewTransport(config ClientConfig) *Transport {
+	_, err := normalizeClientConfig(nil, config)
+	return &Transport{
+		config:      config,
+		configError: err,
+		pools:       make(map[*fasthttp.HostClient]*clientPool),
+	}
+}
+
+// ConfigureHostClient enables HTTP/2 on hc while preserving the built-in
+// HTTP/1 transport as its fallback.
+func ConfigureHostClient(hc *fasthttp.HostClient, config ClientConfig) error {
+	if hc == nil {
+		return errors.New("http2: host client is nil")
+	}
+	transport := NewTransport(config)
+	if transport.configError != nil {
+		return transport.configError
+	}
+	return configureHostClientTransport(hc, transport)
+}
+
+// ConfigureClient arranges for every HostClient lazily created by c to use a
+// shared HTTP/2 transport. Existing ConfigureClient behavior runs first.
+func ConfigureClient(c *fasthttp.Client, config ClientConfig) error {
+	if c == nil {
+		return errors.New("http2: client is nil")
+	}
+	transport := NewTransport(config)
+	if transport.configError != nil {
+		return transport.configError
+	}
+	previous := c.ConfigureClient
+	c.ConfigureClient = func(hc *fasthttp.HostClient) error {
+		if previous != nil {
+			if err := previous(hc); err != nil {
+				return err
+			}
+		}
+		return configureHostClientTransport(hc, transport)
+	}
+	return nil
+}
+
+func configureHostClientTransport(hc *fasthttp.HostClient, transport *Transport) error {
+	if hc.Transport != nil {
+		return errors.New("http2: cannot safely preserve a custom HostClient transport as an HTTP/1 fallback")
+	}
+	if transport.config.Mode == PriorKnowledge && hc.IsTLS {
+		return errors.New("http2: prior knowledge mode requires a cleartext HostClient")
+	}
+	if transport.config.Mode == RequireHTTP2 && !hc.IsTLS {
+		return errors.New("http2: require HTTP/2 mode requires a TLS HostClient")
+	}
+	if _, err := normalizeClientConfig(hc, transport.config); err != nil {
+		return err
+	}
+	return hc.RegisterProtocolTransport(transport)
+}
+
+func (t *Transport) poolFor(hc *fasthttp.HostClient) (*clientPool, error) {
+	if t.configError != nil {
+		return nil, t.configError
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if pool := t.pools[hc]; pool != nil {
+		return pool, nil
+	}
+	config, err := normalizeClientConfig(hc, t.config)
+	if err != nil {
+		return nil, err
+	}
+	pool := &clientPool{
+		transport: t,
+		hc:        hc,
+		config:    config,
+		notify:    make(chan struct{}),
+	}
+	t.pools[hc] = pool
+	return pool, nil
+}
+
+// RoundTripWithContext implements fasthttp.ProtocolRoundTripper.
+func (t *Transport) RoundTripWithContext(
+	ctx *fasthttp.ProtocolClientContext,
+	hc *fasthttp.HostClient,
+	req *fasthttp.Request,
+	resp *fasthttp.Response,
+) (bool, error) {
+	pool, err := t.poolFor(hc)
+	if err != nil {
+		return false, err
+	}
+	if !hc.IsTLS && pool.config.mode != PriorKnowledge {
+		return ctx.RoundTripHTTP1(req, resp)
+	}
+	stream, fallback, err := pool.acquireStream(ctx, req, resp, false)
+	if err != nil {
+		return false, err
+	}
+	if fallback != nil {
+		return fallback.RoundTripHTTP1(req, resp)
+	}
+	if stream == nil {
+		return ctx.RoundTripHTTP1(req, resp)
+	}
+	return stream.conn.roundTrip(ctx, stream)
+}
+
+// OpenStreamWithContext implements fasthttp.StreamRoundTripper.
+func (t *Transport) OpenStreamWithContext(
+	ctx *fasthttp.ProtocolClientContext,
+	hc *fasthttp.HostClient,
+	req *fasthttp.Request,
+	resp *fasthttp.Response,
+) (fasthttp.StreamConn, error) {
+	pool, err := t.poolFor(hc)
+	if err != nil {
+		return nil, err
+	}
+	if !pool.config.enableExtendedConnect {
+		return nil, fasthttp.ErrProtocolNotSupported
+	}
+	if !hc.IsTLS && pool.config.mode != PriorKnowledge {
+		return nil, fasthttp.ErrProtocolNotSupported
+	}
+	stream, fallback, err := pool.acquireStream(ctx, req, resp, true)
+	if err != nil {
+		return nil, err
+	}
+	if fallback != nil {
+		_ = fallback.Close()
+		return nil, fasthttp.ErrProtocolNotSupported
+	}
+	if stream == nil {
+		return nil, fasthttp.ErrProtocolNotSupported
+	}
+	result := stream.conn.openStream(ctx, stream)
+	return result.streamConn, result.err
+}
+
+// CloseIdleConnections closes idle HTTP/2 connections owned for hc.
+func (t *Transport) CloseIdleConnections(hc *fasthttp.HostClient) {
+	t.mu.Lock()
+	pool := t.pools[hc]
+	t.mu.Unlock()
+	if pool != nil {
+		pool.closeIdle()
+	}
+}
+
+func (p *clientPool) acquireStream(
+	ctx *fasthttp.ProtocolClientContext,
+	req *fasthttp.Request,
+	resp *fasthttp.Response,
+	openStream bool,
+) (*clientStream, *fasthttp.ProtocolClientConn, error) {
+	deadline, _ := ctx.Deadline()
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil, nil, errClientConnClosed
+		}
+		if p.h1Only {
+			p.mu.Unlock()
+			return nil, nil, nil
+		}
+		now := time.Now()
+		for _, conn := range p.conns {
+			if stream := conn.reserveStream(req, resp, openStream, deadline, now); stream != nil {
+				p.mu.Unlock()
+				return stream, nil, nil
+			}
+		}
+		if p.dialing {
+			notify := p.notify
+			p.mu.Unlock()
+			if err := waitForClientEvent(notify, deadline, 0); err != nil {
+				return nil, nil, err
+			}
+			continue
+		}
+
+		maxConns := p.hc.MaxConns
+		if maxConns <= 0 {
+			maxConns = fasthttp.DefaultMaxConnsPerHost
+		}
+		if p.hc.ConnsCount() >= maxConns {
+			if p.hc.MaxConnWaitTimeout <= 0 {
+				p.mu.Unlock()
+				return nil, nil, fasthttp.ErrNoFreeConns
+			}
+			notify := p.notify
+			p.mu.Unlock()
+			if err := waitForClientEvent(notify, deadline, p.hc.MaxConnWaitTimeout); err != nil {
+				return nil, nil, err
+			}
+			continue
+		}
+		p.dialing = true
+		p.mu.Unlock()
+
+		conn, fallback, err := p.dial(ctx)
+		p.mu.Lock()
+		p.dialing = false
+		if fallback != nil {
+			p.h1Only = true
+		}
+		if conn != nil {
+			p.conns = append(p.conns, conn)
+		}
+		p.signalLocked()
+		p.mu.Unlock()
+		if conn != nil {
+			go conn.readLoop()
+		}
+		if fallback != nil || err != nil {
+			return nil, fallback, err
+		}
+	}
+}
+
+func (p *clientPool) dial(ctx *fasthttp.ProtocolClientContext) (*clientConn, *fasthttp.ProtocolClientConn, error) {
+	nextProtos := []string(nil)
+	if p.hc.IsTLS {
+		nextProtos = []string{"h2", "http/1.1"}
+	}
+	lease, err := ctx.AcquireConn(nextProtos)
+	if err != nil {
+		return nil, nil, err
+	}
+	if p.hc.IsTLS && lease.NegotiatedProtocol() != "h2" {
+		if p.config.mode == RequireHTTP2 {
+			_ = lease.Close()
+			return nil, nil, errHTTP2Required
+		}
+		return nil, lease, nil
+	}
+	conn, err := newClientConn(p, lease)
+	if err != nil {
+		_ = lease.Close()
+		return nil, nil, err
+	}
+	return conn, nil, nil
+}
+
+func (p *clientPool) signalLocked() {
+	close(p.notify)
+	p.notify = make(chan struct{})
+}
+
+func (p *clientPool) streamAvailable() {
+	p.mu.Lock()
+	p.signalLocked()
+	p.mu.Unlock()
+}
+
+func (p *clientPool) remove(conn *clientConn) {
+	p.mu.Lock()
+	for i, candidate := range p.conns {
+		if candidate == conn {
+			copy(p.conns[i:], p.conns[i+1:])
+			p.conns = p.conns[:len(p.conns)-1]
+			break
+		}
+	}
+	p.signalLocked()
+	p.mu.Unlock()
+}
+
+func (p *clientPool) closeIdle() {
+	p.mu.Lock()
+	connections := append([]*clientConn(nil), p.conns...)
+	p.mu.Unlock()
+	for _, conn := range connections {
+		conn.closeIfIdle()
+	}
+}
+
+func waitForClientEvent(notify <-chan struct{}, deadline time.Time, maxWait time.Duration) error {
+	wait := maxWait
+	if !deadline.IsZero() {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fasthttp.ErrTimeout
+		}
+		if wait <= 0 || remaining < wait {
+			wait = remaining
+		}
+	}
+	if wait <= 0 {
+		<-notify
+		return nil
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-notify:
+		return nil
+	case <-timer.C:
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return fasthttp.ErrTimeout
+		}
+		return fasthttp.ErrNoFreeConns
+	}
+}
+
+func newClientConn(pool *clientPool, lease *fasthttp.ProtocolClientConn) (*clientConn, error) {
+	conn := &clientConn{
+		pool:                     pool,
+		hc:                       pool.hc,
+		config:                   pool.config,
+		lease:                    lease,
+		conn:                     lease.Conn(),
+		streams:                  make(map[uint32]*clientStream),
+		nextStreamID:             1,
+		nextHeaderStreamID:       1,
+		peerMaxConcurrentStreams: 100,
+		peerInitialStreamWindow:  65535,
+		peerConnectionWindow:     65535,
+		peerMaxFrameSize:         defaultMaxFrameSize,
+		peerMaxHeaderListSize:    math.MaxUint32,
+		receiveConnectionWindow:  int64(pool.config.connectionWindowSize),
+		notify:                   make(chan struct{}),
+		created:                  time.Now(),
+	}
+	conn.framer = xhttp2.NewFramer(conn.conn, conn.conn)
+	conn.decoder = hpack.NewDecoder(pool.config.maxDecoderTableSize, nil)
+	conn.decoder.SetAllowedMaxDynamicTableSize(pool.config.maxDecoderTableSize)
+	conn.decoder.SetMaxStringLength(int(pool.config.maxHeaderListSize))
+	conn.framer.ReadMetaHeaders = conn.decoder
+	conn.framer.MaxHeaderListSize = pool.config.maxHeaderListSize
+	conn.framer.SetMaxReadFrameSize(pool.config.maxReadFrameSize)
+	conn.encoder = hpack.NewEncoder(&conn.headerBuffer)
+	conn.encoder.SetMaxDynamicTableSizeLimit(pool.config.maxEncoderTableSize)
+	if err := conn.writePrefaceAndSettings(); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (c *clientConn) writePrefaceAndSettings() error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if _, err := io.WriteString(c.conn, clientPreface); err != nil {
+		return err
+	}
+	settings := []xhttp2.Setting{
+		{ID: xhttp2.SettingEnablePush, Val: boolSetting(c.config.pushHandler != nil)},
+		{ID: xhttp2.SettingMaxConcurrentStreams, Val: c.config.maxConcurrentStreams},
+		{ID: xhttp2.SettingInitialWindowSize, Val: uint32(c.config.streamWindowSize)},
+		{ID: xhttp2.SettingMaxFrameSize, Val: c.config.maxReadFrameSize},
+		{ID: xhttp2.SettingMaxHeaderListSize, Val: c.config.maxHeaderListSize},
+		{ID: xhttp2.SettingHeaderTableSize, Val: c.config.maxDecoderTableSize},
+		{ID: xhttp2.SettingNoRFC7540Priorities, Val: 1},
+	}
+	if c.config.enableExtendedConnect {
+		settings = append(settings, xhttp2.Setting{ID: xhttp2.SettingEnableConnectProtocol, Val: 1})
+	}
+	if err := c.framer.WriteSettings(settings...); err != nil {
+		return err
+	}
+	increment := uint32(c.config.connectionWindowSize - 65535)
+	if increment != 0 {
+		return c.framer.WriteWindowUpdate(0, increment)
+	}
+	return nil
+}
+
+func boolSetting(value bool) uint32 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func (c *clientConn) reserveStream(
+	req *fasthttp.Request,
+	resp *fasthttp.Response,
+	openStream bool,
+	deadline time.Time,
+	now time.Time,
+) *clientStream {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || c.goAway || c.nextStreamID > math.MaxInt32 || c.activeStreams >= c.peerMaxConcurrentStreams {
+		return nil
+	}
+	if c.hc.MaxConnDuration > 0 && now.Sub(c.created) >= c.hc.MaxConnDuration {
+		return nil
+	}
+	if c.idleTimer != nil {
+		c.idleTimer.Stop()
+		c.idleTimer = nil
+	}
+	stream := &clientStream{
+		id:                    c.nextStreamID,
+		conn:                  c,
+		req:                   req,
+		resp:                  resp,
+		result:                make(chan clientResult, 1),
+		done:                  make(chan struct{}),
+		isOpenStream:          openStream,
+		isStreaming:           openStream || resp.StreamBody,
+		sendWindow:            c.peerInitialStreamWindow,
+		recvWindow:            int64(c.config.streamWindowSize),
+		expectedResponseBytes: -1,
+		maxResponseBodySize:   c.hc.MaxResponseBodySize,
+	}
+	c.streams[stream.id] = stream
+	c.nextStreamID += 2
+	c.activeStreams++
+	if !deadline.IsZero() {
+		stream.timer = time.AfterFunc(time.Until(deadline), func() {
+			c.resetStream(stream.id, xhttp2.ErrCodeCancel, fasthttp.ErrTimeout, false)
+		})
+	}
+	return stream
+}
+
+func (c *clientConn) roundTrip(
+	ctx *fasthttp.ProtocolClientContext,
+	stream *clientStream,
+) (bool, error) {
+	deadline, _ := ctx.Deadline()
+	if err := c.writeRequest(stream, false, deadline); err != nil {
+		c.resetStream(stream.id, xhttp2.ErrCodeCancel, err, false)
+	}
+	result := c.waitResult(stream, deadline)
+	return result.retry, result.err
+}
+
+func (c *clientConn) openStream(
+	ctx *fasthttp.ProtocolClientContext,
+	stream *clientStream,
+) clientResult {
+	deadline, _ := ctx.Deadline()
+	if len(stream.req.Header.ConnectProtocol()) == 0 || string(stream.req.Header.Method()) != fasthttp.MethodConnect {
+		c.resetStream(stream.id, xhttp2.ErrCodeCancel, errors.New("http2: OpenStream requires an extended CONNECT request"), false)
+		return c.waitResult(stream, deadline)
+	}
+	if stream.req.IsBodyStream() || len(stream.req.Body()) != 0 {
+		c.resetStream(stream.id, xhttp2.ErrCodeCancel, errors.New("http2: OpenStream request must not have a body"), false)
+		return c.waitResult(stream, deadline)
+	}
+	if err := c.writeRequest(stream, true, deadline); err != nil {
+		c.resetStream(stream.id, xhttp2.ErrCodeCancel, err, false)
+	}
+	return c.waitResult(stream, deadline)
+}
+
+func (c *clientConn) waitResult(stream *clientStream, deadline time.Time) clientResult {
+	if deadline.IsZero() {
+		return <-stream.result
+	}
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
+	select {
+	case result := <-stream.result:
+		return result
+	case <-timer.C:
+		c.resetStream(stream.id, xhttp2.ErrCodeCancel, fasthttp.ErrTimeout, false)
+		return <-stream.result
+	}
+}
+
+func (c *clientConn) writeRequest(stream *clientStream, keepOpen bool, deadline time.Time) error {
+	req := stream.req
+	var body []byte
+	var reader io.Reader
+	if req.IsBodyStream() {
+		reader = req.BodyStream()
+	} else {
+		body = req.Body()
+	}
+	hasBody := reader != nil || len(body) != 0
+	if declared := requestContentLength(&req.Header); declared >= 0 && !req.IsBodyStream() && declared != int64(len(body)) {
+		return errors.New("http2: request body length doesn't match content-length")
+	}
+	if err := c.writeRequestHeaders(stream, !keepOpen && !hasBody, req, deadline); err != nil {
+		c.fail(err)
+		return err
+	}
+	c.mu.Lock()
+	if current := c.streams[stream.id]; current == stream {
+		if !keepOpen && !hasBody {
+			stream.localClosed = true
+			c.maybeFinishStreamLocked(stream)
+		}
+	}
+	c.mu.Unlock()
+	if keepOpen || !hasBody {
+		return nil
+	}
+	if reader == nil {
+		return c.sendData(stream, body, true, deadline)
+	}
+	defer req.CloseBodyStream() //nolint:errcheck
+	return c.sendRequestStream(stream, reader, requestContentLength(&req.Header), deadline)
+}
+
+func requestContentLength(header *fasthttp.RequestHeader) int64 {
+	if len(header.Peek(fasthttp.HeaderContentLength)) == 0 {
+		return -1
+	}
+	return int64(header.ContentLength())
+}
+
+func (c *clientConn) writeRequestHeaders(
+	stream *clientStream,
+	endStream bool,
+	req *fasthttp.Request,
+	deadline time.Time,
+) error {
+	for {
+		c.mu.Lock()
+		if c.streams[stream.id] != stream || stream.err != nil {
+			err := stream.err
+			if err == nil {
+				err = errClientStreamClosed
+			}
+			c.mu.Unlock()
+			return err
+		}
+		if c.nextHeaderStreamID == stream.id {
+			break
+		}
+		notify := c.notify
+		done := stream.done
+		c.mu.Unlock()
+		if err := waitForStreamEvent(notify, done, deadline); err != nil {
+			return err
+		}
+	}
+	maxHeaderListSize := c.peerMaxHeaderListSize
+	maxFrameSize := c.peerMaxFrameSize
+	c.mu.Unlock()
+
+	c.writeMu.Lock()
+	block, err := encodeRequestHeaders(
+		c.encoder,
+		&c.headerBuffer,
+		req,
+		maxHeaderListSize,
+		c.config.enableExtendedConnect,
+	)
+	if err != nil {
+		c.writeMu.Unlock()
+		c.advanceHeaderStream(stream, false)
+		return err
+	}
+	first := min(len(block), maxFrameSize)
+	if err := c.framer.WriteHeaders(xhttp2.HeadersFrameParam{
+		StreamID:      stream.id,
+		BlockFragment: block[:first],
+		EndStream:     endStream,
+		EndHeaders:    first == len(block),
+	}); err != nil {
+		c.writeMu.Unlock()
+		c.advanceHeaderStream(stream, false)
+		return err
+	}
+	block = block[first:]
+	for len(block) != 0 {
+		length := min(len(block), maxFrameSize)
+		if err := c.framer.WriteContinuation(stream.id, length == len(block), block[:length]); err != nil {
+			c.writeMu.Unlock()
+			c.advanceHeaderStream(stream, false)
+			return err
+		}
+		block = block[length:]
+	}
+	c.writeMu.Unlock()
+	c.advanceHeaderStream(stream, true)
+	return nil
+}
+
+func (c *clientConn) advanceHeaderStream(stream *clientStream, started bool) {
+	c.mu.Lock()
+	if c.streams[stream.id] == stream && started {
+		stream.requestStarted = true
+	}
+	if c.nextHeaderStreamID == stream.id {
+		c.nextHeaderStreamID += 2
+		c.skipUnavailableHeaderStreamsLocked()
+	}
+	c.signalLocked()
+	c.mu.Unlock()
+}
+
+func (c *clientConn) skipUnavailableHeaderStreamsLocked() {
+	for c.nextHeaderStreamID < c.nextStreamID {
+		stream := c.streams[c.nextHeaderStreamID]
+		if stream != nil && !stream.requestStarted {
+			return
+		}
+		c.nextHeaderStreamID += 2
+	}
+}
+
+func (c *clientConn) sendRequestStream(
+	stream *clientStream,
+	reader io.Reader,
+	expected int64,
+	deadline time.Time,
+) error {
+	buffer := make([]byte, defaultMaxFrameSize)
+	var sent int64
+	for {
+		c.mu.Lock()
+		responseStarted := stream.responseHeader || stream.remoteClosed
+		c.mu.Unlock()
+		if responseStarted {
+			return c.sendData(stream, nil, true, deadline)
+		}
+		n, readErr := reader.Read(buffer)
+		if n > 0 {
+			sent += int64(n)
+			if expected >= 0 && sent > expected {
+				return errors.New("http2: request body exceeds content-length")
+			}
+			end := errors.Is(readErr, io.EOF)
+			if end && expected >= 0 && sent != expected {
+				return errors.New("http2: request body length doesn't match content-length")
+			}
+			if err := c.sendData(stream, buffer[:n], end, deadline); err != nil {
+				return err
+			}
+			if end {
+				return nil
+			}
+		}
+		if readErr != nil {
+			if !errors.Is(readErr, io.EOF) {
+				return readErr
+			}
+			if expected >= 0 && sent != expected {
+				return errors.New("http2: request body length doesn't match content-length")
+			}
+			return c.sendData(stream, nil, true, deadline)
+		}
+	}
+}
+
+func (c *clientConn) sendData(stream *clientStream, data []byte, endStream bool, deadline time.Time) error {
+	for len(data) != 0 || endStream {
+		c.mu.Lock()
+		current := c.streams[stream.id]
+		if current != stream || stream.err != nil {
+			err := stream.err
+			if err == nil {
+				err = errClientStreamClosed
+			}
+			c.mu.Unlock()
+			return err
+		}
+		if stream.localClosed {
+			c.mu.Unlock()
+			return errClientStreamClosed
+		}
+		amount := 0
+		if len(data) != 0 && c.peerConnectionWindow > 0 && stream.sendWindow > 0 {
+			amount = min(len(data), c.peerMaxFrameSize, int(c.peerConnectionWindow), int(stream.sendWindow))
+		}
+		if len(data) != 0 && amount == 0 {
+			notify := c.notify
+			done := stream.done
+			c.mu.Unlock()
+			if err := waitForStreamEvent(notify, done, deadline); err != nil {
+				return err
+			}
+			continue
+		}
+		last := amount == len(data) && endStream
+		c.peerConnectionWindow -= int64(amount)
+		stream.sendWindow -= int64(amount)
+		stream.requestBytes += int64(amount)
+		if last {
+			stream.localClosed = true
+		}
+		c.mu.Unlock()
+
+		c.writeMu.Lock()
+		err := c.framer.WriteData(stream.id, last, data[:amount])
+		c.writeMu.Unlock()
+		if err != nil {
+			c.fail(err)
+			return err
+		}
+		data = data[amount:]
+		if last {
+			c.mu.Lock()
+			c.maybeFinishStreamLocked(stream)
+			c.mu.Unlock()
+			return nil
+		}
+	}
+	return nil
+}
+
+func waitForStreamEvent(notify, done <-chan struct{}, deadline time.Time) error {
+	if deadline.IsZero() {
+		select {
+		case <-notify:
+			return nil
+		case <-done:
+			return errClientStreamClosed
+		}
+	}
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
+	select {
+	case <-notify:
+		return nil
+	case <-done:
+		return errClientStreamClosed
+	case <-timer.C:
+		return fasthttp.ErrTimeout
+	}
+}
+
+func (c *clientConn) readLoop() {
+	for {
+		frame, err := c.framer.ReadFrame()
+		if err != nil {
+			c.fail(err)
+			return
+		}
+		if err := c.processFrame(frame); err != nil {
+			c.fail(err)
+			return
+		}
+	}
+}
+
+func (c *clientConn) processFrame(frame xhttp2.Frame) error {
+	c.mu.Lock()
+	firstFrame := !c.receivedSettings
+	c.mu.Unlock()
+	if firstFrame {
+		settings, ok := frame.(*xhttp2.SettingsFrame)
+		if !ok || settings.IsAck() {
+			return errors.New("http2: server's first frame isn't settings")
+		}
+	}
+	switch frame := frame.(type) {
+	case *xhttp2.SettingsFrame:
+		return c.processSettings(frame)
+	case *xhttp2.MetaHeadersFrame:
+		return c.processResponseHeaders(frame)
+	case *xhttp2.DataFrame:
+		return c.processResponseData(frame)
+	case *xhttp2.RSTStreamFrame:
+		retry := frame.ErrCode == xhttp2.ErrCodeRefusedStream
+		c.failStream(frame.StreamID, fmt.Errorf("http2: peer reset stream: %s", frame.ErrCode), retry)
+		return nil
+	case *xhttp2.WindowUpdateFrame:
+		return c.processWindowUpdate(frame)
+	case *xhttp2.PingFrame:
+		if !frame.IsAck() {
+			return c.writeControl(func() error { return c.framer.WritePing(true, frame.Data) })
+		}
+		return nil
+	case *xhttp2.GoAwayFrame:
+		c.processGoAway(frame)
+		return nil
+	case *xhttp2.PushPromiseFrame:
+		return c.processPushPromise(frame)
+	case *xhttp2.ContinuationFrame:
+		return c.processPushContinuation(frame)
+	default:
+		return nil
+	}
+}
+
+func (c *clientConn) processSettings(frame *xhttp2.SettingsFrame) error {
+	if frame.IsAck() {
+		return nil
+	}
+	var encoderTableSize uint32
+	var updateEncoderTable bool
+	c.mu.Lock()
+	for i := range frame.NumSettings() {
+		setting := frame.Setting(i)
+		switch setting.ID {
+		case xhttp2.SettingHeaderTableSize:
+			value := setting.Val
+			if value > c.config.maxEncoderTableSize {
+				value = c.config.maxEncoderTableSize
+			}
+			encoderTableSize = value
+			updateEncoderTable = true
+		case xhttp2.SettingMaxConcurrentStreams:
+			c.peerMaxConcurrentStreams = setting.Val
+		case xhttp2.SettingInitialWindowSize:
+			delta := int64(setting.Val) - c.peerInitialStreamWindow
+			for _, stream := range c.streams {
+				stream.sendWindow += delta
+				if stream.sendWindow > math.MaxInt32 {
+					c.mu.Unlock()
+					return errors.New("http2: stream send window overflow")
+				}
+			}
+			c.peerInitialStreamWindow = int64(setting.Val)
+		case xhttp2.SettingMaxFrameSize:
+			c.peerMaxFrameSize = int(setting.Val)
+		case xhttp2.SettingMaxHeaderListSize:
+			c.peerMaxHeaderListSize = uint64(setting.Val)
+		case xhttp2.SettingEnablePush:
+			c.mu.Unlock()
+			return errors.New("http2: server sent SETTINGS_ENABLE_PUSH")
+		}
+	}
+	c.receivedSettings = true
+	c.signalLocked()
+	c.mu.Unlock()
+	c.writeMu.Lock()
+	if updateEncoderTable {
+		c.encoder.SetMaxDynamicTableSize(encoderTableSize)
+	}
+	err := c.framer.WriteSettingsAck()
+	c.writeMu.Unlock()
+	if err != nil {
+		c.fail(err)
+	}
+	return err
+}
+
+func (c *clientConn) processResponseHeaders(frame *xhttp2.MetaHeadersFrame) error {
+	if frame.Truncated {
+		c.resetStream(frame.StreamID, xhttp2.ErrCodeEnhanceYourCalm, errInvalidResponseHeaders, false)
+		return nil
+	}
+	c.mu.Lock()
+	stream := c.streams[frame.StreamID]
+	if stream == nil {
+		c.mu.Unlock()
+		return nil
+	}
+	if stream.responseHeader {
+		if stream.remoteClosed || !frame.StreamEnded() {
+			c.mu.Unlock()
+			return errors.New("http2: invalid response trailers")
+		}
+		if err := populateResponseTrailers(stream.resp, frame.Fields); err != nil {
+			c.mu.Unlock()
+			return err
+		}
+		c.endResponseLocked(stream, nil)
+		c.mu.Unlock()
+		return nil
+	}
+	status, err := responseStatus(frame.Fields)
+	if err != nil {
+		c.mu.Unlock()
+		return err
+	}
+	if status >= 100 && status < 200 {
+		if status == 101 || frame.StreamEnded() {
+			c.mu.Unlock()
+			return errors.New("http2: invalid informational response")
+		}
+		c.mu.Unlock()
+		return nil
+	}
+	status, contentLength, err := populateResponse(
+		stream.resp,
+		frame.Fields,
+		c.hc.DisableHeaderNamesNormalizing,
+	)
+	if err != nil {
+		c.mu.Unlock()
+		return err
+	}
+	stream.statusCode = status
+	stream.expectedResponseBytes = contentLength
+	stream.responseHeader = true
+	c.lease.ApplyResponseMetadata(stream.resp)
+	if responseHasNoBody(stream) && contentLength > 0 && !stream.req.Header.IsHead() {
+		c.mu.Unlock()
+		return errors.New("http2: body-forbidden response has a positive content-length")
+	}
+	if stream.isStreaming {
+		body := newResponseBody(
+			func(consumed int) { c.consumeResponseBytes(stream.id, consumed) },
+			func(discarded int) { c.closeResponseBody(stream.id, discarded) },
+			func() { c.responseBodyDone(stream.id) },
+		)
+		stream.responseBody = body
+		if !stream.isOpenStream {
+			bodySize := -1
+			if contentLength >= 0 {
+				bodySize = int(contentLength)
+			}
+			stream.resp.SetBodyStream(body, bodySize)
+			stream.resp.Header.Del(fasthttp.HeaderTransferEncoding)
+		}
+	}
+	if stream.isOpenStream {
+		if status < 200 || status >= 300 {
+			c.sendResultLocked(stream, clientResult{err: fmt.Errorf("http2: extended connect failed with status %d", status)})
+		} else {
+			streamConn := &clientStreamConn{stream: stream, read: stream.responseBody}
+			c.sendResultLocked(stream, clientResult{streamConn: streamConn})
+		}
+	} else if stream.isStreaming {
+		c.sendResultLocked(stream, clientResult{})
+	}
+	if frame.StreamEnded() {
+		c.endResponseLocked(stream, nil)
+	}
+	c.mu.Unlock()
+	return nil
+}
+
+func responseStatus(fields []hpack.HeaderField) (int, error) {
+	for _, field := range fields {
+		if field.Name == ":status" {
+			if len(field.Value) != 3 {
+				return 0, errInvalidResponseHeaders
+			}
+			value, err := strconv.Atoi(field.Value)
+			if err != nil {
+				return 0, errInvalidResponseHeaders
+			}
+			return value, nil
+		}
+	}
+	return 0, errInvalidResponseHeaders
+}
+
+func responseHasNoBody(stream *clientStream) bool {
+	return stream.req.Header.IsHead() || stream.statusCode == 204 || stream.statusCode == 304
+}
+
+func (c *clientConn) processResponseData(frame *xhttp2.DataFrame) error {
+	flowLength := int64(frame.Header().Length)
+	data := frame.Data()
+	c.mu.Lock()
+	stream := c.streams[frame.StreamID]
+	if stream == nil || !stream.responseHeader || stream.remoteClosed {
+		c.mu.Unlock()
+		return errors.New("http2: data on an invalid response stream")
+	}
+	c.receiveConnectionWindow -= flowLength
+	stream.recvWindow -= flowLength
+	if c.receiveConnectionWindow < 0 || stream.recvWindow < 0 {
+		c.mu.Unlock()
+		return errors.New("http2: response flow-control window exceeded")
+	}
+	if responseHasNoBody(stream) && len(data) != 0 {
+		c.mu.Unlock()
+		return errors.New("http2: response body isn't permitted")
+	}
+	stream.responseBytes += int64(len(data))
+	if stream.expectedResponseBytes >= 0 && stream.responseBytes > stream.expectedResponseBytes {
+		c.mu.Unlock()
+		c.resetStream(frame.StreamID, xhttp2.ErrCodeProtocol, errors.New("http2: response body exceeds content-length"), false)
+		return nil
+	}
+	if stream.maxResponseBodySize > 0 && stream.responseBytes > int64(stream.maxResponseBodySize) {
+		c.mu.Unlock()
+		c.resetStream(frame.StreamID, xhttp2.ErrCodeCancel, errResponseBodyTooLarge, false)
+		return nil
+	}
+	body := stream.responseBody
+	if body == nil {
+		stream.resp.AppendBody(data)
+	}
+	ended := frame.StreamEnded()
+	c.mu.Unlock()
+
+	if body != nil && len(data) != 0 {
+		if err := body.write(data); err != nil {
+			c.closeResponseBody(frame.StreamID, len(data))
+			return nil
+		}
+	} else if len(data) != 0 {
+		c.consumeResponseBytes(frame.StreamID, len(data))
+	}
+	padding := int(flowLength) - len(data)
+	if padding > 0 {
+		c.consumeResponseBytes(frame.StreamID, padding)
+	}
+	if ended {
+		c.mu.Lock()
+		if current := c.streams[frame.StreamID]; current == stream {
+			c.endResponseLocked(stream, nil)
+		}
+		c.mu.Unlock()
+	}
+	return nil
+}
+
+func (c *clientConn) endResponseLocked(stream *clientStream, responseErr error) {
+	if stream.expectedResponseBytes >= 0 && stream.responseBytes != stream.expectedResponseBytes {
+		responseErr = errors.New("http2: response body length doesn't match content-length")
+	}
+	stream.remoteClosed = true
+	if stream.responseBody != nil {
+		stream.responseBody.closeWithError(responseErr)
+	}
+	if responseErr != nil {
+		stream.err = responseErr
+		if !stream.isPush {
+			c.sendResultLocked(stream, clientResult{err: responseErr})
+		}
+	} else if stream.isPush {
+		stream.pushComplete = true
+	} else if !stream.isStreaming {
+		c.sendResultLocked(stream, clientResult{})
+	}
+	c.maybeFinishStreamLocked(stream)
+}
+
+func (c *clientConn) consumeResponseBytes(streamID uint32, amount int) {
+	if amount <= 0 {
+		return
+	}
+	c.mu.Lock()
+	stream := c.streams[streamID]
+	c.receiveConnectionWindow += int64(amount)
+	if stream != nil {
+		stream.recvWindow += int64(amount)
+	}
+	c.mu.Unlock()
+	_ = c.writeControl(func() error {
+		if err := c.framer.WriteWindowUpdate(0, uint32(amount)); err != nil {
+			return err
+		}
+		if stream != nil {
+			return c.framer.WriteWindowUpdate(streamID, uint32(amount))
+		}
+		return nil
+	})
+}
+
+func (c *clientConn) closeResponseBody(streamID uint32, discarded int) {
+	if discarded > 0 {
+		c.consumeResponseBytes(streamID, discarded)
+	}
+	c.mu.Lock()
+	stream := c.streams[streamID]
+	remoteOpen := stream != nil && !stream.remoteClosed
+	c.mu.Unlock()
+	if remoteOpen {
+		c.resetStream(streamID, xhttp2.ErrCodeCancel, errClientStreamClosed, false)
+	}
+}
+
+func (c *clientConn) responseBodyDone(streamID uint32) {
+	c.mu.Lock()
+	if stream := c.streams[streamID]; stream != nil {
+		stream.bodyDone = true
+		c.maybeFinishStreamLocked(stream)
+	}
+	c.mu.Unlock()
+}
+
+func (c *clientConn) processWindowUpdate(frame *xhttp2.WindowUpdateFrame) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if frame.StreamID == 0 {
+		if c.peerConnectionWindow+int64(frame.Increment) > math.MaxInt32 {
+			return errors.New("http2: connection send window overflow")
+		}
+		c.peerConnectionWindow += int64(frame.Increment)
+		c.signalLocked()
+		return nil
+	}
+	if stream := c.streams[frame.StreamID]; stream != nil {
+		if stream.sendWindow+int64(frame.Increment) > math.MaxInt32 {
+			return errors.New("http2: stream send window overflow")
+		}
+		stream.sendWindow += int64(frame.Increment)
+		c.signalLocked()
+	}
+	return nil
+}
+
+func (c *clientConn) processGoAway(frame *xhttp2.GoAwayFrame) {
+	c.mu.Lock()
+	c.goAway = true
+	c.goAwayLastStreamID = frame.LastStreamID
+	for _, stream := range c.streams {
+		if stream.id > frame.LastStreamID && !stream.responseHeader {
+			c.failStreamLocked(stream, errors.New("http2: stream wasn't processed before GOAWAY"), true)
+		}
+	}
+	c.signalLocked()
+	c.mu.Unlock()
+	c.pool.streamAvailable()
+}
+
+func (c *clientConn) processPushPromise(frame *xhttp2.PushPromiseFrame) error {
+	c.mu.Lock()
+	if c.pendingPush != nil {
+		c.mu.Unlock()
+		return errors.New("http2: push promise interrupted a header block")
+	}
+	parent := c.streams[frame.StreamID]
+	validID := frame.PromiseID != 0 && frame.PromiseID&1 == 0 && frame.PromiseID > c.lastPromisedStreamID
+	if !validID {
+		c.mu.Unlock()
+		return errors.New("http2: invalid promised stream id")
+	}
+	c.lastPromisedStreamID = frame.PromiseID
+	if parent == nil || c.config.pushHandler == nil || c.activeStreams >= c.config.maxConcurrentStreams {
+		c.mu.Unlock()
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(frame.PromiseID, xhttp2.ErrCodeCancel)
+		})
+	}
+	pending := &pendingPushBlock{
+		parentID:   frame.StreamID,
+		promisedID: frame.PromiseID,
+		block:      bytes.Clone(frame.HeaderBlockFragment()),
+	}
+	if len(pending.block) > int(c.config.maxHeaderListSize) {
+		c.mu.Unlock()
+		return errors.New("http2: compressed push header block is too large")
+	}
+	if !frame.HeadersEnded() {
+		c.pendingPush = pending
+		c.mu.Unlock()
+		return nil
+	}
+	c.mu.Unlock()
+	return c.finishPushPromise(pending)
+}
+
+func (c *clientConn) processPushContinuation(frame *xhttp2.ContinuationFrame) error {
+	c.mu.Lock()
+	pending := c.pendingPush
+	if pending == nil || frame.StreamID != pending.parentID {
+		c.mu.Unlock()
+		return errors.New("http2: unexpected push continuation")
+	}
+	pending.block = append(pending.block, frame.HeaderBlockFragment()...)
+	if len(pending.block) > int(c.config.maxHeaderListSize) {
+		c.pendingPush = nil
+		c.mu.Unlock()
+		return errors.New("http2: compressed push header block is too large")
+	}
+	if !frame.HeadersEnded() {
+		c.mu.Unlock()
+		return nil
+	}
+	c.pendingPush = nil
+	c.mu.Unlock()
+	return c.finishPushPromise(pending)
+}
+
+func (c *clientConn) finishPushPromise(pending *pendingPushBlock) error {
+	fields := make([]hpack.HeaderField, 0, 8)
+	headerSize := uint64(0)
+	c.decoder.SetEmitFunc(func(field hpack.HeaderField) {
+		headerSize += uint64(len(field.Name) + len(field.Value) + 32)
+		fields = append(fields, hpack.HeaderField{
+			Name:      strings.Clone(field.Name),
+			Value:     strings.Clone(field.Value),
+			Sensitive: field.Sensitive,
+		})
+	})
+	if _, err := c.decoder.Write(pending.block); err != nil {
+		return err
+	}
+	if err := c.decoder.Close(); err != nil {
+		return err
+	}
+	if headerSize > uint64(c.config.maxHeaderListSize) {
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeEnhanceYourCalm)
+		})
+	}
+
+	promised := fasthttp.AcquireRequest()
+	if err := populatePromisedRequest(promised, fields); err != nil {
+		fasthttp.ReleaseRequest(promised)
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeProtocol)
+		})
+	}
+	c.mu.Lock()
+	parent := c.streams[pending.parentID]
+	if parent == nil {
+		c.mu.Unlock()
+		fasthttp.ReleaseRequest(promised)
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeCancel)
+		})
+	}
+	parentCopy := fasthttp.AcquireRequest()
+	parent.req.CopyTo(parentCopy)
+	c.mu.Unlock()
+	accepted := c.config.pushHandler.Accept(parentCopy, promised)
+	fasthttp.ReleaseRequest(parentCopy)
+	if !accepted {
+		fasthttp.ReleaseRequest(promised)
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeCancel)
+		})
+	}
+
+	response := fasthttp.AcquireResponse()
+	c.mu.Lock()
+	if c.closed || c.streams[pending.promisedID] != nil || c.activeStreams >= c.config.maxConcurrentStreams {
+		c.mu.Unlock()
+		fasthttp.ReleaseRequest(promised)
+		fasthttp.ReleaseResponse(response)
+		return c.writeControl(func() error {
+			return c.framer.WriteRSTStream(pending.promisedID, xhttp2.ErrCodeCancel)
+		})
+	}
+	stream := &clientStream{
+		id:                    pending.promisedID,
+		conn:                  c,
+		req:                   promised,
+		resp:                  response,
+		result:                make(chan clientResult, 1),
+		done:                  make(chan struct{}),
+		requestStarted:        true,
+		localClosed:           true,
+		bodyDone:              true,
+		sendWindow:            c.peerInitialStreamWindow,
+		recvWindow:            int64(c.config.streamWindowSize),
+		expectedResponseBytes: -1,
+		maxResponseBodySize:   c.hc.MaxResponseBodySize,
+		isPush:                true,
+		promisedRequest:       promised,
+	}
+	c.streams[stream.id] = stream
+	c.activeStreams++
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *clientConn) writeControl(write func() error) error {
+	c.writeMu.Lock()
+	err := write()
+	c.writeMu.Unlock()
+	if err != nil {
+		c.fail(err)
+	}
+	return err
+}
+
+func (c *clientConn) resetStream(streamID uint32, code xhttp2.ErrCode, cause error, retry bool) {
+	c.mu.Lock()
+	stream := c.streams[streamID]
+	if stream == nil {
+		c.mu.Unlock()
+		return
+	}
+	c.failStreamLocked(stream, cause, retry)
+	c.mu.Unlock()
+	_ = c.writeControl(func() error { return c.framer.WriteRSTStream(streamID, code) })
+}
+
+func (c *clientConn) failStream(streamID uint32, cause error, retry bool) {
+	c.mu.Lock()
+	if stream := c.streams[streamID]; stream != nil {
+		c.failStreamLocked(stream, cause, retry)
+	}
+	c.mu.Unlock()
+}
+
+func (c *clientConn) failStreamLocked(stream *clientStream, cause error, retry bool) {
+	stream.err = cause
+	stream.localClosed = true
+	stream.remoteClosed = true
+	stream.bodyDone = true
+	if stream.responseBody != nil {
+		stream.responseBody.closeWithError(cause)
+	}
+	if !stream.isPush {
+		c.sendResultLocked(stream, clientResult{retry: retry && !stream.responseHeader, err: cause})
+	}
+	c.releaseStreamLocked(stream)
+	c.skipUnavailableHeaderStreamsLocked()
+}
+
+func (c *clientConn) sendResultLocked(stream *clientStream, result clientResult) {
+	if stream.resultSent {
+		return
+	}
+	stream.resultSent = true
+	stream.result <- result
+}
+
+func (c *clientConn) maybeFinishStreamLocked(stream *clientStream) {
+	if !stream.localClosed || !stream.remoteClosed {
+		return
+	}
+	if stream.isStreaming && !stream.bodyDone {
+		return
+	}
+	c.releaseStreamLocked(stream)
+}
+
+func (c *clientConn) releaseStreamLocked(stream *clientStream) {
+	if c.streams[stream.id] != stream {
+		return
+	}
+	delete(c.streams, stream.id)
+	if stream.timer != nil {
+		stream.timer.Stop()
+	}
+	if !stream.doneClosed {
+		close(stream.done)
+		stream.doneClosed = true
+	}
+	if c.activeStreams > 0 {
+		c.activeStreams--
+	}
+	if stream.isPush {
+		request := stream.promisedRequest
+		response := stream.resp
+		if stream.pushComplete {
+			handler := c.config.pushHandler
+			go func() {
+				handler.Handle(request, response)
+				fasthttp.ReleaseRequest(request)
+				fasthttp.ReleaseResponse(response)
+			}()
+		} else {
+			fasthttp.ReleaseRequest(request)
+			fasthttp.ReleaseResponse(response)
+		}
+		stream.promisedRequest = nil
+		stream.req = nil
+		stream.resp = nil
+	}
+	c.lastIdle = time.Now()
+	c.signalLocked()
+	if c.activeStreams == 0 {
+		idleTimeout := c.hc.MaxIdleConnDuration
+		if idleTimeout <= 0 {
+			idleTimeout = fasthttp.DefaultMaxIdleConnDuration
+		}
+		c.idleTimer = time.AfterFunc(idleTimeout, c.closeIfIdle)
+	}
+	go c.pool.streamAvailable()
+}
+
+func (c *clientConn) signalLocked() {
+	close(c.notify)
+	c.notify = make(chan struct{})
+}
+
+func (c *clientConn) fail(cause error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	c.err = cause
+	if c.idleTimer != nil {
+		c.idleTimer.Stop()
+	}
+	for _, stream := range c.streams {
+		c.failStreamLocked(stream, cause, false)
+	}
+	c.signalLocked()
+	c.mu.Unlock()
+	_ = c.lease.Close()
+	c.pool.remove(c)
+}
+
+func (c *clientConn) closeIfIdle() {
+	c.mu.Lock()
+	if c.closed || c.activeStreams != 0 {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	c.mu.Unlock()
+	_ = c.lease.Close()
+	c.pool.remove(c)
+}
+
+var _ fasthttp.ProtocolRoundTripper = (*Transport)(nil)
+var _ fasthttp.StreamRoundTripper = (*Transport)(nil)
+var _ fasthttp.ProtocolTransportCloser = (*Transport)(nil)

--- a/http2/client_headers.go
+++ b/http2/client_headers.go
@@ -16,66 +16,79 @@ var errInvalidResponseHeaders = errors.New("http2: invalid response headers")
 func encodeRequestHeaders(
 	encoder *hpack.Encoder,
 	buffer *bytes.Buffer,
+	stringsCache *headerStringCache,
 	req *fasthttp.Request,
 	maxHeaderListSize uint64,
 	enableExtendedConnect bool,
 ) ([]byte, error) {
 	buffer.Reset()
-	method := string(req.Header.Method())
+	method := stringsCache.value(req.Header.Method(), false)
 	if method == "" {
 		method = fasthttp.MethodGet
 	}
 	uri := req.URI()
-	authority := string(req.Header.Host())
-	if authority == "" {
-		authority = string(uri.Host())
+	authorityBytes := req.Header.Host()
+	if len(authorityBytes) == 0 {
+		authorityBytes = uri.Host()
 	}
+	authority := stringsCache.value(authorityBytes, false)
 	if authority == "" {
 		return nil, errors.New("http2: request authority is empty")
 	}
 
-	fields := make([]hpack.HeaderField, 0, 8)
-	fields = append(fields, hpack.HeaderField{Name: ":method", Value: method})
-	connectProtocol := string(req.Header.ConnectProtocol())
+	headerSize := uint64(0)
+	writePseudo := func(name, value string) error {
+		headerSize += uint64(len(name) + len(value) + 32)
+		if maxHeaderListSize != 0 && headerSize > maxHeaderListSize {
+			return errors.New("http2: request header list exceeds peer limit")
+		}
+		return encoder.WriteField(hpack.HeaderField{Name: name, Value: value})
+	}
+	if err := writePseudo(":method", method); err != nil {
+		return nil, err
+	}
+	connectProtocol := stringsCache.value(req.Header.ConnectProtocol(), false)
 	switch {
 	case connectProtocol != "":
 		if !enableExtendedConnect || method != fasthttp.MethodConnect {
 			return nil, errors.New("http2: invalid extended connect request")
 		}
-		fields = append(fields,
-			hpack.HeaderField{Name: ":protocol", Value: connectProtocol},
-			hpack.HeaderField{Name: ":scheme", Value: string(uri.Scheme())},
-			hpack.HeaderField{Name: ":authority", Value: authority},
-			hpack.HeaderField{Name: ":path", Value: string(uri.RequestURI())},
-		)
+		for _, field := range [...]hpack.HeaderField{
+			{Name: ":protocol", Value: connectProtocol},
+			{Name: ":scheme", Value: stringsCache.value(uri.Scheme(), false)},
+			{Name: ":authority", Value: authority},
+			{Name: ":path", Value: stringsCache.value(uri.RequestURI(), false)},
+		} {
+			if err := writePseudo(field.Name, field.Value); err != nil {
+				return nil, err
+			}
+		}
 	case method == fasthttp.MethodConnect:
-		fields = append(fields, hpack.HeaderField{Name: ":authority", Value: authority})
+		if err := writePseudo(":authority", authority); err != nil {
+			return nil, err
+		}
 	default:
-		scheme := string(uri.Scheme())
+		scheme := stringsCache.value(uri.Scheme(), false)
 		if scheme == "" {
 			scheme = "http"
 		}
-		path := string(uri.RequestURI())
+		path := stringsCache.value(uri.RequestURI(), false)
 		if path == "" {
 			path = "/"
 		}
-		fields = append(fields,
-			hpack.HeaderField{Name: ":scheme", Value: scheme},
-			hpack.HeaderField{Name: ":authority", Value: authority},
-			hpack.HeaderField{Name: ":path", Value: path},
-		)
-	}
-
-	headerSize := uint64(0)
-	for _, field := range fields {
-		headerSize += uint64(len(field.Name) + len(field.Value) + 32)
-		if err := encoder.WriteField(field); err != nil {
-			return nil, err
+		for _, field := range [...]hpack.HeaderField{
+			{Name: ":scheme", Value: scheme},
+			{Name: ":authority", Value: authority},
+			{Name: ":path", Value: path},
+		} {
+			if err := writePseudo(field.Name, field.Value); err != nil {
+				return nil, err
+			}
 		}
 	}
 	var encodeErr error
 	req.Header.All()(func(key, value []byte) bool {
-		name := strings.ToLower(string(key))
+		name := stringsCache.name(key)
 		switch name {
 		case "host", "connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade":
 			return true
@@ -91,17 +104,18 @@ func encodeRequestHeaders(
 			return false
 		}
 		headerSize += fieldSize
+		sensitive := isSensitiveHeader(name)
 		encodeErr = encoder.WriteField(hpack.HeaderField{
 			Name:      name,
-			Value:     string(value),
-			Sensitive: isSensitiveHeader(name),
+			Value:     stringsCache.value(value, sensitive),
+			Sensitive: sensitive,
 		})
 		return encodeErr == nil
 	})
 	if encodeErr != nil {
 		return nil, encodeErr
 	}
-	return bytes.Clone(buffer.Bytes()), nil
+	return buffer.Bytes(), nil
 }
 
 func populateResponse(
@@ -147,6 +161,31 @@ func populateResponse(
 	resp.Header.SetStatusCode(statusCode)
 	resp.Header.SetProtocol([]byte("HTTP/2"))
 	return statusCode, contentLength, nil
+}
+
+func responseStatus(fields []hpack.HeaderField) (int, error) {
+	status := ""
+	for _, field := range fields {
+		if field.IsPseudo() {
+			if field.Name != ":status" || status != "" {
+				return 0, errInvalidResponseHeaders
+			}
+			status = field.Value
+			continue
+		}
+		if isConnectionSpecificHeader(field.Name) {
+			return 0, errInvalidResponseHeaders
+		}
+	}
+	if len(status) != 3 || status[0] < '1' || status[0] > '9' ||
+		status[1] < '0' || status[1] > '9' || status[2] < '0' || status[2] > '9' {
+		return 0, errInvalidResponseHeaders
+	}
+	value, err := strconv.Atoi(status)
+	if err != nil {
+		return 0, errInvalidResponseHeaders
+	}
+	return value, nil
 }
 
 func populateResponseTrailers(resp *fasthttp.Response, fields []hpack.HeaderField) error {

--- a/http2/client_headers.go
+++ b/http2/client_headers.go
@@ -1,0 +1,215 @@
+package http2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/valyala/fasthttp"
+	"golang.org/x/net/http2/hpack"
+)
+
+var errInvalidResponseHeaders = errors.New("http2: invalid response headers")
+
+func encodeRequestHeaders(
+	encoder *hpack.Encoder,
+	buffer *bytes.Buffer,
+	req *fasthttp.Request,
+	maxHeaderListSize uint64,
+	enableExtendedConnect bool,
+) ([]byte, error) {
+	buffer.Reset()
+	method := string(req.Header.Method())
+	if method == "" {
+		method = fasthttp.MethodGet
+	}
+	uri := req.URI()
+	authority := string(req.Header.Host())
+	if authority == "" {
+		authority = string(uri.Host())
+	}
+	if authority == "" {
+		return nil, errors.New("http2: request authority is empty")
+	}
+
+	fields := make([]hpack.HeaderField, 0, 8)
+	fields = append(fields, hpack.HeaderField{Name: ":method", Value: method})
+	connectProtocol := string(req.Header.ConnectProtocol())
+	switch {
+	case connectProtocol != "":
+		if !enableExtendedConnect || method != fasthttp.MethodConnect {
+			return nil, errors.New("http2: invalid extended connect request")
+		}
+		fields = append(fields,
+			hpack.HeaderField{Name: ":protocol", Value: connectProtocol},
+			hpack.HeaderField{Name: ":scheme", Value: string(uri.Scheme())},
+			hpack.HeaderField{Name: ":authority", Value: authority},
+			hpack.HeaderField{Name: ":path", Value: string(uri.RequestURI())},
+		)
+	case method == fasthttp.MethodConnect:
+		fields = append(fields, hpack.HeaderField{Name: ":authority", Value: authority})
+	default:
+		scheme := string(uri.Scheme())
+		if scheme == "" {
+			scheme = "http"
+		}
+		path := string(uri.RequestURI())
+		if path == "" {
+			path = "/"
+		}
+		fields = append(fields,
+			hpack.HeaderField{Name: ":scheme", Value: scheme},
+			hpack.HeaderField{Name: ":authority", Value: authority},
+			hpack.HeaderField{Name: ":path", Value: path},
+		)
+	}
+
+	headerSize := uint64(0)
+	for _, field := range fields {
+		headerSize += uint64(len(field.Name) + len(field.Value) + 32)
+		if err := encoder.WriteField(field); err != nil {
+			return nil, err
+		}
+	}
+	var encodeErr error
+	req.Header.All()(func(key, value []byte) bool {
+		name := strings.ToLower(string(key))
+		switch name {
+		case "host", "connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade":
+			return true
+		case "te":
+			if !strings.EqualFold(strings.TrimSpace(string(value)), "trailers") {
+				encodeErr = errors.New("http2: invalid te request header")
+				return false
+			}
+		}
+		fieldSize := uint64(len(name) + len(value) + 32)
+		if maxHeaderListSize != 0 && headerSize+fieldSize > maxHeaderListSize {
+			encodeErr = errors.New("http2: request header list exceeds peer limit")
+			return false
+		}
+		headerSize += fieldSize
+		encodeErr = encoder.WriteField(hpack.HeaderField{
+			Name:      name,
+			Value:     string(value),
+			Sensitive: isSensitiveHeader(name),
+		})
+		return encodeErr == nil
+	})
+	if encodeErr != nil {
+		return nil, encodeErr
+	}
+	return bytes.Clone(buffer.Bytes()), nil
+}
+
+func populateResponse(
+	resp *fasthttp.Response,
+	fields []hpack.HeaderField,
+	disableNormalizing bool,
+) (statusCode int, contentLength int64, err error) {
+	if disableNormalizing {
+		resp.Header.DisableNormalizing()
+	}
+	status := ""
+	contentLength = -1
+	seenRegular := false
+	for _, field := range fields {
+		if field.IsPseudo() {
+			if seenRegular || field.Name != ":status" || status != "" {
+				return 0, -1, errInvalidResponseHeaders
+			}
+			status = field.Value
+			continue
+		}
+		seenRegular = true
+		name := field.Name
+		if isConnectionSpecificHeader(name) {
+			return 0, -1, fmt.Errorf("%w: connection-specific header %q", errInvalidResponseHeaders, name)
+		}
+		if name == "content-length" {
+			length, parseErr := parseHTTP2ContentLength(field.Value)
+			if parseErr != nil || contentLength >= 0 && contentLength != length {
+				return 0, -1, fmt.Errorf("%w: invalid content-length", errInvalidResponseHeaders)
+			}
+			contentLength = length
+		}
+		resp.Header.Add(name, field.Value)
+	}
+	if len(status) != 3 || status[0] < '1' || status[0] > '9' || status[1] < '0' || status[1] > '9' || status[2] < '0' || status[2] > '9' {
+		return 0, -1, fmt.Errorf("%w: invalid :status", errInvalidResponseHeaders)
+	}
+	statusCode, err = strconv.Atoi(status)
+	if err != nil {
+		return 0, -1, fmt.Errorf("%w: invalid :status", errInvalidResponseHeaders)
+	}
+	resp.Header.SetStatusCode(statusCode)
+	resp.Header.SetProtocol([]byte("HTTP/2"))
+	return statusCode, contentLength, nil
+}
+
+func populateResponseTrailers(resp *fasthttp.Response, fields []hpack.HeaderField) error {
+	for _, field := range fields {
+		if field.IsPseudo() || isConnectionSpecificHeader(field.Name) {
+			return errInvalidResponseHeaders
+		}
+		if err := resp.Header.AddTrailer(field.Name); err != nil {
+			return err
+		}
+		resp.Header.Set(field.Name, field.Value)
+	}
+	return nil
+}
+
+func populatePromisedRequest(req *fasthttp.Request, fields []hpack.HeaderField) error {
+	var method, scheme, authority, path string
+	seenPseudo := make(map[string]struct{}, 4)
+	for _, field := range fields {
+		if field.IsPseudo() {
+			if _, ok := seenPseudo[field.Name]; ok {
+				return errors.New("http2: duplicate promised request pseudo-header")
+			}
+			seenPseudo[field.Name] = struct{}{}
+			switch field.Name {
+			case ":method":
+				method = field.Value
+			case ":scheme":
+				scheme = field.Value
+			case ":authority":
+				authority = field.Value
+			case ":path":
+				path = field.Value
+			default:
+				return errors.New("http2: invalid promised request pseudo-header")
+			}
+			continue
+		}
+		if isConnectionSpecificHeader(field.Name) || field.Name == "host" {
+			return errors.New("http2: invalid promised request header")
+		}
+		req.Header.Add(field.Name, field.Value)
+	}
+	if method != fasthttp.MethodGet && method != fasthttp.MethodHead {
+		return errors.New("http2: promised request must use GET or HEAD")
+	}
+	if scheme == "" || authority == "" || path == "" {
+		return errors.New("http2: promised request is missing a pseudo-header")
+	}
+	req.Header.SetMethod(method)
+	req.Header.SetHost(authority)
+	req.Header.SetProtocol("HTTP/2")
+	req.SetRequestURI(scheme + "://" + authority + path)
+	_ = req.URI()
+	req.Header.SetRequestURI(path)
+	return nil
+}
+
+func isSensitiveHeader(name string) bool {
+	switch name {
+	case "authorization", "proxy-authorization", "cookie", "set-cookie":
+		return true
+	default:
+		return false
+	}
+}

--- a/http2/client_test.go
+++ b/http2/client_test.go
@@ -1,0 +1,471 @@
+package http2
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	stdhttp "net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	xhttp2 "golang.org/x/net/http2"
+)
+
+func newPriorKnowledgeHostClient(t *testing.T, addr string) *fasthttp.HostClient {
+	t.Helper()
+	hc := &fasthttp.HostClient{Addr: addr}
+	if err := ConfigureHostClient(hc, ClientConfig{Mode: PriorKnowledge}); err != nil {
+		t.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	t.Cleanup(hc.CloseIdleConnections)
+	return hc
+}
+
+func TestClientRequestResponse(t *testing.T) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.Response.Header.Set("X-Protocol", string(ctx.Request.Header.Protocol()))
+			ctx.SetBody(ctx.Request.Body())
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+	hc := newPriorKnowledgeHostClient(t, testServer.listener.Addr().String())
+
+	body := bytes.Repeat([]byte("client-request-body"), 10_000)
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI(testServer.URL("/echo"))
+	req.SetBody(body)
+	if err := hc.Do(req, resp); err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	if got := string(resp.Header.Protocol()); got != "HTTP/2" {
+		t.Fatalf("response protocol = %q, want HTTP/2", got)
+	}
+	if got := string(resp.Header.Peek("X-Protocol")); got != "HTTP/2" {
+		t.Fatalf("X-Protocol = %q, want HTTP/2", got)
+	}
+	if !bytes.Equal(resp.Body(), body) {
+		t.Fatalf("response body length = %d, want %d", len(resp.Body()), len(body))
+	}
+}
+
+func TestClientMultiplexesRequests(t *testing.T) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			time.Sleep(time.Duration(ctx.QueryArgs().GetUintOrZero("delay")) * time.Millisecond)
+			ctx.SetBody(ctx.Path())
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+	hc := newPriorKnowledgeHostClient(t, testServer.listener.Addr().String())
+	hc.MaxConns = 1
+	hc.MaxConnWaitTimeout = time.Second
+
+	const requests = 50
+	errorsByRequest := make(chan error, requests)
+	var wait sync.WaitGroup
+	for i := range requests {
+		wait.Go(func() {
+			req := fasthttp.AcquireRequest()
+			resp := fasthttp.AcquireResponse()
+			defer fasthttp.ReleaseRequest(req)
+			defer fasthttp.ReleaseResponse(resp)
+			req.SetRequestURI(fmt.Sprintf("http://%s/request-%d?delay=%d", testServer.listener.Addr(), i, i%5))
+			if err := hc.Do(req, resp); err != nil {
+				errorsByRequest <- err
+				return
+			}
+			want := fmt.Sprintf("/request-%d", i)
+			if string(resp.Body()) != want {
+				errorsByRequest <- fmt.Errorf("body = %q, want %q", resp.Body(), want)
+			}
+		})
+	}
+	wait.Wait()
+	close(errorsByRequest)
+	for err := range errorsByRequest {
+		t.Error(err)
+	}
+	if got := hc.ConnsCount(); got != 1 {
+		t.Fatalf("physical connection count = %d, want 1", got)
+	}
+}
+
+func TestClientStreamingResponse(t *testing.T) {
+	body := bytes.Repeat([]byte("streaming-response"), 20_000)
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.Response.SetBodyStream(bytes.NewReader(body), len(body))
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+	hc := newPriorKnowledgeHostClient(t, testServer.listener.Addr().String())
+	hc.StreamResponseBody = true
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.SetRequestURI(testServer.URL("/stream"))
+	if err := hc.Do(req, resp); err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	got, err := io.ReadAll(resp.BodyStream())
+	if err != nil {
+		t.Fatalf("reading response stream: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("response body length = %d, want %d", len(got), len(body))
+	}
+}
+
+func TestClientInteroperatesWithGoHTTP2Server(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error: %v", err)
+	}
+	server := &xhttp2.Server{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go server.ServeConn(conn, &xhttp2.ServeConnOpts{Handler: stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+				w.Header().Set("Trailer", "X-Checksum")
+				_, _ = io.Copy(w, r.Body)
+				w.Header().Set("X-Checksum", "ok")
+			})})
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-done
+	})
+	hc := newPriorKnowledgeHostClient(t, listener.Addr().String())
+
+	body := bytes.Repeat([]byte("go-server"), 20_000)
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("http://" + listener.Addr().String() + "/")
+	req.SetBody(body)
+	if err := hc.Do(req, resp); err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	if !bytes.Equal(resp.Body(), body) {
+		t.Fatalf("response body length = %d, want %d", len(resp.Body()), len(body))
+	}
+	if got := string(resp.Header.Peek("X-Checksum")); got != "ok" {
+		t.Fatalf("response trailer = %q, want ok", got)
+	}
+}
+
+func TestExtendedConnectStream(t *testing.T) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if got := string(ctx.Request.Header.ConnectProtocol()); got != "websocket" {
+				t.Errorf("connect protocol = %q, want websocket", got)
+				ctx.SetStatusCode(fasthttp.StatusBadRequest)
+				return
+			}
+			ctx.SetStatusCode(fasthttp.StatusOK)
+			if err := ctx.AcceptStream(func(conn fasthttp.StreamConn) {
+				_, _ = io.Copy(conn, conn)
+			}); err != nil {
+				t.Errorf("AcceptStream() error: %v", err)
+			}
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{EnableExtendedConnect: true})
+	hc := &fasthttp.HostClient{Addr: testServer.listener.Addr().String()}
+	if err := ConfigureHostClient(hc, ClientConfig{
+		Mode:                  PriorKnowledge,
+		EnableExtendedConnect: true,
+	}); err != nil {
+		t.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	t.Cleanup(hc.CloseIdleConnections)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.Header.SetMethod(fasthttp.MethodConnect)
+	req.Header.SetConnectProtocol("websocket")
+	req.SetRequestURI(testServer.URL("/chat"))
+	conn, err := hc.OpenStream(req, resp)
+	if err != nil {
+		t.Fatalf("OpenStream() error: %v", err)
+	}
+	defer conn.Close()
+	message := bytes.Repeat([]byte("websocket-payload"), 10_000)
+	if _, err := conn.Write(message); err != nil {
+		t.Fatalf("Write() error: %v", err)
+	}
+	if err := conn.CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite() error: %v", err)
+	}
+	got, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("ReadAll() error: %v", err)
+	}
+	if !bytes.Equal(got, message) {
+		t.Fatalf("echo length = %d, want %d", len(got), len(message))
+	}
+}
+
+func TestClientTLSALPN(t *testing.T) {
+	certData, keyData, err := fasthttp.GenerateTestCertificate("localhost")
+	if err != nil {
+		t.Fatalf("GenerateTestCertificate() error: %v", err)
+	}
+	certificate, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		t.Fatalf("X509KeyPair() error: %v", err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error: %v", err)
+	}
+	server := &fasthttp.Server{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{certificate}},
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBody(ctx.Request.Header.Protocol())
+		},
+	}
+	if err := ConfigureServer(server, ServerConfig{}); err != nil {
+		t.Fatalf("ConfigureServer() error: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- server.Serve(tls.NewListener(listener, server.TLSConfig.Clone()))
+	}()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.ShutdownWithContext(ctx)
+		<-done
+	})
+
+	hc := &fasthttp.HostClient{
+		Addr:  listener.Addr().String(),
+		IsTLS: true,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Test-only certificate.
+		},
+	}
+	if err := ConfigureHostClient(hc, ClientConfig{}); err != nil {
+		t.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.SetRequestURI("https://" + listener.Addr().String() + "/")
+	if err := hc.Do(req, resp); err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	if got := string(resp.Body()); got != "HTTP/2" {
+		t.Fatalf("body = %q, want HTTP/2", got)
+	}
+}
+
+func TestClientTLSHTTP1FallbackReusesNegotiatedConnection(t *testing.T) {
+	certData, keyData, err := fasthttp.GenerateTestCertificate("localhost")
+	if err != nil {
+		t.Fatalf("GenerateTestCertificate() error: %v", err)
+	}
+	certificate, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		t.Fatalf("X509KeyPair() error: %v", err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error: %v", err)
+	}
+	server := &fasthttp.Server{
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{certificate},
+			NextProtos:   []string{"http/1.1"},
+		},
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBody(ctx.Request.Header.Protocol())
+		},
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- server.Serve(tls.NewListener(listener, server.TLSConfig.Clone()))
+	}()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.ShutdownWithContext(ctx)
+		<-done
+	})
+
+	var dials atomic.Int32
+	hc := &fasthttp.HostClient{
+		Addr:  listener.Addr().String(),
+		IsTLS: true,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Test-only certificate.
+		},
+		DialTimeout: func(addr string, timeout time.Duration) (net.Conn, error) {
+			dials.Add(1)
+			return net.DialTimeout("tcp", addr, timeout)
+		},
+	}
+	if err := ConfigureHostClient(hc, ClientConfig{}); err != nil {
+		t.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	for range 2 {
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		req.SetRequestURI("https://" + listener.Addr().String() + "/")
+		err := hc.Do(req, resp)
+		if err != nil {
+			t.Fatalf("Do() error: %v", err)
+		}
+		if got := string(resp.Body()); got != "HTTP/1.1" {
+			t.Fatalf("body = %q, want HTTP/1.1", got)
+		}
+		fasthttp.ReleaseRequest(req)
+		fasthttp.ReleaseResponse(resp)
+	}
+	if got := dials.Load(); got != 1 {
+		t.Fatalf("dial count = %d, want 1", got)
+	}
+}
+
+func TestClientRequireHTTP2RejectsHTTP1ALPN(t *testing.T) {
+	certData, keyData, err := fasthttp.GenerateTestCertificate("localhost")
+	if err != nil {
+		t.Fatalf("GenerateTestCertificate() error: %v", err)
+	}
+	certificate, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		t.Fatalf("X509KeyPair() error: %v", err)
+	}
+	serverConn, clientConn := net.Pipe()
+	serverDone := make(chan error, 1)
+	go func() {
+		conn := tls.Server(serverConn, &tls.Config{
+			Certificates: []tls.Certificate{certificate},
+			NextProtos:   []string{"http/1.1"},
+		})
+		serverDone <- conn.Handshake()
+		_ = conn.Close()
+	}()
+	hc := &fasthttp.HostClient{
+		Addr:  "localhost:443",
+		IsTLS: true,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Test-only certificate.
+		},
+		DialTimeout: func(string, time.Duration) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+	if err := ConfigureHostClient(hc, ClientConfig{Mode: RequireHTTP2}); err != nil {
+		t.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.SetRequestURI("https://localhost/")
+	if err := hc.Do(req, resp); !errors.Is(err, errHTTP2Required) {
+		t.Fatalf("Do() error = %v, want %v", err, errHTTP2Required)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatalf("server handshake error: %v", err)
+	}
+}
+
+type testPushHandler struct {
+	t            *testing.T
+	acceptedPath chan string
+	responseBody chan string
+}
+
+func (h *testPushHandler) Accept(_, promised *fasthttp.Request) bool {
+	h.acceptedPath <- string(promised.URI().Path())
+	return true
+}
+
+func (h *testPushHandler) Handle(_ *fasthttp.Request, response *fasthttp.Response) {
+	h.responseBody <- string(response.Body())
+}
+
+func TestServerPush(t *testing.T) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if string(ctx.Path()) == "/pushed" {
+				ctx.SetBodyString("pushed response")
+				return
+			}
+			if err := ctx.Push("/pushed", nil); err != nil {
+				t.Errorf("Push() error: %v", err)
+			}
+			ctx.SetBodyString("parent response")
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{EnablePush: true})
+	handler := &testPushHandler{
+		t:            t,
+		acceptedPath: make(chan string, 1),
+		responseBody: make(chan string, 1),
+	}
+	hc := &fasthttp.HostClient{Addr: testServer.listener.Addr().String()}
+	if err := ConfigureHostClient(hc, ClientConfig{
+		Mode:        PriorKnowledge,
+		PushHandler: handler,
+	}); err != nil {
+		t.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	t.Cleanup(hc.CloseIdleConnections)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.SetRequestURI(testServer.URL("/"))
+	if err := hc.Do(req, resp); err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	if got := string(resp.Body()); got != "parent response" {
+		t.Fatalf("parent body = %q", got)
+	}
+	select {
+	case path := <-handler.acceptedPath:
+		if path != "/pushed" {
+			t.Fatalf("promised path = %q, want /pushed", path)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("push wasn't offered")
+	}
+	select {
+	case body := <-handler.responseBody:
+		if body != "pushed response" {
+			t.Fatalf("pushed body = %q, want pushed response", body)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("push response wasn't handled")
+	}
+}

--- a/http2/client_test.go
+++ b/http2/client_test.go
@@ -18,7 +18,7 @@ import (
 	xhttp2 "golang.org/x/net/http2"
 )
 
-func newPriorKnowledgeHostClient(t *testing.T, addr string) *fasthttp.HostClient {
+func newPriorKnowledgeHostClient(t testing.TB, addr string) *fasthttp.HostClient {
 	t.Helper()
 	hc := &fasthttp.HostClient{Addr: addr}
 	if err := ConfigureHostClient(hc, ClientConfig{Mode: PriorKnowledge}); err != nil {
@@ -102,6 +102,56 @@ func TestClientMultiplexesRequests(t *testing.T) {
 	}
 }
 
+func TestClientReadTimeoutCancelsOnlyOneStream(t *testing.T) {
+	slowStarted := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if string(ctx.Path()) == "/slow" {
+				close(slowStarted)
+				<-releaseSlow
+			}
+			ctx.SetBodyString("ok")
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+	hc := newPriorKnowledgeHostClient(t, testServer.listener.Addr().String())
+	hc.MaxConns = 1
+	hc.MaxConnWaitTimeout = time.Second
+	hc.ReadTimeout = 30 * time.Millisecond
+
+	slowDone := make(chan error, 1)
+	go func() {
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+		req.SetRequestURI(testServer.URL("/slow"))
+		slowDone <- hc.Do(req, resp)
+	}()
+	select {
+	case <-slowStarted:
+	case <-time.After(time.Second):
+		t.Fatal("slow handler didn't start")
+	}
+
+	fastReq := fasthttp.AcquireRequest()
+	fastResp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(fastReq)
+	defer fasthttp.ReleaseResponse(fastResp)
+	fastReq.SetRequestURI(testServer.URL("/fast"))
+	if err := hc.Do(fastReq, fastResp); err != nil {
+		t.Fatalf("fast request error: %v", err)
+	}
+	if got := string(fastResp.Body()); got != "ok" {
+		t.Fatalf("fast response body = %q, want ok", got)
+	}
+	if err := <-slowDone; !errors.Is(err, fasthttp.ErrTimeout) {
+		t.Fatalf("slow request error = %v, want timeout", err)
+	}
+	close(releaseSlow)
+}
+
 func TestClientStreamingResponse(t *testing.T) {
 	body := bytes.Repeat([]byte("streaming-response"), 20_000)
 	server := &fasthttp.Server{
@@ -127,6 +177,26 @@ func TestClientStreamingResponse(t *testing.T) {
 	}
 	if !bytes.Equal(got, body) {
 		t.Fatalf("response body length = %d, want %d", len(got), len(body))
+	}
+}
+
+func TestClientResponseBodyLimitUsesFasthttpSentinel(t *testing.T) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBody(bytes.Repeat([]byte("x"), 1024))
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+	hc := newPriorKnowledgeHostClient(t, testServer.listener.Addr().String())
+	hc.MaxResponseBodySize = 16
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.SetRequestURI(testServer.URL("/large"))
+	if err := hc.Do(req, resp); !errors.Is(err, fasthttp.ErrBodyTooLarge) {
+		t.Fatalf("Do() error = %v, want ErrBodyTooLarge", err)
 	}
 }
 
@@ -227,6 +297,86 @@ func TestExtendedConnectStream(t *testing.T) {
 	}
 	if !bytes.Equal(got, message) {
 		t.Fatalf("echo length = %d, want %d", len(got), len(message))
+	}
+}
+
+func TestExtendedConnectRequiresPeerSetting(t *testing.T) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if len(ctx.Request.Header.ConnectProtocol()) != 0 {
+				t.Error("server received extended CONNECT without advertising support")
+			}
+			ctx.SetBodyString("ok")
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+	hc := &fasthttp.HostClient{Addr: testServer.listener.Addr().String()}
+	if err := ConfigureHostClient(hc, ClientConfig{
+		Mode:                  PriorKnowledge,
+		EnableExtendedConnect: true,
+	}); err != nil {
+		t.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	t.Cleanup(hc.CloseIdleConnections)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.Header.SetMethod(fasthttp.MethodConnect)
+	req.Header.SetConnectProtocol("websocket")
+	req.SetRequestURI(testServer.URL("/chat"))
+	if _, err := hc.OpenStream(req, resp); !errors.Is(err, fasthttp.ErrProtocolNotSupported) {
+		t.Fatalf("OpenStream() error = %v, want protocol not supported", err)
+	}
+
+	req.Reset()
+	resp.Reset()
+	req.SetRequestURI(testServer.URL("/regular"))
+	if err := hc.Do(req, resp); err != nil {
+		t.Fatalf("regular request after rejected CONNECT: %v", err)
+	}
+	if got := string(resp.Body()); got != "ok" {
+		t.Fatalf("regular response body = %q, want ok", got)
+	}
+}
+
+func TestRejectedExtendedConnectDoesNotRunStreamHandler(t *testing.T) {
+	streamHandlerCalled := make(chan struct{}, 1)
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if err := ctx.AcceptStream(func(fasthttp.StreamConn) {
+				streamHandlerCalled <- struct{}{}
+			}); err != nil {
+				t.Errorf("AcceptStream() error: %v", err)
+			}
+			ctx.SetStatusCode(fasthttp.StatusForbidden)
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{EnableExtendedConnect: true})
+	hc := &fasthttp.HostClient{Addr: testServer.listener.Addr().String()}
+	if err := ConfigureHostClient(hc, ClientConfig{
+		Mode:                  PriorKnowledge,
+		EnableExtendedConnect: true,
+	}); err != nil {
+		t.Fatalf("ConfigureHostClient() error: %v", err)
+	}
+	t.Cleanup(hc.CloseIdleConnections)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.Header.SetMethod(fasthttp.MethodConnect)
+	req.Header.SetConnectProtocol("websocket")
+	req.SetRequestURI(testServer.URL("/chat"))
+	if _, err := hc.OpenStream(req, resp); err == nil {
+		t.Fatal("OpenStream() succeeded for a rejected extended CONNECT")
+	}
+	select {
+	case <-streamHandlerCalled:
+		t.Fatal("stream handler ran for a non-2xx CONNECT response")
+	case <-time.After(20 * time.Millisecond):
 	}
 }
 
@@ -390,8 +540,8 @@ func TestClientRequireHTTP2RejectsHTTP1ALPN(t *testing.T) {
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 	req.SetRequestURI("https://localhost/")
-	if err := hc.Do(req, resp); !errors.Is(err, errHTTP2Required) {
-		t.Fatalf("Do() error = %v, want %v", err, errHTTP2Required)
+	if err := hc.Do(req, resp); !errors.Is(err, ErrHTTP2Required) {
+		t.Fatalf("Do() error = %v, want %v", err, ErrHTTP2Required)
 	}
 	if err := <-serverDone; err != nil {
 		t.Fatalf("server handshake error: %v", err)

--- a/http2/codec.go
+++ b/http2/codec.go
@@ -1,0 +1,206 @@
+package http2
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"golang.org/x/net/http/httpguts"
+	xhttp2 "golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+const (
+	maxCachedHeaderNames  = 128
+	maxCachedHeaderValues = 256
+	maxCachedHeaderValue  = 4 << 10
+)
+
+type headerStringCache struct {
+	names  map[string]string
+	values map[string]string
+}
+
+func (c *headerStringCache) name(value []byte) string {
+	if cached, ok := c.names[string(value)]; ok {
+		return cached
+	}
+	original := string(value)
+	lower := strings.ToLower(original)
+	if c.names == nil {
+		c.names = make(map[string]string, 16)
+	} else if len(c.names) >= maxCachedHeaderNames {
+		clear(c.names)
+	}
+	c.names[original] = lower
+	return lower
+}
+
+func (c *headerStringCache) value(value []byte, sensitive bool) string {
+	if sensitive || len(value) > maxCachedHeaderValue {
+		return string(value)
+	}
+	if cached, ok := c.values[string(value)]; ok {
+		return cached
+	}
+	stable := string(value)
+	if c.values == nil {
+		c.values = make(map[string]string, 32)
+	} else if len(c.values) >= maxCachedHeaderValues {
+		clear(c.values)
+	}
+	c.values[stable] = stable
+	return stable
+}
+
+type headerBlockFrame interface {
+	HeaderBlockFragment() []byte
+	HeadersEnded() bool
+}
+
+type completeHeaderBlock []byte
+
+func (b completeHeaderBlock) HeaderBlockFragment() []byte { return b }
+func (completeHeaderBlock) HeadersEnded() bool            { return true }
+
+// headerCodec owns the connection-scoped HPACK decoder. It decodes directly
+// into caller-provided pooled storage instead of asking x/net Framer to build a
+// second MetaHeadersFrame field slice for every message.
+type headerCodec struct {
+	decoder *hpack.Decoder
+
+	fields      []hpack.HeaderField
+	remaining   uint64
+	truncated   bool
+	invalid     error
+	sawRegular  bool
+	maxListSize uint64
+}
+
+func newHeaderCodec(maxTableSize, maxListSize uint32) *headerCodec {
+	codec := &headerCodec{maxListSize: uint64(maxListSize)}
+	if codec.maxListSize == 0 {
+		codec.maxListSize = math.MaxUint32
+	}
+	codec.decoder = hpack.NewDecoder(maxTableSize, codec.emit)
+	codec.decoder.SetAllowedMaxDynamicTableSize(maxTableSize)
+	codec.decoder.SetMaxStringLength(int(codec.maxListSize))
+	return codec
+}
+
+func (c *headerCodec) decode(
+	framer *xhttp2.Framer,
+	streamID uint32,
+	first headerBlockFrame,
+	fields []hpack.HeaderField,
+) ([]hpack.HeaderField, bool, error, error) {
+	c.fields = fields
+	c.remaining = c.maxListSize
+	c.truncated = false
+	c.invalid = nil
+	c.sawRegular = false
+	c.decoder.SetEmitEnabled(true)
+
+	current := first
+	for {
+		fragment := current.HeaderBlockFragment()
+		if uint64(len(fragment)) > 2*c.remaining {
+			decodedFields := c.fields
+			c.resetBlock()
+			return decodedFields, false, nil, xhttp2.ConnectionError(xhttp2.ErrCodeProtocol)
+		}
+		if c.invalid != nil {
+			decodedFields := c.fields
+			c.resetBlock()
+			return decodedFields, false, nil, xhttp2.ConnectionError(xhttp2.ErrCodeProtocol)
+		}
+		if _, err := c.decoder.Write(fragment); err != nil {
+			decodedFields := c.fields
+			c.resetBlock()
+			return decodedFields, false, nil, xhttp2.ConnectionError(xhttp2.ErrCodeCompression)
+		}
+		if current.HeadersEnded() {
+			break
+		}
+		frame, err := framer.ReadFrame()
+		if err != nil {
+			decodedFields := c.fields
+			c.resetBlock()
+			return decodedFields, false, nil, err
+		}
+		continuation, ok := frame.(*xhttp2.ContinuationFrame)
+		if !ok || continuation.StreamID != streamID {
+			decodedFields := c.fields
+			c.resetBlock()
+			return decodedFields, false, nil, xhttp2.ConnectionError(xhttp2.ErrCodeProtocol)
+		}
+		current = continuation
+	}
+	if err := c.decoder.Close(); err != nil {
+		decodedFields := c.fields
+		c.resetBlock()
+		return decodedFields, false, nil, xhttp2.ConnectionError(xhttp2.ErrCodeCompression)
+	}
+	decodedFields := c.fields
+	truncated := c.truncated
+	invalid := c.invalid
+	c.resetBlock()
+	return decodedFields, truncated, invalid, nil
+}
+
+func (c *headerCodec) decodeComplete(
+	fragment []byte,
+	fields []hpack.HeaderField,
+) ([]hpack.HeaderField, bool, error, error) {
+	return c.decode(nil, 0, completeHeaderBlock(fragment), fields)
+}
+
+func (c *headerCodec) emit(field hpack.HeaderField) {
+	if !httpguts.ValidHeaderFieldValue(field.Value) {
+		c.invalid = fmt.Errorf("http2: invalid value for header %q", field.Name)
+		c.decoder.SetEmitEnabled(false)
+		return
+	}
+	pseudo := field.IsPseudo()
+	if pseudo {
+		if c.sawRegular {
+			c.invalid = errors.New("http2: pseudo-header after regular header")
+			c.decoder.SetEmitEnabled(false)
+			return
+		}
+	} else {
+		c.sawRegular = true
+		if !validWireHeaderName(field.Name) {
+			c.invalid = fmt.Errorf("http2: invalid header name %q", field.Name)
+			c.decoder.SetEmitEnabled(false)
+			return
+		}
+	}
+	fieldSize := uint64(len(field.Name) + len(field.Value) + 32)
+	if fieldSize > c.remaining {
+		c.remaining = 0
+		c.truncated = true
+		c.decoder.SetEmitEnabled(false)
+		return
+	}
+	c.remaining -= fieldSize
+	c.fields = append(c.fields, field)
+}
+
+func (c *headerCodec) resetBlock() {
+	c.fields = nil
+	c.invalid = nil
+}
+
+func validWireHeaderName(name string) bool {
+	if !httpguts.ValidHeaderFieldName(name) {
+		return false
+	}
+	for i := range len(name) {
+		if name[i] >= 'A' && name[i] <= 'Z' {
+			return false
+		}
+	}
+	return true
+}

--- a/http2/config.go
+++ b/http2/config.go
@@ -1,8 +1,10 @@
 package http2
 
 import (
+	"crypto/tls"
 	"errors"
 	"net"
+	"reflect"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -11,12 +13,18 @@ import (
 const (
 	clientPreface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 
-	defaultMaxConcurrentStreams   = 250
-	defaultHeaderTableSize        = 4096
-	defaultMaxFrameSize           = 16 << 10
-	defaultConnectionWindowSize   = 1 << 20
-	defaultStreamWindowSize       = 1 << 20
-	defaultMaxQueuedControlFrames = 10_000
+	defaultMaxConcurrentStreams    = 250
+	defaultHeaderTableSize         = 4096
+	defaultMaxFrameSize            = 16 << 10
+	defaultWriteBufferSize         = 64 << 10
+	maxResponseBodyPreallocation   = 1 << 20
+	defaultConnectionWindowSize    = 1 << 20
+	defaultStreamWindowSize        = 1 << 20
+	defaultMaxQueuedControlFrames  = 10_000
+	maxConfiguredConcurrentStreams = 1 << 20
+	maxConfiguredHeaderListSize    = 64 << 20
+	maxConfiguredHeaderTableSize   = 64 << 20
+	maxConfiguredControlFrames     = 1_000_000
 )
 
 // ClientMode selects how an HTTP/2 transport negotiates a connection.
@@ -51,8 +59,6 @@ type ClientConfig struct {
 	MaxDecoderHeaderTableSize      uint32
 	MaxEncoderHeaderTableSize      uint32
 	MaxReadFrameSize               uint32
-	MaxUploadBufferPerConnection   int32
-	MaxUploadBufferPerStream       int32
 	MaxResponseBufferPerConnection int32
 	MaxResponseBufferPerStream     int32
 
@@ -84,6 +90,9 @@ func normalizeClientConfig(hc *fasthttp.HostClient, cfg ClientConfig) (clientCon
 	if cfg.Mode > PriorKnowledge {
 		return clientConfig{}, errors.New("http2: invalid client mode")
 	}
+	if isTypedNil(cfg.PushHandler) {
+		return clientConfig{}, errors.New("http2: push handler is nil")
+	}
 	result := clientConfig{
 		mode:                  cfg.Mode,
 		maxConcurrentStreams:  cfg.MaxConcurrentStreams,
@@ -102,6 +111,9 @@ func normalizeClientConfig(hc *fasthttp.HostClient, cfg ClientConfig) (clientCon
 	if result.maxConcurrentStreams == 0 {
 		result.maxConcurrentStreams = defaultMaxConcurrentStreams
 	}
+	if result.maxConcurrentStreams > maxConfiguredConcurrentStreams {
+		return clientConfig{}, errors.New("http2: max concurrent streams exceeds the safety limit")
+	}
 	if result.maxHeaderListSize == 0 {
 		if hc != nil && hc.ReadBufferSize > 0 {
 			result.maxHeaderListSize = uint32(hc.ReadBufferSize)
@@ -111,6 +123,11 @@ func normalizeClientConfig(hc *fasthttp.HostClient, cfg ClientConfig) (clientCon
 	}
 	if result.maxDecoderTableSize == 0 {
 		result.maxDecoderTableSize = defaultHeaderTableSize
+	}
+	if result.maxHeaderListSize > maxConfiguredHeaderListSize ||
+		result.maxDecoderTableSize > maxConfiguredHeaderTableSize ||
+		result.maxEncoderTableSize > maxConfiguredHeaderTableSize {
+		return clientConfig{}, errors.New("http2: configured header memory limit is too large")
 	}
 	if result.maxEncoderTableSize == 0 {
 		result.maxEncoderTableSize = defaultHeaderTableSize
@@ -139,6 +156,19 @@ func normalizeClientConfig(hc *fasthttp.HostClient, cfg ClientConfig) (clientCon
 	return result, nil
 }
 
+func isTypedNil(value any) bool {
+	if value == nil {
+		return false
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
 // ServerConfig controls HTTP/2-specific server behavior. The zero value uses
 // bounded production defaults and keeps server push and extended CONNECT
 // disabled.
@@ -151,6 +181,7 @@ type ServerConfig struct {
 	MaxQueuedControlFrames       int
 	MaxPromisedStreams           uint32
 	MaxPushDepth                 uint8
+	MaxRapidResetsPerSecond      uint32
 	MaxUploadBufferPerConnection int32
 	MaxUploadBufferPerStream     int32
 
@@ -165,47 +196,52 @@ type ServerConfig struct {
 }
 
 type serverConfig struct {
-	maxConcurrentStreams   uint32
-	maxHeaderListSize      uint32
-	maxDecoderTableSize    uint32
-	maxEncoderTableSize    uint32
-	maxReadFrameSize       uint32
-	maxQueuedControlFrames int
-	maxPromisedStreams     uint32
-	maxPushDepth           uint8
-	connectionWindowSize   int32
-	streamWindowSize       int32
-	idleTimeout            time.Duration
-	readIdleTimeout        time.Duration
-	pingTimeout            time.Duration
-	writeByteTimeout       time.Duration
-	enablePush             bool
-	enableExtendedConnect  bool
-	countError             func(string)
+	maxConcurrentStreams    uint32
+	maxHeaderListSize       uint32
+	maxDecoderTableSize     uint32
+	maxEncoderTableSize     uint32
+	maxReadFrameSize        uint32
+	maxQueuedControlFrames  int
+	maxPromisedStreams      uint32
+	maxPushDepth            uint8
+	maxRapidResetsPerSecond uint32
+	connectionWindowSize    int32
+	streamWindowSize        int32
+	idleTimeout             time.Duration
+	readIdleTimeout         time.Duration
+	pingTimeout             time.Duration
+	writeByteTimeout        time.Duration
+	enablePush              bool
+	enableExtendedConnect   bool
+	countError              func(string)
 }
 
 func normalizeServerConfig(s *fasthttp.Server, cfg ServerConfig) (serverConfig, error) {
 	result := serverConfig{
-		maxConcurrentStreams:   cfg.MaxConcurrentStreams,
-		maxHeaderListSize:      cfg.MaxHeaderListSize,
-		maxDecoderTableSize:    cfg.MaxDecoderHeaderTableSize,
-		maxEncoderTableSize:    cfg.MaxEncoderHeaderTableSize,
-		maxReadFrameSize:       cfg.MaxReadFrameSize,
-		maxQueuedControlFrames: cfg.MaxQueuedControlFrames,
-		maxPromisedStreams:     cfg.MaxPromisedStreams,
-		maxPushDepth:           cfg.MaxPushDepth,
-		connectionWindowSize:   cfg.MaxUploadBufferPerConnection,
-		streamWindowSize:       cfg.MaxUploadBufferPerStream,
-		idleTimeout:            cfg.IdleTimeout,
-		readIdleTimeout:        cfg.ReadIdleTimeout,
-		pingTimeout:            cfg.PingTimeout,
-		writeByteTimeout:       cfg.WriteByteTimeout,
-		enablePush:             cfg.EnablePush,
-		enableExtendedConnect:  cfg.EnableExtendedConnect,
-		countError:             cfg.CountError,
+		maxConcurrentStreams:    cfg.MaxConcurrentStreams,
+		maxHeaderListSize:       cfg.MaxHeaderListSize,
+		maxDecoderTableSize:     cfg.MaxDecoderHeaderTableSize,
+		maxEncoderTableSize:     cfg.MaxEncoderHeaderTableSize,
+		maxReadFrameSize:        cfg.MaxReadFrameSize,
+		maxQueuedControlFrames:  cfg.MaxQueuedControlFrames,
+		maxPromisedStreams:      cfg.MaxPromisedStreams,
+		maxPushDepth:            cfg.MaxPushDepth,
+		maxRapidResetsPerSecond: cfg.MaxRapidResetsPerSecond,
+		connectionWindowSize:    cfg.MaxUploadBufferPerConnection,
+		streamWindowSize:        cfg.MaxUploadBufferPerStream,
+		idleTimeout:             cfg.IdleTimeout,
+		readIdleTimeout:         cfg.ReadIdleTimeout,
+		pingTimeout:             cfg.PingTimeout,
+		writeByteTimeout:        cfg.WriteByteTimeout,
+		enablePush:              cfg.EnablePush,
+		enableExtendedConnect:   cfg.EnableExtendedConnect,
+		countError:              cfg.CountError,
 	}
 	if result.maxConcurrentStreams == 0 {
 		result.maxConcurrentStreams = defaultMaxConcurrentStreams
+	}
+	if result.maxConcurrentStreams > maxConfiguredConcurrentStreams {
+		return serverConfig{}, errors.New("http2: max concurrent streams exceeds the safety limit")
 	}
 	if result.maxHeaderListSize == 0 {
 		result.maxHeaderListSize = uint32(s.ReadBufferSize)
@@ -219,6 +255,11 @@ func normalizeServerConfig(s *fasthttp.Server, cfg ServerConfig) (serverConfig, 
 	if result.maxEncoderTableSize == 0 {
 		result.maxEncoderTableSize = defaultHeaderTableSize
 	}
+	if result.maxHeaderListSize > maxConfiguredHeaderListSize ||
+		result.maxDecoderTableSize > maxConfiguredHeaderTableSize ||
+		result.maxEncoderTableSize > maxConfiguredHeaderTableSize {
+		return serverConfig{}, errors.New("http2: configured header memory limit is too large")
+	}
 	if result.maxReadFrameSize == 0 {
 		result.maxReadFrameSize = defaultMaxFrameSize
 	}
@@ -228,14 +269,20 @@ func normalizeServerConfig(s *fasthttp.Server, cfg ServerConfig) (serverConfig, 
 	if result.maxQueuedControlFrames == 0 {
 		result.maxQueuedControlFrames = defaultMaxQueuedControlFrames
 	}
-	if result.maxQueuedControlFrames < 1 {
-		return serverConfig{}, errors.New("http2: max queued control frames must be positive")
+	if result.maxQueuedControlFrames < 32 {
+		return serverConfig{}, errors.New("http2: max queued control frames must be at least 32")
+	}
+	if result.maxQueuedControlFrames > maxConfiguredControlFrames {
+		return serverConfig{}, errors.New("http2: max queued control frames exceeds the safety limit")
 	}
 	if result.maxPromisedStreams == 0 {
 		result.maxPromisedStreams = 16
 	}
 	if result.maxPushDepth == 0 {
 		result.maxPushDepth = 1
+	}
+	if result.maxRapidResetsPerSecond == 0 {
+		result.maxRapidResetsPerSecond = 1000
 	}
 	if result.connectionWindowSize == 0 {
 		result.connectionWindowSize = defaultConnectionWindowSize
@@ -251,6 +298,9 @@ func normalizeServerConfig(s *fasthttp.Server, cfg ServerConfig) (serverConfig, 
 	}
 	if result.pingTimeout == 0 {
 		result.pingTimeout = 15 * time.Second
+	}
+	if result.idleTimeout == 0 {
+		result.idleTimeout = s.IdleTimeout
 	}
 	return result, nil
 }
@@ -269,8 +319,16 @@ func ConfigureServer(s *fasthttp.Server, cfg ServerConfig) error {
 	if err != nil {
 		return err
 	}
-	if s.TLSConfig != nil {
+	if s.TLSConfig == nil {
+		s.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	} else {
 		s.TLSConfig = s.TLSConfig.Clone()
+		if s.TLSConfig.MaxVersion != 0 && s.TLSConfig.MaxVersion < tls.VersionTLS12 {
+			return errors.New("http2: TLS maximum version must be at least 1.2")
+		}
+		if s.TLSConfig.MinVersion < tls.VersionTLS12 {
+			s.TLSConfig.MinVersion = tls.VersionTLS12
+		}
 	}
 	return s.RegisterProtocol(fasthttp.ProtocolRegistration{
 		ALPN:             []string{"h2"},

--- a/http2/config.go
+++ b/http2/config.go
@@ -1,0 +1,296 @@
+package http2
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	clientPreface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+	defaultMaxConcurrentStreams   = 250
+	defaultHeaderTableSize        = 4096
+	defaultMaxFrameSize           = 16 << 10
+	defaultConnectionWindowSize   = 1 << 20
+	defaultStreamWindowSize       = 1 << 20
+	defaultMaxQueuedControlFrames = 10_000
+)
+
+// ClientMode selects how an HTTP/2 transport negotiates a connection.
+type ClientMode uint8
+
+const (
+	// PreferHTTP2 advertises h2 and http/1.1 over TLS and reuses a connection
+	// that selects HTTP/1.1 as the HostClient fallback connection.
+	PreferHTTP2 ClientMode = iota
+	// RequireHTTP2 fails when TLS ALPN doesn't select h2.
+	RequireHTTP2
+	// PriorKnowledge sends the HTTP/2 connection preface immediately on a
+	// cleartext connection. It must only be used for known HTTP/2 origins.
+	PriorKnowledge
+)
+
+// PushHandler decides whether promised requests are accepted and handles
+// accepted push responses. Request and response values are only valid for the
+// duration of the callback that receives them.
+type PushHandler interface {
+	Accept(parent, promised *fasthttp.Request) bool
+	Handle(promised *fasthttp.Request, response *fasthttp.Response)
+}
+
+// ClientConfig controls HTTP/2 client negotiation, limits, and optional
+// protocol extensions. The zero value prefers HTTP/2 for TLS origins and uses
+// ordinary HTTP/1 for cleartext origins.
+type ClientConfig struct {
+	Mode                           ClientMode
+	MaxConcurrentStreams           uint32
+	MaxHeaderListSize              uint32
+	MaxDecoderHeaderTableSize      uint32
+	MaxEncoderHeaderTableSize      uint32
+	MaxReadFrameSize               uint32
+	MaxUploadBufferPerConnection   int32
+	MaxUploadBufferPerStream       int32
+	MaxResponseBufferPerConnection int32
+	MaxResponseBufferPerStream     int32
+
+	ReadIdleTimeout time.Duration
+	PingTimeout     time.Duration
+
+	EnableExtendedConnect bool
+	PushHandler           PushHandler
+	CountError            func(errorType string)
+}
+
+type clientConfig struct {
+	mode                  ClientMode
+	maxConcurrentStreams  uint32
+	maxHeaderListSize     uint32
+	maxDecoderTableSize   uint32
+	maxEncoderTableSize   uint32
+	maxReadFrameSize      uint32
+	connectionWindowSize  int32
+	streamWindowSize      int32
+	readIdleTimeout       time.Duration
+	pingTimeout           time.Duration
+	enableExtendedConnect bool
+	pushHandler           PushHandler
+	countError            func(string)
+}
+
+func normalizeClientConfig(hc *fasthttp.HostClient, cfg ClientConfig) (clientConfig, error) {
+	if cfg.Mode > PriorKnowledge {
+		return clientConfig{}, errors.New("http2: invalid client mode")
+	}
+	result := clientConfig{
+		mode:                  cfg.Mode,
+		maxConcurrentStreams:  cfg.MaxConcurrentStreams,
+		maxHeaderListSize:     cfg.MaxHeaderListSize,
+		maxDecoderTableSize:   cfg.MaxDecoderHeaderTableSize,
+		maxEncoderTableSize:   cfg.MaxEncoderHeaderTableSize,
+		maxReadFrameSize:      cfg.MaxReadFrameSize,
+		connectionWindowSize:  cfg.MaxResponseBufferPerConnection,
+		streamWindowSize:      cfg.MaxResponseBufferPerStream,
+		readIdleTimeout:       cfg.ReadIdleTimeout,
+		pingTimeout:           cfg.PingTimeout,
+		enableExtendedConnect: cfg.EnableExtendedConnect,
+		pushHandler:           cfg.PushHandler,
+		countError:            cfg.CountError,
+	}
+	if result.maxConcurrentStreams == 0 {
+		result.maxConcurrentStreams = defaultMaxConcurrentStreams
+	}
+	if result.maxHeaderListSize == 0 {
+		if hc != nil && hc.ReadBufferSize > 0 {
+			result.maxHeaderListSize = uint32(hc.ReadBufferSize)
+		} else {
+			result.maxHeaderListSize = 4096
+		}
+	}
+	if result.maxDecoderTableSize == 0 {
+		result.maxDecoderTableSize = defaultHeaderTableSize
+	}
+	if result.maxEncoderTableSize == 0 {
+		result.maxEncoderTableSize = defaultHeaderTableSize
+	}
+	if result.maxReadFrameSize == 0 {
+		result.maxReadFrameSize = defaultMaxFrameSize
+	}
+	if result.maxReadFrameSize < defaultMaxFrameSize || result.maxReadFrameSize > 1<<24-1 {
+		return clientConfig{}, errors.New("http2: max read frame size must be between 16384 and 16777215")
+	}
+	if result.connectionWindowSize == 0 {
+		result.connectionWindowSize = defaultConnectionWindowSize
+	}
+	if result.connectionWindowSize < 65535 {
+		return clientConfig{}, errors.New("http2: connection response window must be at least 65535")
+	}
+	if result.streamWindowSize == 0 {
+		result.streamWindowSize = defaultStreamWindowSize
+	}
+	if result.streamWindowSize < 1 {
+		return clientConfig{}, errors.New("http2: stream response window must be positive")
+	}
+	if result.pingTimeout == 0 {
+		result.pingTimeout = 15 * time.Second
+	}
+	return result, nil
+}
+
+// ServerConfig controls HTTP/2-specific server behavior. The zero value uses
+// bounded production defaults and keeps server push and extended CONNECT
+// disabled.
+type ServerConfig struct {
+	MaxConcurrentStreams         uint32
+	MaxHeaderListSize            uint32
+	MaxDecoderHeaderTableSize    uint32
+	MaxEncoderHeaderTableSize    uint32
+	MaxReadFrameSize             uint32
+	MaxQueuedControlFrames       int
+	MaxPromisedStreams           uint32
+	MaxPushDepth                 uint8
+	MaxUploadBufferPerConnection int32
+	MaxUploadBufferPerStream     int32
+
+	IdleTimeout      time.Duration
+	ReadIdleTimeout  time.Duration
+	PingTimeout      time.Duration
+	WriteByteTimeout time.Duration
+
+	EnablePush            bool
+	EnableExtendedConnect bool
+	CountError            func(errorType string)
+}
+
+type serverConfig struct {
+	maxConcurrentStreams   uint32
+	maxHeaderListSize      uint32
+	maxDecoderTableSize    uint32
+	maxEncoderTableSize    uint32
+	maxReadFrameSize       uint32
+	maxQueuedControlFrames int
+	maxPromisedStreams     uint32
+	maxPushDepth           uint8
+	connectionWindowSize   int32
+	streamWindowSize       int32
+	idleTimeout            time.Duration
+	readIdleTimeout        time.Duration
+	pingTimeout            time.Duration
+	writeByteTimeout       time.Duration
+	enablePush             bool
+	enableExtendedConnect  bool
+	countError             func(string)
+}
+
+func normalizeServerConfig(s *fasthttp.Server, cfg ServerConfig) (serverConfig, error) {
+	result := serverConfig{
+		maxConcurrentStreams:   cfg.MaxConcurrentStreams,
+		maxHeaderListSize:      cfg.MaxHeaderListSize,
+		maxDecoderTableSize:    cfg.MaxDecoderHeaderTableSize,
+		maxEncoderTableSize:    cfg.MaxEncoderHeaderTableSize,
+		maxReadFrameSize:       cfg.MaxReadFrameSize,
+		maxQueuedControlFrames: cfg.MaxQueuedControlFrames,
+		maxPromisedStreams:     cfg.MaxPromisedStreams,
+		maxPushDepth:           cfg.MaxPushDepth,
+		connectionWindowSize:   cfg.MaxUploadBufferPerConnection,
+		streamWindowSize:       cfg.MaxUploadBufferPerStream,
+		idleTimeout:            cfg.IdleTimeout,
+		readIdleTimeout:        cfg.ReadIdleTimeout,
+		pingTimeout:            cfg.PingTimeout,
+		writeByteTimeout:       cfg.WriteByteTimeout,
+		enablePush:             cfg.EnablePush,
+		enableExtendedConnect:  cfg.EnableExtendedConnect,
+		countError:             cfg.CountError,
+	}
+	if result.maxConcurrentStreams == 0 {
+		result.maxConcurrentStreams = defaultMaxConcurrentStreams
+	}
+	if result.maxHeaderListSize == 0 {
+		result.maxHeaderListSize = uint32(s.ReadBufferSize)
+		if result.maxHeaderListSize == 0 {
+			result.maxHeaderListSize = 4096
+		}
+	}
+	if result.maxDecoderTableSize == 0 {
+		result.maxDecoderTableSize = defaultHeaderTableSize
+	}
+	if result.maxEncoderTableSize == 0 {
+		result.maxEncoderTableSize = defaultHeaderTableSize
+	}
+	if result.maxReadFrameSize == 0 {
+		result.maxReadFrameSize = defaultMaxFrameSize
+	}
+	if result.maxReadFrameSize < defaultMaxFrameSize || result.maxReadFrameSize > 1<<24-1 {
+		return serverConfig{}, errors.New("http2: max read frame size must be between 16384 and 16777215")
+	}
+	if result.maxQueuedControlFrames == 0 {
+		result.maxQueuedControlFrames = defaultMaxQueuedControlFrames
+	}
+	if result.maxQueuedControlFrames < 1 {
+		return serverConfig{}, errors.New("http2: max queued control frames must be positive")
+	}
+	if result.maxPromisedStreams == 0 {
+		result.maxPromisedStreams = 16
+	}
+	if result.maxPushDepth == 0 {
+		result.maxPushDepth = 1
+	}
+	if result.connectionWindowSize == 0 {
+		result.connectionWindowSize = defaultConnectionWindowSize
+	}
+	if result.connectionWindowSize < 65535 {
+		return serverConfig{}, errors.New("http2: connection upload window must be at least 65535")
+	}
+	if result.streamWindowSize == 0 {
+		result.streamWindowSize = defaultStreamWindowSize
+	}
+	if result.streamWindowSize < 1 {
+		return serverConfig{}, errors.New("http2: stream upload window must be positive")
+	}
+	if result.pingTimeout == 0 {
+		result.pingTimeout = 15 * time.Second
+	}
+	return result, nil
+}
+
+type serverHandler struct {
+	config serverConfig
+}
+
+// ConfigureServer enables HTTP/2 on s through TLS ALPN and cleartext prior
+// knowledge. Existing TLS settings are preserved.
+func ConfigureServer(s *fasthttp.Server, cfg ServerConfig) error {
+	if s == nil {
+		return errors.New("http2: server is nil")
+	}
+	normalized, err := normalizeServerConfig(s, cfg)
+	if err != nil {
+		return err
+	}
+	if s.TLSConfig != nil {
+		s.TLSConfig = s.TLSConfig.Clone()
+	}
+	return s.RegisterProtocol(fasthttp.ProtocolRegistration{
+		ALPN:             []string{"h2"},
+		CleartextPreface: []byte(clientPreface),
+		Handler:          &serverHandler{config: normalized},
+	})
+}
+
+// ServeConn serves one HTTP/2 prior-knowledge connection. It doesn't accept
+// the obsolete h2c Upgrade handshake.
+func ServeConn(s *fasthttp.Server, c net.Conn, cfg ServerConfig) error {
+	if s == nil {
+		return errors.New("http2: server is nil")
+	}
+	if c == nil {
+		return errors.New("http2: connection is nil")
+	}
+	normalized, err := normalizeServerConfig(s, cfg)
+	if err != nil {
+		return err
+	}
+	return s.ServeProtocolConn(c, &serverHandler{config: normalized})
+}

--- a/http2/doc.go
+++ b/http2/doc.go
@@ -2,7 +2,14 @@
 //
 // HTTP/2 is opt-in. Use ConfigureServer for ALPN and same-port cleartext
 // prior-knowledge dispatch, or ServeConn for a dedicated prior-knowledge
-// connection. The package doesn't implement the obsolete h2c Upgrade path.
+// connection. ConfigureHostClient and ConfigureClient install the multiplexed
+// client transport while retaining the built-in HTTP/1 fallback. TLS clients
+// prefer HTTP/2 unless RequireHTTP2 is selected; cleartext HTTP/2 requires
+// PriorKnowledge. The package doesn't implement the obsolete h2c Upgrade path.
+//
+// Server push and extended CONNECT are disabled by default. Extended CONNECT
+// is exposed as a request-scoped fasthttp.StreamConn rather than changing
+// RequestCtx.Hijack's physical-connection behavior.
 //
 // Experimental: the package API may change before it has shipped in two
 // fasthttp minor releases.

--- a/http2/doc.go
+++ b/http2/doc.go
@@ -1,0 +1,9 @@
+// Package http2 provides experimental native HTTP/2 support for fasthttp.
+//
+// HTTP/2 is opt-in. Use ConfigureServer for ALPN and same-port cleartext
+// prior-knowledge dispatch, or ServeConn for a dedicated prior-knowledge
+// connection. The package doesn't implement the obsolete h2c Upgrade path.
+//
+// Experimental: the package API may change before it has shipped in two
+// fasthttp minor releases.
+package http2

--- a/http2/example_test.go
+++ b/http2/example_test.go
@@ -1,0 +1,65 @@
+package http2_test
+
+import (
+	"io"
+	"log"
+
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/http2"
+)
+
+func ExampleConfigureServer() {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBodyString("hello over HTTP/1 or HTTP/2")
+		},
+	}
+	if err := http2.ConfigureServer(server, http2.ServerConfig{}); err != nil {
+		log.Fatal(err)
+	}
+	// server.ListenAndServeTLS(":8443", "cert.pem", "key.pem")
+}
+
+func ExampleConfigureHostClient() {
+	client := &fasthttp.HostClient{
+		Addr:  "example.com:443",
+		IsTLS: true,
+	}
+	if err := http2.ConfigureHostClient(client, http2.ClientConfig{}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleConfigureHostClient_priorKnowledge() {
+	client := &fasthttp.HostClient{Addr: "127.0.0.1:8080"}
+	if err := http2.ConfigureHostClient(client, http2.ClientConfig{
+		Mode: http2.PriorKnowledge,
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func Example_extendedConnectByteEcho() {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if string(ctx.Request.Header.ConnectProtocol()) != "websocket" {
+				ctx.Error("extended CONNECT required", fasthttp.StatusBadRequest)
+				return
+			}
+			ctx.Response.SetStatusCode(fasthttp.StatusOK)
+			if err := ctx.AcceptStream(func(stream fasthttp.StreamConn) {
+				defer stream.Close()
+				_, _ = io.Copy(stream, stream)
+			}); err != nil {
+				ctx.Error(err.Error(), fasthttp.StatusBadRequest)
+			}
+		},
+	}
+	if err := http2.ConfigureServer(server, http2.ServerConfig{
+		EnableExtendedConnect: true,
+	}); err != nil {
+		log.Fatal(err)
+	}
+	// DATA bytes are echoed on one HTTP/2 stream. A WebSocket application
+	// layers its WebSocket frame codec over the returned StreamConn.
+}

--- a/http2/fuzz_test.go
+++ b/http2/fuzz_test.go
@@ -1,0 +1,81 @@
+package http2
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+	xhttp2 "golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func FuzzPriority(f *testing.F) {
+	for _, seed := range []string{"", "u=0", "u=7, i", "i=?1, u=3", "u=8", "u=-1", "x=extension"} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(_ *testing.T, value string) {
+		_, _ = parsePriority(value)
+	})
+}
+
+func FuzzHTTP2ContentLength(f *testing.F) {
+	for _, seed := range []string{"0", "1", "18446744073709551615", "-1", "+1", "1, 1", ""} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(_ *testing.T, value string) {
+		_, _ = parseHTTP2ContentLength(value)
+	})
+}
+
+func FuzzHPACKRequestHeaders(f *testing.F) {
+	var encoded bytes.Buffer
+	encoder := hpack.NewEncoder(&encoded)
+	for _, field := range []hpack.HeaderField{
+		{Name: ":method", Value: "GET"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":authority", Value: "example.com"},
+		{Name: ":path", Value: "/"},
+	} {
+		if err := encoder.WriteField(field); err != nil {
+			f.Fatal(err)
+		}
+	}
+	f.Add(encoded.Bytes())
+	f.Fuzz(func(_ *testing.T, block []byte) {
+		codec := newHeaderCodec(defaultHeaderTableSize, 64<<10)
+		fieldStorage := acquireIncomingHeaderFields(8)
+		fields, truncated, invalid, err := codec.decodeComplete(block, fieldStorage.fields)
+		event := incomingFrame{fields: fields, fieldStorage: fieldStorage}
+		defer releaseIncomingFrame(&event)
+		if err != nil || truncated || invalid != nil {
+			return
+		}
+		ctx := &fasthttp.RequestCtx{}
+		_, _ = populateRequest(ctx, &fasthttp.Server{}, fields, true)
+	})
+}
+
+func FuzzFrameSequence(f *testing.F) {
+	var seed bytes.Buffer
+	framer := xhttp2.NewFramer(&seed, nil)
+	if err := framer.WriteSettings(); err != nil {
+		f.Fatal(err)
+	}
+	if err := framer.WritePing(false, [8]byte{1, 2, 3}); err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed.Bytes())
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		framer := xhttp2.NewFramer(io.Discard, bytes.NewReader(data))
+		framer.SetMaxReadFrameSize(1 << 20)
+		for range 32 {
+			frame, err := framer.ReadFrame()
+			if err != nil {
+				return
+			}
+			event := incomingFrameFromWire(frame)
+			releaseIncomingFrame(&event)
+		}
+	})
+}

--- a/http2/h2specserver/main.go
+++ b/http2/h2specserver/main.go
@@ -1,0 +1,48 @@
+// Command h2specserver runs the cleartext prior-knowledge endpoint used by
+// the HTTP/2 conformance workflow.
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/valyala/fasthttp"
+	fasthttphttp2 "github.com/valyala/fasthttp/http2"
+)
+
+func main() {
+	address := flag.String("addr", "127.0.0.1:8080", "listen address")
+	flag.Parse()
+
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBodyString("ok")
+		},
+	}
+	config := fasthttphttp2.ServerConfig{MaxHeaderListSize: 1 << 20}
+	listener, err := net.Listen("tcp", *address)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stopping := make(chan os.Signal, 1)
+	signal.Notify(stopping, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-stopping
+		_ = listener.Close()
+	}()
+	for {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		go func() {
+			if serveErr := fasthttphttp2.ServeConn(server, conn, config); serveErr != nil {
+				log.Printf("serve connection: %v", serveErr)
+			}
+		}()
+	}
+}

--- a/http2/headers.go
+++ b/http2/headers.go
@@ -1,0 +1,275 @@
+package http2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	"golang.org/x/net/http2/hpack"
+)
+
+var (
+	errInvalidRequestHeaders  = errors.New("http2: invalid request headers")
+	errRequestBodyTooLarge    = errors.New("http2: request body too large")
+	errResponseHeaderTooLarge = errors.New("http2: response header list too large")
+)
+
+func populateRequest(
+	ctx *fasthttp.RequestCtx,
+	server *fasthttp.Server,
+	fields []hpack.HeaderField,
+	enableExtendedConnect bool,
+) (int64, error) {
+	if ctx == nil {
+		return -1, errInvalidRequestHeaders
+	}
+	if server.DisableHeaderNamesNormalizing {
+		ctx.Request.Header.DisableNormalizing()
+	}
+
+	var method string
+	var scheme string
+	var authority string
+	var path string
+	var connectProtocol string
+	var host string
+	var contentLength int64 = -1
+	seenPseudo := make(map[string]struct{}, 5)
+	cookies := make([]string, 0, 1)
+	for _, field := range fields {
+		if field.IsPseudo() {
+			if _, ok := seenPseudo[field.Name]; ok {
+				return -1, fmt.Errorf("%w: duplicate pseudo-header %q", errInvalidRequestHeaders, field.Name)
+			}
+			seenPseudo[field.Name] = struct{}{}
+			switch field.Name {
+			case ":method":
+				method = field.Value
+			case ":scheme":
+				scheme = field.Value
+			case ":authority":
+				authority = field.Value
+			case ":path":
+				path = field.Value
+			case ":protocol":
+				connectProtocol = field.Value
+			default:
+				return -1, fmt.Errorf("%w: unknown pseudo-header %q", errInvalidRequestHeaders, field.Name)
+			}
+			continue
+		}
+
+		name := field.Name
+		value := field.Value
+		if isConnectionSpecificHeader(name) {
+			return -1, fmt.Errorf("%w: connection-specific header %q", errInvalidRequestHeaders, name)
+		}
+		if name == "te" && !strings.EqualFold(strings.TrimSpace(value), "trailers") {
+			return -1, fmt.Errorf("%w: invalid te header", errInvalidRequestHeaders)
+		}
+		if name == "content-length" {
+			parsed, err := parseHTTP2ContentLength(value)
+			if err != nil {
+				return -1, err
+			}
+			if contentLength >= 0 && contentLength != parsed {
+				return -1, fmt.Errorf("%w: conflicting content-length", errInvalidRequestHeaders)
+			}
+			contentLength = parsed
+		}
+		if name == "host" {
+			host = value
+			continue
+		}
+		if name == "cookie" {
+			cookies = append(cookies, value)
+			continue
+		}
+		ctx.Request.Header.Add(name, value)
+	}
+
+	if method == "" {
+		return -1, fmt.Errorf("%w: missing :method", errInvalidRequestHeaders)
+	}
+	isConnect := method == fasthttp.MethodConnect
+	switch {
+	case connectProtocol != "":
+		if !enableExtendedConnect {
+			return -1, fmt.Errorf("%w: extended connect is disabled", errInvalidRequestHeaders)
+		}
+		if !isConnect || scheme == "" || authority == "" || path == "" {
+			return -1, fmt.Errorf("%w: malformed extended connect", errInvalidRequestHeaders)
+		}
+	case isConnect:
+		if authority == "" || scheme != "" || path != "" {
+			return -1, fmt.Errorf("%w: malformed connect", errInvalidRequestHeaders)
+		}
+	default:
+		if scheme == "" || path == "" {
+			return -1, fmt.Errorf("%w: missing request pseudo-header", errInvalidRequestHeaders)
+		}
+	}
+	if authority == "" {
+		authority = host
+	}
+	if authority == "" {
+		return -1, fmt.Errorf("%w: missing authority", errInvalidRequestHeaders)
+	}
+	if host != "" && host != authority {
+		return -1, fmt.Errorf("%w: host and authority differ", errInvalidRequestHeaders)
+	}
+
+	ctx.Request.Header.SetMethod(method)
+	ctx.Request.Header.SetProtocol("HTTP/2")
+	ctx.Request.Header.SetHost(authority)
+	if path != "" {
+		ctx.Request.Header.SetRequestURI(path)
+	}
+	if connectProtocol != "" {
+		ctx.Request.Header.SetConnectProtocol(connectProtocol)
+	}
+	if len(cookies) != 0 {
+		ctx.Request.Header.Set(fasthttp.HeaderCookie, strings.Join(cookies, "; "))
+	}
+	return contentLength, nil
+}
+
+func parseHTTP2ContentLength(value string) (int64, error) {
+	if value == "" {
+		return 0, fmt.Errorf("%w: invalid content-length", errInvalidRequestHeaders)
+	}
+	for i := range len(value) {
+		if value[i] < '0' || value[i] > '9' {
+			return 0, fmt.Errorf("%w: invalid content-length", errInvalidRequestHeaders)
+		}
+	}
+	length, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || uint64(length) > uint64(^uint(0)>>1) {
+		return 0, fmt.Errorf("%w: invalid content-length", errInvalidRequestHeaders)
+	}
+	return length, nil
+}
+
+func encodeTrailerHeaders(
+	encoder *hpack.Encoder,
+	buffer *bytes.Buffer,
+	header *fasthttp.ResponseHeader,
+) ([]byte, error) {
+	buffer.Reset()
+	for _, key := range header.PeekTrailerKeys() {
+		name := strings.ToLower(string(key))
+		if isConnectionSpecificHeader(name) {
+			return nil, fmt.Errorf("http2: invalid response trailer %q", name)
+		}
+		values := header.PeekAll(string(key))
+		for _, value := range values {
+			if err := encoder.WriteField(hpack.HeaderField{
+				Name:  name,
+				Value: string(value),
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return bytes.Clone(buffer.Bytes()), nil
+}
+
+func encodeResponseHeaders(
+	encoder *hpack.Encoder,
+	buffer *bytes.Buffer,
+	server *fasthttp.Server,
+	response *fasthttp.Response,
+	maxHeaderListSize uint64,
+) ([]byte, error) {
+	buffer.Reset()
+	statusCode := response.StatusCode()
+	if statusCode == 0 {
+		statusCode = fasthttp.StatusOK
+	}
+	if err := encoder.WriteField(hpack.HeaderField{
+		Name:  ":status",
+		Value: strconv.Itoa(statusCode),
+	}); err != nil {
+		return nil, err
+	}
+	headerSize := uint64(len(":status") + len(strconv.Itoa(statusCode)) + 32)
+
+	if len(response.Header.Server()) == 0 && !server.NoDefaultServerHeader {
+		name := server.Name
+		if name == "" {
+			name = "fasthttp"
+		}
+		response.Header.SetServer(name)
+	}
+	if len(response.Header.Peek(fasthttp.HeaderDate)) == 0 && !server.NoDefaultDate {
+		response.Header.SetBytesV(fasthttp.HeaderDate, fasthttp.AppendHTTPDate(nil, time.Now()))
+	}
+
+	var encodeErr error
+	response.Header.All()(func(key, value []byte) bool {
+		name := strings.ToLower(string(key))
+		if name == "trailer" || isConnectionSpecificHeader(name) {
+			return true
+		}
+		fieldSize := uint64(len(name) + len(value) + 32)
+		if maxHeaderListSize != 0 && headerSize+fieldSize > maxHeaderListSize {
+			encodeErr = errResponseHeaderTooLarge
+			return false
+		}
+		headerSize += fieldSize
+		encodeErr = encoder.WriteField(hpack.HeaderField{
+			Name:      name,
+			Value:     string(value),
+			Sensitive: name == "set-cookie",
+		})
+		return encodeErr == nil
+	})
+	if encodeErr != nil {
+		return nil, encodeErr
+	}
+	return bytes.Clone(buffer.Bytes()), nil
+}
+
+func encodeInformationalHeaders(
+	encoder *hpack.Encoder,
+	buffer *bytes.Buffer,
+	statusCode int,
+	header *fasthttp.ResponseHeader,
+) ([]byte, error) {
+	buffer.Reset()
+	if err := encoder.WriteField(hpack.HeaderField{
+		Name:  ":status",
+		Value: strconv.Itoa(statusCode),
+	}); err != nil {
+		return nil, err
+	}
+	var encodeErr error
+	header.All()(func(key, value []byte) bool {
+		name := strings.ToLower(string(key))
+		if name == "content-length" || name == "trailer" || isConnectionSpecificHeader(name) {
+			return true
+		}
+		encodeErr = encoder.WriteField(hpack.HeaderField{
+			Name:  name,
+			Value: string(value),
+		})
+		return encodeErr == nil
+	})
+	if encodeErr != nil {
+		return nil, encodeErr
+	}
+	return bytes.Clone(buffer.Bytes()), nil
+}
+
+func isConnectionSpecificHeader(name string) bool {
+	switch name {
+	case "connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}

--- a/http2/headers.go
+++ b/http2/headers.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/valyala/fasthttp"
+	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/http2/hpack"
 )
 
@@ -119,8 +119,22 @@ func populateRequest(
 	if authority == "" {
 		return -1, fmt.Errorf("%w: missing authority", errInvalidRequestHeaders)
 	}
+	if !httpguts.ValidHostHeader(authority) {
+		return -1, fmt.Errorf("%w: invalid authority", errInvalidRequestHeaders)
+	}
 	if host != "" && host != authority {
-		return -1, fmt.Errorf("%w: host and authority differ", errInvalidRequestHeaders)
+		if !strings.EqualFold(host, authority) {
+			return -1, fmt.Errorf("%w: host and authority differ", errInvalidRequestHeaders)
+		}
+	}
+	if path != "" && path != "*" && path[0] != '/' {
+		return -1, fmt.Errorf("%w: invalid :path", errInvalidRequestHeaders)
+	}
+	if path == "*" && method != fasthttp.MethodOptions {
+		return -1, fmt.Errorf("%w: asterisk :path requires OPTIONS", errInvalidRequestHeaders)
+	}
+	if scheme != "" && !validScheme(scheme) {
+		return -1, fmt.Errorf("%w: invalid :scheme", errInvalidRequestHeaders)
 	}
 
 	ctx.Request.Header.SetMethod(method)
@@ -136,6 +150,25 @@ func populateRequest(
 		ctx.Request.Header.Set(fasthttp.HeaderCookie, strings.Join(cookies, "; "))
 	}
 	return contentLength, nil
+}
+
+func validScheme(scheme string) bool {
+	if scheme == "" {
+		return false
+	}
+	first := scheme[0]
+	if (first < 'A' || first > 'Z') && (first < 'a' || first > 'z') {
+		return false
+	}
+	for i := 1; i < len(scheme); i++ {
+		value := scheme[i]
+		if value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' ||
+			value >= '0' && value <= '9' || value == '+' || value == '-' || value == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func parseHTTP2ContentLength(value string) (int64, error) {
@@ -157,46 +190,52 @@ func parseHTTP2ContentLength(value string) (int64, error) {
 func encodeTrailerHeaders(
 	encoder *hpack.Encoder,
 	buffer *bytes.Buffer,
+	stringsCache *headerStringCache,
 	header *fasthttp.ResponseHeader,
 ) ([]byte, error) {
 	buffer.Reset()
 	for _, key := range header.PeekTrailerKeys() {
-		name := strings.ToLower(string(key))
+		name := stringsCache.name(key)
 		if isConnectionSpecificHeader(name) {
 			return nil, fmt.Errorf("http2: invalid response trailer %q", name)
 		}
 		values := header.PeekAll(string(key))
 		for _, value := range values {
+			sensitive := isSensitiveHeader(name)
 			if err := encoder.WriteField(hpack.HeaderField{
-				Name:  name,
-				Value: string(value),
+				Name:      name,
+				Value:     stringsCache.value(value, sensitive),
+				Sensitive: sensitive,
 			}); err != nil {
 				return nil, err
 			}
 		}
 	}
-	return bytes.Clone(buffer.Bytes()), nil
+	return buffer.Bytes(), nil
 }
 
 func encodeResponseHeaders(
 	encoder *hpack.Encoder,
 	buffer *bytes.Buffer,
+	stringsCache *headerStringCache,
 	server *fasthttp.Server,
 	response *fasthttp.Response,
 	maxHeaderListSize uint64,
+	serverDate []byte,
 ) ([]byte, error) {
 	buffer.Reset()
 	statusCode := response.StatusCode()
 	if statusCode == 0 {
 		statusCode = fasthttp.StatusOK
 	}
+	status := statusCodeString(statusCode)
 	if err := encoder.WriteField(hpack.HeaderField{
 		Name:  ":status",
-		Value: strconv.Itoa(statusCode),
+		Value: status,
 	}); err != nil {
 		return nil, err
 	}
-	headerSize := uint64(len(":status") + len(strconv.Itoa(statusCode)) + 32)
+	headerSize := uint64(len(":status") + len(status) + 32)
 
 	if len(response.Header.Server()) == 0 && !server.NoDefaultServerHeader {
 		name := server.Name
@@ -206,12 +245,12 @@ func encodeResponseHeaders(
 		response.Header.SetServer(name)
 	}
 	if len(response.Header.Peek(fasthttp.HeaderDate)) == 0 && !server.NoDefaultDate {
-		response.Header.SetBytesV(fasthttp.HeaderDate, fasthttp.AppendHTTPDate(nil, time.Now()))
+		response.Header.SetBytesV(fasthttp.HeaderDate, serverDate)
 	}
 
 	var encodeErr error
 	response.Header.All()(func(key, value []byte) bool {
-		name := strings.ToLower(string(key))
+		name := stringsCache.name(key)
 		if name == "trailer" || isConnectionSpecificHeader(name) {
 			return true
 		}
@@ -221,48 +260,89 @@ func encodeResponseHeaders(
 			return false
 		}
 		headerSize += fieldSize
+		sensitive := name == "set-cookie"
 		encodeErr = encoder.WriteField(hpack.HeaderField{
 			Name:      name,
-			Value:     string(value),
-			Sensitive: name == "set-cookie",
+			Value:     stringsCache.value(value, sensitive),
+			Sensitive: sensitive,
 		})
 		return encodeErr == nil
 	})
 	if encodeErr != nil {
 		return nil, encodeErr
 	}
-	return bytes.Clone(buffer.Bytes()), nil
+	return buffer.Bytes(), nil
 }
 
 func encodeInformationalHeaders(
 	encoder *hpack.Encoder,
 	buffer *bytes.Buffer,
+	stringsCache *headerStringCache,
 	statusCode int,
 	header *fasthttp.ResponseHeader,
 ) ([]byte, error) {
 	buffer.Reset()
 	if err := encoder.WriteField(hpack.HeaderField{
 		Name:  ":status",
-		Value: strconv.Itoa(statusCode),
+		Value: statusCodeString(statusCode),
 	}); err != nil {
 		return nil, err
 	}
 	var encodeErr error
 	header.All()(func(key, value []byte) bool {
-		name := strings.ToLower(string(key))
+		name := stringsCache.name(key)
 		if name == "content-length" || name == "trailer" || isConnectionSpecificHeader(name) {
 			return true
 		}
+		sensitive := isSensitiveHeader(name)
 		encodeErr = encoder.WriteField(hpack.HeaderField{
-			Name:  name,
-			Value: string(value),
+			Name:      name,
+			Value:     stringsCache.value(value, sensitive),
+			Sensitive: sensitive,
 		})
 		return encodeErr == nil
 	})
 	if encodeErr != nil {
 		return nil, encodeErr
 	}
-	return bytes.Clone(buffer.Bytes()), nil
+	return buffer.Bytes(), nil
+}
+
+func statusCodeString(statusCode int) string {
+	switch statusCode {
+	case fasthttp.StatusContinue:
+		return "100"
+	case fasthttp.StatusEarlyHints:
+		return "103"
+	case fasthttp.StatusOK:
+		return "200"
+	case fasthttp.StatusNoContent:
+		return "204"
+	case fasthttp.StatusPartialContent:
+		return "206"
+	case fasthttp.StatusMovedPermanently:
+		return "301"
+	case fasthttp.StatusFound:
+		return "302"
+	case fasthttp.StatusNotModified:
+		return "304"
+	case fasthttp.StatusBadRequest:
+		return "400"
+	case fasthttp.StatusUnauthorized:
+		return "401"
+	case fasthttp.StatusForbidden:
+		return "403"
+	case fasthttp.StatusNotFound:
+		return "404"
+	case fasthttp.StatusInternalServerError:
+		return "500"
+	case fasthttp.StatusBadGateway:
+		return "502"
+	case fasthttp.StatusServiceUnavailable:
+		return "503"
+	default:
+		return strconv.Itoa(statusCode)
+	}
 }
 
 func isConnectionSpecificHeader(name string) bool {

--- a/http2/server.go
+++ b/http2/server.go
@@ -1231,6 +1231,14 @@ func (c *serverConn) handleHandlerDone(
 		return nil
 	}
 
+	var bufferedBody []byte
+	if !requestCtx.Response.IsBodyStream() {
+		bufferedBody = requestCtx.Response.Body()
+		if len(requestCtx.Response.Header.Peek(fasthttp.HeaderContentLength)) == 0 &&
+			(!responseMustNotHaveBody(requestCtx) || len(bufferedBody) != 0) {
+			requestCtx.Response.Header.SetContentLength(len(bufferedBody))
+		}
+	}
 	block, err := encodeResponseHeaders(
 		c.encoder,
 		&c.headerBuffer,
@@ -1263,7 +1271,7 @@ func (c *serverConn) handleHandlerDone(
 		return nil
 	}
 
-	body := requestCtx.Response.Body()
+	body := bufferedBody
 	stream.expectedResponse = responseContentLength(&requestCtx.Response.Header)
 	if stream.expectedResponse >= 0 && stream.expectedResponse != int64(len(body)) {
 		return c.resetStream(stream.id, xhttp2.ErrCodeInternal, errors.New("http2: response body length doesn't match content-length"))

--- a/http2/server.go
+++ b/http2/server.go
@@ -1,0 +1,1287 @@
+package http2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	xhttp2 "golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+type incomingFrameKind uint8
+
+const (
+	incomingFrameUnknown incomingFrameKind = iota
+	incomingFrameSettings
+	incomingFrameHeaders
+	incomingFrameData
+	incomingFrameRST
+	incomingFrameWindowUpdate
+	incomingFramePing
+	incomingFrameGoAway
+	incomingFramePriorityUpdate
+	incomingFrameInvalidPushPromise
+)
+
+type incomingFrame struct {
+	kind         incomingFrameKind
+	streamID     uint32
+	endStream    bool
+	ack          bool
+	truncated    bool
+	flowLength   int
+	data         []byte
+	fields       []hpack.HeaderField
+	settings     []xhttp2.Setting
+	increment    uint32
+	errCode      xhttp2.ErrCode
+	lastStreamID uint32
+	pingData     [8]byte
+	priority     string
+	err          error
+}
+
+type serverCommandKind uint8
+
+const (
+	serverCommandUnknown serverCommandKind = iota
+	serverCommandHandlerDone
+	serverCommandInformational
+	serverCommandBodyConsumed
+	serverCommandResponseData
+	serverCommandResponseEOF
+	serverCommandStreamHandlerDone
+	serverCommandPush
+)
+
+type serverCommand struct {
+	kind       serverCommandKind
+	streamID   uint32
+	requestCtx *fasthttp.RequestCtx
+	statusCode int
+	header     *fasthttp.ResponseHeader
+	data       []byte
+	consumed   int
+	err        error
+	result     chan error
+	target     string
+	pushOpts   *fasthttp.PushOptions
+}
+
+type serverError struct {
+	code xhttp2.ErrCode
+	err  error
+}
+
+func (e *serverError) Error() string {
+	return e.err.Error()
+}
+
+func (e *serverError) Unwrap() error {
+	return e.err
+}
+
+type serverConn struct {
+	protocolContext *fasthttp.ProtocolServerContext
+	server          *fasthttp.Server
+	config          serverConfig
+	conn            net.Conn
+	ctx             context.Context
+	cancel          context.CancelCauseFunc
+	framer          *xhttp2.Framer
+	encoder         *hpack.Encoder
+	headerBuffer    bytes.Buffer
+
+	events   chan incomingFrame
+	commands chan serverCommand
+	workers  sync.WaitGroup
+
+	streams            map[uint32]*serverStream
+	lastClientStreamID uint32
+	lastProcessedID    uint32
+	isGoingAway        bool
+	receivedSettings   bool
+
+	peerInitialStreamWindow  int64
+	peerConnectionWindow     int64
+	peerMaxFrameSize         int
+	peerMaxHeaderListSize    uint64
+	peerMaxConcurrentStreams uint32
+	peerAllowsPush           bool
+
+	receiveConnectionWindow int64
+	nextPushStreamID        uint32
+	activePushes            uint32
+	priorityUpdates         map[uint32]priority
+}
+
+func (h *serverHandler) ServeConn(ctx *fasthttp.ProtocolServerContext, c net.Conn) error {
+	conn := newServerConn(ctx, c, h.config)
+	return conn.serve()
+}
+
+func newServerConn(
+	protocolContext *fasthttp.ProtocolServerContext,
+	c net.Conn,
+	config serverConfig,
+) *serverConn {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	maxCommands := int(config.maxConcurrentStreams)*2 + 32
+	if maxCommands > config.maxQueuedControlFrames {
+		maxCommands = config.maxQueuedControlFrames
+	}
+	if maxCommands < 32 {
+		maxCommands = 32
+	}
+	conn := &serverConn{
+		protocolContext:          protocolContext,
+		server:                   protocolContext.Server(),
+		config:                   config,
+		conn:                     c,
+		ctx:                      ctx,
+		cancel:                   cancel,
+		events:                   make(chan incomingFrame, 32),
+		commands:                 make(chan serverCommand, maxCommands),
+		streams:                  make(map[uint32]*serverStream),
+		peerInitialStreamWindow:  65535,
+		peerConnectionWindow:     65535,
+		peerMaxFrameSize:         defaultMaxFrameSize,
+		peerMaxHeaderListSize:    math.MaxUint32,
+		peerMaxConcurrentStreams: math.MaxUint32,
+		peerAllowsPush:           true,
+		receiveConnectionWindow:  int64(config.connectionWindowSize),
+		nextPushStreamID:         2,
+		priorityUpdates:          make(map[uint32]priority),
+	}
+	conn.encoder = hpack.NewEncoder(&conn.headerBuffer)
+	conn.encoder.SetMaxDynamicTableSizeLimit(config.maxEncoderTableSize)
+	return conn
+}
+
+func (c *serverConn) serve() (retErr error) {
+	defer func() {
+		c.cancel(retErr)
+		_ = c.conn.Close()
+		for _, stream := range c.streams {
+			stream.cancel(retErr)
+			if stream.body != nil {
+				stream.body.closeWithError(retErr)
+			}
+			if stream.pendingAck != nil {
+				stream.pendingAck <- retErr
+				stream.pendingAck = nil
+			}
+		}
+		c.workers.Wait()
+		c.releaseAllStreams()
+	}()
+
+	if err := c.readClientPreface(); err != nil {
+		return err
+	}
+	decoder := hpack.NewDecoder(c.config.maxDecoderTableSize, nil)
+	decoder.SetAllowedMaxDynamicTableSize(c.config.maxDecoderTableSize)
+	decoder.SetMaxStringLength(int(c.config.maxHeaderListSize))
+	c.framer = xhttp2.NewFramer(c.conn, c.conn)
+	c.framer.ReadMetaHeaders = decoder
+	c.framer.MaxHeaderListSize = c.config.maxHeaderListSize
+	c.framer.SetMaxReadFrameSize(c.config.maxReadFrameSize)
+	if err := c.writeInitialSettings(); err != nil {
+		return fmt.Errorf("http2: writing initial settings: %w", err)
+	}
+
+	go c.readLoop()
+	serverDone := c.protocolContext.Done()
+	for {
+		if c.isGoingAway && len(c.streams) == 0 {
+			return nil
+		}
+		select {
+		case event := <-c.events:
+			if event.err != nil {
+				if errors.Is(event.err, io.EOF) && len(c.streams) == 0 {
+					return nil
+				}
+				return c.failConnection(errorCode(event.err), event.err)
+			}
+			if err := c.processFrame(event); err != nil {
+				var protocolErr *serverError
+				if errors.As(err, &protocolErr) {
+					return c.failConnection(protocolErr.code, protocolErr.err)
+				}
+				return c.failConnection(xhttp2.ErrCodeInternal, err)
+			}
+		case command := <-c.commands:
+			if err := c.processCommand(command); err != nil {
+				return c.failConnection(xhttp2.ErrCodeInternal, err)
+			}
+		case <-serverDone:
+			serverDone = nil
+			if err := c.startGracefulShutdown(); err != nil {
+				return err
+			}
+		case <-c.ctx.Done():
+			return context.Cause(c.ctx)
+		}
+		if err := c.flushResponses(); err != nil {
+			return err
+		}
+	}
+}
+
+func (c *serverConn) readClientPreface() error {
+	if c.server.ReadTimeout > 0 {
+		if err := c.conn.SetReadDeadline(time.Now().Add(c.server.ReadTimeout)); err != nil {
+			return err
+		}
+	}
+	preface := make([]byte, len(clientPreface))
+	if _, err := io.ReadFull(c.conn, preface); err != nil {
+		return fmt.Errorf("http2: reading client preface: %w", err)
+	}
+	if string(preface) != clientPreface {
+		return errors.New("http2: invalid client preface")
+	}
+	if c.server.ReadTimeout > 0 {
+		if err := c.conn.SetReadDeadline(time.Time{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *serverConn) writeInitialSettings() error {
+	settings := []xhttp2.Setting{
+		{ID: xhttp2.SettingMaxConcurrentStreams, Val: c.config.maxConcurrentStreams},
+		{ID: xhttp2.SettingInitialWindowSize, Val: uint32(c.config.streamWindowSize)},
+		{ID: xhttp2.SettingMaxFrameSize, Val: c.config.maxReadFrameSize},
+		{ID: xhttp2.SettingMaxHeaderListSize, Val: c.config.maxHeaderListSize},
+		{ID: xhttp2.SettingHeaderTableSize, Val: c.config.maxDecoderTableSize},
+		{ID: xhttp2.SettingNoRFC7540Priorities, Val: 1},
+	}
+	if c.config.enableExtendedConnect {
+		settings = append(settings, xhttp2.Setting{ID: xhttp2.SettingEnableConnectProtocol, Val: 1})
+	}
+	if err := c.framer.WriteSettings(settings...); err != nil {
+		return err
+	}
+	windowIncrement := uint32(c.config.connectionWindowSize - 65535)
+	if windowIncrement != 0 {
+		return c.framer.WriteWindowUpdate(0, windowIncrement)
+	}
+	return nil
+}
+
+func (c *serverConn) readLoop() {
+	for {
+		frame, err := c.framer.ReadFrame()
+		event := incomingFrame{err: err}
+		if err == nil {
+			event = copyIncomingFrame(frame)
+		}
+		select {
+		case c.events <- event:
+		case <-c.ctx.Done():
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func copyIncomingFrame(frame xhttp2.Frame) incomingFrame {
+	header := frame.Header()
+	event := incomingFrame{streamID: header.StreamID}
+	switch frame := frame.(type) {
+	case *xhttp2.SettingsFrame:
+		event.kind = incomingFrameSettings
+		event.ack = frame.IsAck()
+		if !event.ack {
+			event.settings = make([]xhttp2.Setting, frame.NumSettings())
+			for i := range frame.NumSettings() {
+				event.settings[i] = frame.Setting(i)
+			}
+		}
+	case *xhttp2.MetaHeadersFrame:
+		event.kind = incomingFrameHeaders
+		event.endStream = frame.StreamEnded()
+		event.truncated = frame.Truncated
+		event.fields = make([]hpack.HeaderField, len(frame.Fields))
+		for i, field := range frame.Fields {
+			event.fields[i] = hpack.HeaderField{
+				Name:      strings.Clone(field.Name),
+				Value:     strings.Clone(field.Value),
+				Sensitive: field.Sensitive,
+			}
+		}
+	case *xhttp2.DataFrame:
+		event.kind = incomingFrameData
+		event.endStream = frame.StreamEnded()
+		event.flowLength = int(frame.Header().Length)
+		event.data = bytes.Clone(frame.Data())
+	case *xhttp2.RSTStreamFrame:
+		event.kind = incomingFrameRST
+		event.errCode = frame.ErrCode
+	case *xhttp2.WindowUpdateFrame:
+		event.kind = incomingFrameWindowUpdate
+		event.increment = frame.Increment
+	case *xhttp2.PingFrame:
+		event.kind = incomingFramePing
+		event.ack = frame.IsAck()
+		event.pingData = frame.Data
+	case *xhttp2.GoAwayFrame:
+		event.kind = incomingFrameGoAway
+		event.lastStreamID = frame.LastStreamID
+		event.errCode = frame.ErrCode
+	case *xhttp2.PriorityUpdateFrame:
+		event.kind = incomingFramePriorityUpdate
+		event.streamID = frame.PrioritizedStreamID
+		event.priority = strings.Clone(frame.Priority)
+	case *xhttp2.PushPromiseFrame:
+		event.kind = incomingFrameInvalidPushPromise
+	default:
+		event.kind = incomingFrameUnknown
+	}
+	return event
+}
+
+func (c *serverConn) processFrame(event incomingFrame) error {
+	if !c.receivedSettings {
+		if event.kind != incomingFrameSettings || event.ack {
+			return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: first frame isn't settings")}
+		}
+		c.receivedSettings = true
+	}
+
+	switch event.kind {
+	case incomingFrameUnknown:
+		return nil
+	case incomingFrameSettings:
+		return c.processSettings(event)
+	case incomingFrameHeaders:
+		return c.processHeaders(event)
+	case incomingFrameData:
+		return c.processData(event)
+	case incomingFrameRST:
+		return c.processRST(event)
+	case incomingFrameWindowUpdate:
+		return c.processWindowUpdate(event)
+	case incomingFramePing:
+		if !event.ack {
+			return c.framer.WritePing(true, event.pingData)
+		}
+		return nil
+	case incomingFrameGoAway:
+		c.isGoingAway = true
+		return nil
+	case incomingFramePriorityUpdate:
+		return c.processPriorityUpdate(event)
+	case incomingFrameInvalidPushPromise:
+		return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: client sent push promise")}
+	default:
+		return nil
+	}
+}
+
+func (c *serverConn) processSettings(event incomingFrame) error {
+	if event.ack {
+		return nil
+	}
+	for _, setting := range event.settings {
+		switch setting.ID {
+		case xhttp2.SettingHeaderTableSize:
+			value := setting.Val
+			if value > c.config.maxEncoderTableSize {
+				value = c.config.maxEncoderTableSize
+			}
+			c.encoder.SetMaxDynamicTableSize(value)
+		case xhttp2.SettingEnablePush:
+			c.peerAllowsPush = setting.Val == 1
+		case xhttp2.SettingMaxConcurrentStreams:
+			c.peerMaxConcurrentStreams = setting.Val
+		case xhttp2.SettingInitialWindowSize:
+			delta := int64(setting.Val) - c.peerInitialStreamWindow
+			for _, stream := range c.streams {
+				stream.sendWindow += delta
+				if stream.sendWindow > math.MaxInt32 {
+					return &serverError{code: xhttp2.ErrCodeFlowControl, err: errors.New("http2: stream send window overflow")}
+				}
+			}
+			c.peerInitialStreamWindow = int64(setting.Val)
+		case xhttp2.SettingMaxFrameSize:
+			c.peerMaxFrameSize = int(setting.Val)
+		case xhttp2.SettingMaxHeaderListSize:
+			c.peerMaxHeaderListSize = uint64(setting.Val)
+		case xhttp2.SettingEnableConnectProtocol, xhttp2.SettingNoRFC7540Priorities:
+			// The values affect features initiated by the peer; frame validation
+			// and request validation happen at their use sites.
+		}
+	}
+	return c.framer.WriteSettingsAck()
+}
+
+func (c *serverConn) processHeaders(event incomingFrame) error {
+	if event.truncated {
+		return c.resetStream(event.streamID, xhttp2.ErrCodeEnhanceYourCalm, errInvalidRequestHeaders)
+	}
+	if existing := c.streams[event.streamID]; existing != nil {
+		return c.processTrailers(existing, event)
+	}
+	if c.isGoingAway {
+		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeRefusedStream)
+	}
+	if event.streamID == 0 || event.streamID&1 == 0 || event.streamID <= c.lastClientStreamID {
+		return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: invalid client stream id")}
+	}
+	c.lastClientStreamID = event.streamID
+	if uint32(len(c.streams)) >= c.config.maxConcurrentStreams {
+		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeRefusedStream)
+	}
+
+	stream := newServerStream(c, event.streamID)
+	stream.priority = priority{urgency: 3}
+	requestCtx := c.protocolContext.AcquireRequestCtx(c.conn, stream)
+	stream.request = requestCtx
+	expectedBody, err := populateRequest(requestCtx, c.server, event.fields, c.config.enableExtendedConnect)
+	if err != nil {
+		c.protocolContext.ReleaseRequestCtx(requestCtx)
+		stream.request = nil
+		stream.cancel(err)
+		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeProtocol)
+	}
+	if c.server.GetOnly && !requestCtx.Request.Header.IsGet() && !requestCtx.Request.Header.IsHead() {
+		c.protocolContext.ReleaseRequestCtx(requestCtx)
+		stream.request = nil
+		stream.cancel(fasthttp.ErrGetOnly)
+		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeRefusedStream)
+	}
+	stream.maxBody = c.server.MaxRequestBodySize
+	if stream.maxBody <= 0 {
+		stream.maxBody = fasthttp.DefaultMaxRequestBodySize
+	}
+	if c.server.HeaderReceived != nil {
+		requestConfig := c.server.HeaderReceived(&requestCtx.Request.Header)
+		if requestConfig.MaxRequestBodySize > 0 {
+			stream.maxBody = requestConfig.MaxRequestBodySize
+		}
+	}
+	stream.expectedBody = expectedBody
+	if value := requestCtx.Request.Header.Peek("Priority"); len(value) != 0 {
+		parsed, parseErr := parsePriority(string(value))
+		if parseErr != nil {
+			c.protocolContext.ReleaseRequestCtx(requestCtx)
+			stream.request = nil
+			stream.cancel(parseErr)
+			return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeProtocol)
+		}
+		stream.priority = parsed
+	}
+	if updated, ok := c.priorityUpdates[event.streamID]; ok {
+		stream.priority = updated
+		delete(c.priorityUpdates, event.streamID)
+	}
+	if expectedBody >= 0 && expectedBody > int64(stream.maxBody) {
+		c.protocolContext.ReleaseRequestCtx(requestCtx)
+		stream.request = nil
+		stream.cancel(errRequestBodyTooLarge)
+		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeCancel)
+	}
+	c.streams[event.streamID] = stream
+	c.lastProcessedID = event.streamID
+
+	isExtended := len(requestCtx.Request.Header.ConnectProtocol()) != 0
+	if !event.endStream && (c.server.StreamRequestBody || isExtended) {
+		stream.body = newRequestBody(func(consumed int) {
+			select {
+			case c.commands <- serverCommand{
+				kind:     serverCommandBodyConsumed,
+				streamID: stream.id,
+				consumed: consumed,
+			}:
+			case <-stream.ctx.Done():
+			}
+		})
+		bodySize := -1
+		if stream.expectedBody >= 0 {
+			bodySize = int(stream.expectedBody)
+		}
+		requestCtx.Request.SetBodyStream(stream.body, bodySize)
+		c.startHandler(stream)
+	}
+	if event.endStream {
+		return c.finishRequestBody(stream)
+	}
+	return nil
+}
+
+func (c *serverConn) processTrailers(stream *serverStream, event incomingFrame) error {
+	if stream.remoteClosed || !event.endStream {
+		return c.resetStream(stream.id, xhttp2.ErrCodeProtocol, errors.New("http2: invalid request trailers"))
+	}
+	for _, field := range event.fields {
+		if field.IsPseudo() || isConnectionSpecificHeader(field.Name) {
+			return c.resetStream(stream.id, xhttp2.ErrCodeProtocol, errors.New("http2: invalid trailer field"))
+		}
+		if err := stream.request.Request.Header.AddTrailer(field.Name); err != nil {
+			return c.resetStream(stream.id, xhttp2.ErrCodeProtocol, err)
+		}
+		stream.request.Request.Header.Set(field.Name, field.Value)
+	}
+	return c.finishRequestBody(stream)
+}
+
+func (c *serverConn) processData(event incomingFrame) error {
+	stream := c.streams[event.streamID]
+	if stream == nil || stream.remoteClosed {
+		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeStreamClosed)
+	}
+	flowLength := int64(event.flowLength)
+	c.receiveConnectionWindow -= flowLength
+	stream.recvWindow -= flowLength
+	if c.receiveConnectionWindow < 0 {
+		return &serverError{code: xhttp2.ErrCodeFlowControl, err: errors.New("http2: connection receive window exceeded")}
+	}
+	if stream.recvWindow < 0 {
+		return c.resetStream(stream.id, xhttp2.ErrCodeFlowControl, errors.New("http2: stream receive window exceeded"))
+	}
+
+	stream.bodyBytes += int64(len(event.data))
+	if stream.expectedBody >= 0 && stream.bodyBytes > stream.expectedBody {
+		c.restoreConnectionWindow(flowLength)
+		return c.resetStream(stream.id, xhttp2.ErrCodeProtocol, errors.New("http2: request body exceeds content-length"))
+	}
+	if stream.maxBody > 0 && stream.bodyBytes > int64(stream.maxBody) {
+		c.restoreConnectionWindow(flowLength)
+		return c.resetStream(stream.id, xhttp2.ErrCodeCancel, errRequestBodyTooLarge)
+	}
+	if stream.body != nil {
+		stream.unconsumedFlow += int64(len(event.data))
+		if err := stream.body.write(event.data); err != nil {
+			c.restoreConnectionWindow(flowLength)
+			return c.resetStream(stream.id, xhttp2.ErrCodeCancel, err)
+		}
+		padding := flowLength - int64(len(event.data))
+		if padding > 0 {
+			if err := c.consumeRequestBytes(stream, padding); err != nil {
+				return err
+			}
+		}
+	} else {
+		stream.request.Request.AppendBody(event.data)
+		if err := c.consumeRequestBytes(stream, flowLength); err != nil {
+			return err
+		}
+	}
+	if event.endStream {
+		return c.finishRequestBody(stream)
+	}
+	return nil
+}
+
+func (c *serverConn) finishRequestBody(stream *serverStream) error {
+	if stream.expectedBody >= 0 && stream.bodyBytes != stream.expectedBody {
+		return c.resetStream(stream.id, xhttp2.ErrCodeProtocol, errors.New("http2: request body length doesn't match content-length"))
+	}
+	stream.remoteClosed = true
+	if stream.body != nil {
+		stream.body.closeWithError(nil)
+	}
+	if !stream.handlerStarted {
+		c.startHandler(stream)
+	}
+	return nil
+}
+
+func (c *serverConn) consumeRequestBytes(stream *serverStream, amount int64) error {
+	if amount <= 0 {
+		return nil
+	}
+	c.receiveConnectionWindow += amount
+	stream.recvWindow += amount
+	if amount > math.MaxInt32 {
+		return &serverError{code: xhttp2.ErrCodeFlowControl, err: errors.New("http2: window update overflow")}
+	}
+	increment := uint32(amount)
+	if err := c.framer.WriteWindowUpdate(0, increment); err != nil {
+		return err
+	}
+	return c.framer.WriteWindowUpdate(stream.id, increment)
+}
+
+func (c *serverConn) restoreConnectionWindow(amount int64) {
+	if amount <= 0 || amount > math.MaxInt32 {
+		return
+	}
+	c.receiveConnectionWindow += amount
+	_ = c.framer.WriteWindowUpdate(0, uint32(amount))
+}
+
+func (c *serverConn) processRST(event incomingFrame) error {
+	stream := c.streams[event.streamID]
+	if stream == nil {
+		return nil
+	}
+	stream.isReset = true
+	stream.remoteClosed = true
+	stream.localClosed = true
+	stream.cancel(fmt.Errorf("http2: peer reset stream: %s", event.errCode))
+	if stream.body != nil {
+		stream.body.closeWithError(errStreamClosed)
+	}
+	c.restoreUnconsumedFlow(stream)
+	if stream.pendingAck != nil {
+		stream.pendingAck <- errStreamClosed
+		stream.pendingAck = nil
+	}
+	if !stream.handlerStarted || stream.handlerDone {
+		c.releaseStream(stream)
+	}
+	return nil
+}
+
+func (c *serverConn) processWindowUpdate(event incomingFrame) error {
+	if event.streamID == 0 {
+		if c.peerConnectionWindow+int64(event.increment) > math.MaxInt32 {
+			return &serverError{code: xhttp2.ErrCodeFlowControl, err: errors.New("http2: connection send window overflow")}
+		}
+		c.peerConnectionWindow += int64(event.increment)
+		return nil
+	}
+	stream := c.streams[event.streamID]
+	if stream == nil {
+		return nil
+	}
+	if stream.sendWindow+int64(event.increment) > math.MaxInt32 {
+		return c.resetStream(stream.id, xhttp2.ErrCodeFlowControl, errors.New("http2: stream send window overflow"))
+	}
+	stream.sendWindow += int64(event.increment)
+	return nil
+}
+
+func (c *serverConn) processPriorityUpdate(event incomingFrame) error {
+	if event.streamID == 0 {
+		return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: priority update targets stream zero")}
+	}
+	updated, err := parsePriority(event.priority)
+	if err != nil {
+		return err
+	}
+	if stream := c.streams[event.streamID]; stream != nil {
+		stream.priority = updated
+		return nil
+	}
+	if event.streamID > c.lastClientStreamID {
+		if len(c.priorityUpdates) >= int(c.config.maxConcurrentStreams)*4 {
+			return &serverError{code: xhttp2.ErrCodeEnhanceYourCalm, err: errors.New("http2: too many pending priority updates")}
+		}
+		c.priorityUpdates[event.streamID] = updated
+	}
+	return nil
+}
+
+func (c *serverConn) processCommand(command serverCommand) error {
+	stream := c.streams[command.streamID]
+	if stream == nil {
+		if command.result != nil {
+			command.result <- errStreamClosed
+		}
+		return nil
+	}
+	switch command.kind {
+	case serverCommandHandlerDone:
+		return c.handleHandlerDone(stream, command.requestCtx)
+	case serverCommandInformational:
+		block, err := encodeInformationalHeaders(c.encoder, &c.headerBuffer, command.statusCode, command.header)
+		if err == nil {
+			err = c.writeHeaderBlock(stream.id, false, block)
+		}
+		command.result <- err
+		return err
+	case serverCommandBodyConsumed:
+		stream.unconsumedFlow -= int64(command.consumed)
+		if stream.unconsumedFlow < 0 {
+			return errors.New("http2: request body flow accounting underflow")
+		}
+		return c.consumeRequestBytes(stream, int64(command.consumed))
+	case serverCommandResponseData:
+		if len(stream.pendingData) != 0 || stream.pendingAck != nil || stream.responseEOF {
+			command.result <- errors.New("http2: response stream has pending data")
+			return nil
+		}
+		if stream.expectedResponse >= 0 && stream.responseBytes+int64(len(command.data)) > stream.expectedResponse {
+			err := errors.New("http2: response body exceeds content-length")
+			command.result <- err
+			return c.resetStream(stream.id, xhttp2.ErrCodeInternal, err)
+		}
+		stream.pendingData = command.data
+		stream.pendingAck = command.result
+		stream.responseBytes += int64(len(command.data))
+		return nil
+	case serverCommandResponseEOF:
+		if command.err != nil && !errors.Is(command.err, io.EOF) {
+			if command.result != nil {
+				command.result <- command.err
+			}
+			return c.resetStream(stream.id, xhttp2.ErrCodeInternal, command.err)
+		}
+		if stream.expectedResponse >= 0 && stream.responseBytes != stream.expectedResponse {
+			err := errors.New("http2: response body length doesn't match content-length")
+			if command.result != nil {
+				command.result <- err
+			}
+			return c.resetStream(stream.id, xhttp2.ErrCodeInternal, err)
+		}
+		stream.responseEOF = true
+		if command.result != nil {
+			if stream.pendingData == nil {
+				command.result <- nil
+			} else {
+				stream.pendingAck = command.result
+			}
+		}
+		return nil
+	case serverCommandStreamHandlerDone:
+		stream.handlerDone = true
+		if !stream.localClosed {
+			stream.responseEOF = true
+		}
+		return nil
+	case serverCommandPush:
+		err := c.handlePush(stream, command.target, command.pushOpts)
+		command.result <- err
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (c *serverConn) startHandler(stream *serverStream) {
+	if stream.handlerStarted {
+		return
+	}
+	stream.handlerStarted = true
+	c.workers.Add(1)
+	go func() {
+		defer c.workers.Done()
+		c.server.Handler(stream.request)
+		select {
+		case c.commands <- serverCommand{
+			kind:       serverCommandHandlerDone,
+			streamID:   stream.id,
+			requestCtx: stream.request,
+		}:
+		case <-c.ctx.Done():
+		}
+	}()
+}
+
+func (c *serverConn) handleHandlerDone(
+	stream *serverStream,
+	requestCtx *fasthttp.RequestCtx,
+) error {
+	stream.handlerDone = true
+	if stream.request != requestCtx {
+		return errors.New("http2: handler returned an unexpected request context")
+	}
+	if stream.isReset {
+		c.releaseStream(stream)
+		return nil
+	}
+
+	stream.acceptMu.Lock()
+	streamHandler := stream.streamHandler
+	stream.acceptMu.Unlock()
+	if streamHandler != nil {
+		block, err := encodeResponseHeaders(
+			c.encoder,
+			&c.headerBuffer,
+			c.server,
+			&requestCtx.Response,
+			c.peerMaxHeaderListSize,
+		)
+		if err != nil {
+			return c.resetStream(stream.id, xhttp2.ErrCodeInternal, err)
+		}
+		if err := c.writeHeaderBlock(stream.id, false, block); err != nil {
+			return err
+		}
+		stream.responseHeaderSent = true
+		c.startStreamHandler(stream, streamHandler)
+		return nil
+	}
+
+	block, err := encodeResponseHeaders(
+		c.encoder,
+		&c.headerBuffer,
+		c.server,
+		&requestCtx.Response,
+		c.peerMaxHeaderListSize,
+	)
+	if err != nil {
+		return c.resetStream(stream.id, xhttp2.ErrCodeInternal, err)
+	}
+	stream.responseHasTrailers = len(requestCtx.Response.Header.PeekTrailerKeys()) != 0
+	if responseMustNotHaveBody(requestCtx) {
+		if err := c.writeHeaderBlock(stream.id, true, block); err != nil {
+			return err
+		}
+		stream.responseHeaderSent = true
+		stream.localClosed = true
+		c.finishResponse(stream)
+		return nil
+	}
+	if requestCtx.Response.IsBodyStream() {
+		stream.expectedResponse = responseContentLength(&requestCtx.Response.Header)
+		if err := c.writeHeaderBlock(stream.id, false, block); err != nil {
+			return err
+		}
+		stream.responseHeaderSent = true
+		c.startResponsePump(stream)
+		return nil
+	}
+
+	body := requestCtx.Response.Body()
+	stream.expectedResponse = responseContentLength(&requestCtx.Response.Header)
+	if stream.expectedResponse >= 0 && stream.expectedResponse != int64(len(body)) {
+		return c.resetStream(stream.id, xhttp2.ErrCodeInternal, errors.New("http2: response body length doesn't match content-length"))
+	}
+	stream.responseBytes = int64(len(body))
+	endStream := len(body) == 0 && !stream.responseHasTrailers
+	if err := c.writeHeaderBlock(stream.id, endStream, block); err != nil {
+		return err
+	}
+	stream.responseHeaderSent = true
+	if endStream {
+		stream.localClosed = true
+		c.finishResponse(stream)
+		return nil
+	}
+	if len(body) != 0 {
+		stream.pendingData = body
+	}
+	stream.responseEOF = true
+	return nil
+}
+
+func (c *serverConn) startResponsePump(stream *serverStream) {
+	c.workers.Add(1)
+	go func() {
+		defer c.workers.Done()
+		reader := stream.request.Response.BodyStream()
+		buffer := make([]byte, defaultMaxFrameSize)
+		for {
+			n, readErr := reader.Read(buffer)
+			if n > 0 {
+				result := make(chan error, 1)
+				command := serverCommand{
+					kind:     serverCommandResponseData,
+					streamID: stream.id,
+					data:     bytes.Clone(buffer[:n]),
+					result:   result,
+				}
+				select {
+				case c.commands <- command:
+				case <-stream.ctx.Done():
+					_ = stream.request.Response.CloseBodyStream()
+					return
+				}
+				select {
+				case err := <-result:
+					if err != nil {
+						_ = stream.request.Response.CloseBodyStream()
+						return
+					}
+				case <-stream.ctx.Done():
+					_ = stream.request.Response.CloseBodyStream()
+					return
+				}
+			}
+			if readErr != nil {
+				_ = stream.request.Response.CloseBodyStream()
+				result := make(chan error, 1)
+				select {
+				case c.commands <- serverCommand{
+					kind:     serverCommandResponseEOF,
+					streamID: stream.id,
+					err:      readErr,
+					result:   result,
+				}:
+				case <-stream.ctx.Done():
+					return
+				}
+				select {
+				case <-result:
+				case <-stream.ctx.Done():
+				}
+				return
+			}
+		}
+	}()
+}
+
+func (c *serverConn) startStreamHandler(
+	stream *serverStream,
+	handler fasthttp.StreamHandler,
+) {
+	stream.handlerDone = false
+	c.workers.Add(1)
+	go func() {
+		defer c.workers.Done()
+		streamConn := &streamConn{stream: stream, read: stream.body}
+		handler(streamConn)
+		_ = streamConn.Close()
+		select {
+		case c.commands <- serverCommand{kind: serverCommandStreamHandlerDone, streamID: stream.id}:
+		case <-stream.ctx.Done():
+		}
+	}()
+}
+
+func (c *serverConn) flushResponses() error {
+	for {
+		madeProgress := false
+		for urgency := uint8(0); urgency <= 7; urgency++ {
+			for _, stream := range c.streams {
+				if stream.priority.urgency != urgency {
+					continue
+				}
+				if len(stream.pendingData) != 0 && c.peerConnectionWindow > 0 && stream.sendWindow > 0 {
+					amount := min(
+						len(stream.pendingData),
+						c.peerMaxFrameSize,
+						int(c.peerConnectionWindow),
+						int(stream.sendWindow),
+					)
+					isLast := amount == len(stream.pendingData) && stream.responseEOF && !stream.responseHasTrailers
+					if err := c.framer.WriteData(stream.id, isLast, stream.pendingData[:amount]); err != nil {
+						return err
+					}
+					c.peerConnectionWindow -= int64(amount)
+					stream.sendWindow -= int64(amount)
+					stream.pendingData = stream.pendingData[amount:]
+					if len(stream.pendingData) == 0 {
+						stream.pendingData = nil
+					}
+					madeProgress = true
+					if len(stream.pendingData) == 0 && stream.pendingAck != nil {
+						stream.pendingAck <- nil
+						stream.pendingAck = nil
+					}
+					if isLast {
+						stream.localClosed = true
+						c.finishResponse(stream)
+					}
+					continue
+				}
+				if len(stream.pendingData) == 0 && stream.responseEOF && !stream.localClosed {
+					if stream.responseHasTrailers {
+						if err := c.writeResponseTrailers(stream); err != nil {
+							return err
+						}
+					} else {
+						if err := c.framer.WriteData(stream.id, true, nil); err != nil {
+							return err
+						}
+					}
+					stream.localClosed = true
+					madeProgress = true
+					c.finishResponse(stream)
+				}
+			}
+		}
+		if !madeProgress {
+			return nil
+		}
+	}
+}
+
+func (c *serverConn) writeResponseTrailers(stream *serverStream) error {
+	block, err := encodeTrailerHeaders(c.encoder, &c.headerBuffer, &stream.request.Response.Header)
+	if err != nil {
+		return err
+	}
+	return c.writeHeaderBlock(stream.id, true, block)
+}
+
+func (c *serverConn) writeHeaderBlock(streamID uint32, endStream bool, block []byte) error {
+	firstLength := min(len(block), c.peerMaxFrameSize)
+	if err := c.framer.WriteHeaders(xhttp2.HeadersFrameParam{
+		StreamID:      streamID,
+		BlockFragment: block[:firstLength],
+		EndStream:     endStream,
+		EndHeaders:    firstLength == len(block),
+	}); err != nil {
+		return err
+	}
+	block = block[firstLength:]
+	for len(block) != 0 {
+		fragmentLength := min(len(block), c.peerMaxFrameSize)
+		if err := c.framer.WriteContinuation(
+			streamID,
+			fragmentLength == len(block),
+			block[:fragmentLength],
+		); err != nil {
+			return err
+		}
+		block = block[fragmentLength:]
+	}
+	return nil
+}
+
+func (c *serverConn) finishResponse(stream *serverStream) {
+	stream.responseEOF = false
+	if stream.pendingAck != nil {
+		stream.pendingAck <- nil
+		stream.pendingAck = nil
+	}
+	if stream.streamHandler != nil && !stream.remoteClosed {
+		return
+	}
+	if !stream.remoteClosed {
+		_ = c.framer.WriteRSTStream(stream.id, xhttp2.ErrCodeNo)
+		stream.remoteClosed = true
+		c.restoreUnconsumedFlow(stream)
+		if stream.body != nil {
+			stream.body.closeWithError(errStreamClosed)
+		}
+	}
+	c.releaseStream(stream)
+}
+
+func (c *serverConn) restoreUnconsumedFlow(stream *serverStream) {
+	if stream.unconsumedFlow <= 0 {
+		return
+	}
+	c.restoreConnectionWindow(stream.unconsumedFlow)
+	stream.unconsumedFlow = 0
+}
+
+func (c *serverConn) releaseStream(stream *serverStream) {
+	if c.streams[stream.id] != stream {
+		return
+	}
+	delete(c.streams, stream.id)
+	if stream.isPush && c.activePushes > 0 {
+		c.activePushes--
+	}
+	stream.cancel(errStreamClosed)
+	if stream.body != nil {
+		stream.body.closeWithError(errStreamClosed)
+	}
+	if stream.request != nil {
+		c.protocolContext.ReleaseRequestCtx(stream.request)
+		stream.request = nil
+	}
+}
+
+func (c *serverConn) releaseAllStreams() {
+	for _, stream := range c.streams {
+		if stream.request != nil {
+			c.protocolContext.ReleaseRequestCtx(stream.request)
+			stream.request = nil
+		}
+	}
+	c.streams = make(map[uint32]*serverStream)
+}
+
+func (c *serverConn) resetStream(streamID uint32, code xhttp2.ErrCode, cause error) error {
+	if c.config.countError != nil {
+		c.config.countError("stream_" + strings.ToLower(code.String()))
+	}
+	if err := c.framer.WriteRSTStream(streamID, code); err != nil {
+		return err
+	}
+	stream := c.streams[streamID]
+	if stream != nil {
+		stream.isReset = true
+		stream.cancel(cause)
+		if !stream.handlerStarted || stream.handlerDone {
+			c.releaseStream(stream)
+		}
+	}
+	return nil
+}
+
+func (c *serverConn) startGracefulShutdown() error {
+	if c.isGoingAway {
+		return nil
+	}
+	c.isGoingAway = true
+	return c.framer.WriteGoAway(c.lastProcessedID, xhttp2.ErrCodeNo, nil)
+}
+
+func (c *serverConn) failConnection(code xhttp2.ErrCode, cause error) error {
+	if c.config.countError != nil {
+		c.config.countError("connection_" + strings.ToLower(code.String()))
+	}
+	_ = c.framer.WriteGoAway(c.lastProcessedID, code, []byte(cause.Error()))
+	return cause
+}
+
+func (c *serverConn) handlePush(
+	parent *serverStream,
+	target string,
+	opts *fasthttp.PushOptions,
+) error {
+	if !c.config.enablePush || !c.peerAllowsPush {
+		return fasthttp.ErrPushDisabled
+	}
+	if parent == nil || parent.isReset || parent.localClosed || parent.responseHeaderSent || parent.handlerDone {
+		return fasthttp.ErrPushNotAllowed
+	}
+	if parent.pushDepth >= c.config.maxPushDepth ||
+		c.activePushes >= c.config.maxPromisedStreams ||
+		c.activePushes >= c.peerMaxConcurrentStreams {
+		return fasthttp.ErrPushLimit
+	}
+	if c.nextPushStreamID == 0 || c.nextPushStreamID > math.MaxInt32 {
+		return fasthttp.ErrPushLimit
+	}
+
+	method := fasthttp.MethodGet
+	if opts != nil && opts.Method != "" {
+		method = opts.Method
+	}
+	if method != fasthttp.MethodGet && method != fasthttp.MethodHead {
+		return errors.New("http2: pushed request method must be GET or HEAD")
+	}
+	if target == "" {
+		return errors.New("http2: pushed request target is empty")
+	}
+
+	parentURI := parent.request.URI()
+	uri := fasthttp.AcquireURI()
+	defer fasthttp.ReleaseURI(uri)
+	if err := uri.Parse(parentURI.Host(), []byte(target)); err != nil {
+		return fmt.Errorf("http2: invalid pushed request target: %w", err)
+	}
+	if !bytes.Equal(uri.Host(), parentURI.Host()) || !bytes.Equal(uri.Scheme(), parentURI.Scheme()) {
+		return errors.New("http2: pushed request must have the same origin as its parent")
+	}
+
+	streamID := c.nextPushStreamID
+	stream := newServerStream(c, streamID)
+	stream.isPush = true
+	stream.pushDepth = parent.pushDepth + 1
+	stream.priority = parent.priority
+	stream.remoteClosed = true
+	stream.maxBody = parent.maxBody
+	requestCtx := c.protocolContext.AcquireRequestCtx(c.conn, stream)
+	stream.request = requestCtx
+	if opts != nil && opts.Header != nil {
+		opts.Header.CopyTo(&requestCtx.Request.Header)
+	}
+	requestCtx.Request.SetURI(uri)
+	requestCtx.Request.Header.SetMethod(method)
+	requestCtx.Request.Header.SetHostBytes(uri.Host())
+	requestCtx.Request.Header.SetRequestURIBytes(uri.RequestURI())
+	requestCtx.Request.Header.SetProtocol("HTTP/2")
+	requestCtx.Request.Header.SetConnectProtocol("")
+
+	block, err := encodeRequestHeaders(
+		c.encoder,
+		&c.headerBuffer,
+		&requestCtx.Request,
+		c.peerMaxHeaderListSize,
+		false,
+	)
+	if err != nil {
+		c.protocolContext.ReleaseRequestCtx(requestCtx)
+		stream.request = nil
+		stream.cancel(err)
+		return err
+	}
+	if err := c.writePushPromise(parent.id, streamID, block); err != nil {
+		c.protocolContext.ReleaseRequestCtx(requestCtx)
+		stream.request = nil
+		stream.cancel(err)
+		return err
+	}
+	c.nextPushStreamID += 2
+	c.activePushes++
+	c.streams[streamID] = stream
+	c.startHandler(stream)
+	return nil
+}
+
+func (c *serverConn) writePushPromise(parentID, promisedID uint32, block []byte) error {
+	firstLength := min(len(block), c.peerMaxFrameSize)
+	if err := c.framer.WritePushPromise(xhttp2.PushPromiseParam{
+		StreamID:      parentID,
+		PromiseID:     promisedID,
+		BlockFragment: block[:firstLength],
+		EndHeaders:    firstLength == len(block),
+	}); err != nil {
+		return err
+	}
+	block = block[firstLength:]
+	for len(block) != 0 {
+		fragmentLength := min(len(block), c.peerMaxFrameSize)
+		if err := c.framer.WriteContinuation(
+			parentID,
+			fragmentLength == len(block),
+			block[:fragmentLength],
+		); err != nil {
+			return err
+		}
+		block = block[fragmentLength:]
+	}
+	return nil
+}
+
+func responseMustNotHaveBody(ctx *fasthttp.RequestCtx) bool {
+	if ctx.Request.Header.IsHead() {
+		return true
+	}
+	statusCode := ctx.Response.StatusCode()
+	return statusCode >= 100 && statusCode < 200 || statusCode == 204 || statusCode == 304
+}
+
+func responseContentLength(header *fasthttp.ResponseHeader) int64 {
+	if len(header.Peek(fasthttp.HeaderContentLength)) == 0 {
+		return -1
+	}
+	return int64(header.ContentLength())
+}
+
+type priority struct {
+	urgency     uint8
+	incremental bool
+}
+
+func parsePriority(value string) (priority, error) {
+	result := priority{urgency: 3}
+	for _, member := range strings.Split(value, ",") {
+		member = strings.TrimSpace(member)
+		switch {
+		case member == "i" || member == "i=?1":
+			result.incremental = true
+		case strings.HasPrefix(member, "u="):
+			urgency, err := strconv.Atoi(strings.TrimPrefix(member, "u="))
+			if err != nil || urgency < 0 || urgency > 7 {
+				return priority{}, errors.New("http2: invalid priority urgency")
+			}
+			result.urgency = uint8(urgency)
+		}
+	}
+	return result, nil
+}
+
+func errorCode(err error) xhttp2.ErrCode {
+	var connectionError xhttp2.ConnectionError
+	if errors.As(err, &connectionError) {
+		return xhttp2.ErrCode(connectionError)
+	}
+	return xhttp2.ErrCodeProtocol
+}

--- a/http2/server.go
+++ b/http2/server.go
@@ -1,6 +1,7 @@
 package http2
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -30,7 +31,10 @@ const (
 	incomingFramePing
 	incomingFrameGoAway
 	incomingFramePriorityUpdate
+	incomingFramePriority
 	incomingFrameInvalidPushPromise
+	incomingFrameReadIdle
+	incomingFrameStreamError
 )
 
 type incomingFrame struct {
@@ -48,8 +52,22 @@ type incomingFrame struct {
 	lastStreamID uint32
 	pingData     [8]byte
 	priority     string
+	dependency   uint32
+	hasPriority  bool
 	err          error
+	fieldStorage *incomingHeaderFieldStorage
+	pooledData   bool
+	pooledConfig bool
 }
+
+type incomingHeaderFieldStorage struct {
+	fields []hpack.HeaderField
+}
+
+var incomingHeaderFieldsPool sync.Pool
+var incomingDataPool sync.Pool
+var incomingSettingsPool sync.Pool
+var responsePumpBufferPool sync.Pool
 
 type serverCommandKind uint8
 
@@ -60,8 +78,11 @@ const (
 	serverCommandBodyConsumed
 	serverCommandResponseData
 	serverCommandResponseEOF
+	serverCommandResponsePumpDone
 	serverCommandStreamHandlerDone
 	serverCommandPush
+	serverCommandCloseRead
+	serverCommandCancelStream
 )
 
 type serverCommand struct {
@@ -99,8 +120,11 @@ type serverConn struct {
 	ctx             context.Context
 	cancel          context.CancelCauseFunc
 	framer          *xhttp2.Framer
+	headerDecoder   *headerCodec
+	bufferedWriter  *bufio.Writer
 	encoder         *hpack.Encoder
 	headerBuffer    bytes.Buffer
+	headerStrings   headerStringCache
 
 	events   chan incomingFrame
 	commands chan serverCommand
@@ -110,6 +134,7 @@ type serverConn struct {
 	lastClientStreamID uint32
 	lastProcessedID    uint32
 	isGoingAway        bool
+	isDraining         bool
 	receivedSettings   bool
 
 	peerInitialStreamWindow  int64
@@ -119,10 +144,16 @@ type serverConn struct {
 	peerMaxConcurrentStreams uint32
 	peerAllowsPush           bool
 
-	receiveConnectionWindow int64
-	nextPushStreamID        uint32
-	activePushes            uint32
-	priorityUpdates         map[uint32]priority
+	receiveConnectionWindow  int64
+	pendingConnectionUpdate  int64
+	nextPushStreamID         uint32
+	activePushes             uint32
+	priorityUpdates          map[uint32]priority
+	closedClientStreams      map[uint32]struct{}
+	closedClientStreamOrder  []uint32
+	closedClientStreamCursor int
+	rapidResetWindowStart    time.Time
+	rapidResetCount          uint32
 }
 
 func (h *serverHandler) ServeConn(ctx *fasthttp.ProtocolServerContext, c net.Conn) error {
@@ -162,6 +193,7 @@ func newServerConn(
 		receiveConnectionWindow:  int64(config.connectionWindowSize),
 		nextPushStreamID:         2,
 		priorityUpdates:          make(map[uint32]priority),
+		closedClientStreams:      make(map[uint32]struct{}),
 	}
 	conn.encoder = hpack.NewEncoder(&conn.headerBuffer)
 	conn.encoder.SetMaxDynamicTableSizeLimit(config.maxEncoderTableSize)
@@ -187,39 +219,66 @@ func (c *serverConn) serve() (retErr error) {
 	}()
 
 	if err := c.readClientPreface(); err != nil {
+		_ = c.conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		_, _ = io.CopyN(io.Discard, c.conn, 64<<10)
 		return err
 	}
-	decoder := hpack.NewDecoder(c.config.maxDecoderTableSize, nil)
-	decoder.SetAllowedMaxDynamicTableSize(c.config.maxDecoderTableSize)
-	decoder.SetMaxStringLength(int(c.config.maxHeaderListSize))
-	c.framer = xhttp2.NewFramer(c.conn, c.conn)
-	c.framer.ReadMetaHeaders = decoder
-	c.framer.MaxHeaderListSize = c.config.maxHeaderListSize
+	if err := validateTLSConnection(c.conn); err != nil {
+		return err
+	}
+	writer := io.Writer(c.conn)
+	if c.config.writeByteTimeout > 0 {
+		writer = &deadlineWriter{conn: c.conn, timeout: c.config.writeByteTimeout}
+	}
+	writeBufferSize := c.server.WriteBufferSize
+	if writeBufferSize <= 0 {
+		writeBufferSize = defaultWriteBufferSize
+	}
+	c.bufferedWriter = bufio.NewWriterSize(writer, writeBufferSize)
+	c.framer = xhttp2.NewFramer(c.bufferedWriter, c.conn)
+	c.framer.SetReuseFrames()
+	c.headerDecoder = newHeaderCodec(c.config.maxDecoderTableSize, c.config.maxHeaderListSize)
 	c.framer.SetMaxReadFrameSize(c.config.maxReadFrameSize)
 	if err := c.writeInitialSettings(); err != nil {
 		return fmt.Errorf("http2: writing initial settings: %w", err)
 	}
+	if err := c.bufferedWriter.Flush(); err != nil {
+		return fmt.Errorf("http2: flushing initial settings: %w", err)
+	}
 
 	go c.readLoop()
 	serverDone := c.protocolContext.Done()
+	var idleTimer *time.Timer
+	if c.config.idleTimeout > 0 {
+		idleTimer = time.NewTimer(c.config.idleTimeout)
+		defer idleTimer.Stop()
+	}
+	idleArmed := idleTimer != nil
+	var shutdownTimer *time.Timer
 	for {
 		if c.isGoingAway && len(c.streams) == 0 {
 			return nil
 		}
 		select {
 		case event := <-c.events:
-			if event.err != nil {
-				if errors.Is(event.err, io.EOF) && len(c.streams) == 0 {
-					return nil
-				}
-				return c.failConnection(errorCode(event.err), event.err)
+			if closeConnection, err := c.handleIncomingEvent(event); closeConnection {
+				return err
 			}
-			if err := c.processFrame(event); err != nil {
-				var protocolErr *serverError
-				if errors.As(err, &protocolErr) {
-					return c.failConnection(protocolErr.code, protocolErr.err)
+		case <-timerChannel(idleTimer):
+			if len(c.streams) == 0 {
+				if err := c.startGracefulShutdown(); err != nil {
+					return err
 				}
-				return c.failConnection(xhttp2.ErrCodeInternal, err)
+				if shutdownTimer == nil {
+					shutdownTimer = time.NewTimer(c.config.pingTimeout)
+					defer shutdownTimer.Stop()
+				}
+			} else {
+				idleArmed = false
+			}
+		case <-timerChannel(shutdownTimer):
+			if err := c.finishGracefulShutdown(); err != nil {
+				return err
 			}
 		case command := <-c.commands:
 			if err := c.processCommand(command); err != nil {
@@ -230,13 +289,63 @@ func (c *serverConn) serve() (retErr error) {
 			if err := c.startGracefulShutdown(); err != nil {
 				return err
 			}
+			if shutdownTimer == nil {
+				shutdownTimer = time.NewTimer(c.config.pingTimeout)
+				defer shutdownTimer.Stop()
+			}
 		case <-c.ctx.Done():
 			return context.Cause(c.ctx)
 		}
+		for range 63 {
+			select {
+			case event := <-c.events:
+				if closeConnection, err := c.handleIncomingEvent(event); closeConnection {
+					return err
+				}
+			case command := <-c.commands:
+				if err := c.processCommand(command); err != nil {
+					return c.failConnection(xhttp2.ErrCodeInternal, err)
+				}
+			default:
+				goto flush
+			}
+		}
+	flush:
 		if err := c.flushResponses(); err != nil {
 			return err
 		}
+		if err := c.bufferedWriter.Flush(); err != nil {
+			return err
+		}
+		if idleTimer != nil {
+			switch {
+			case len(c.streams) == 0 && !idleArmed:
+				resetTimer(idleTimer, c.config.idleTimeout)
+				idleArmed = true
+			case len(c.streams) != 0 && idleArmed:
+				stopTimer(idleTimer)
+				idleArmed = false
+			}
+		}
 	}
+}
+
+func (c *serverConn) handleIncomingEvent(event incomingFrame) (bool, error) {
+	defer releaseIncomingFrame(&event)
+	if event.err != nil && event.kind != incomingFrameStreamError {
+		if errors.Is(event.err, io.EOF) && len(c.streams) == 0 {
+			return true, nil
+		}
+		return true, c.failConnection(errorCode(event.err), event.err)
+	}
+	if err := c.processFrame(&event); err != nil {
+		var protocolErr *serverError
+		if errors.As(err, &protocolErr) {
+			return true, c.failConnection(protocolErr.code, protocolErr.err)
+		}
+		return true, c.failConnection(xhttp2.ErrCodeInternal, err)
+	}
+	return false, nil
 }
 
 func (c *serverConn) readClientPreface() error {
@@ -283,24 +392,80 @@ func (c *serverConn) writeInitialSettings() error {
 }
 
 func (c *serverConn) readLoop() {
+	waitingForPing := false
 	for {
+		readTimeout := c.config.readIdleTimeout
+		if waitingForPing {
+			readTimeout = c.config.pingTimeout
+		}
+		if readTimeout > 0 {
+			_ = c.conn.SetReadDeadline(time.Now().Add(readTimeout))
+		}
 		frame, err := c.framer.ReadFrame()
+		if err != nil && isTimeout(err) && c.config.readIdleTimeout > 0 && !waitingForPing {
+			select {
+			case c.events <- incomingFrame{kind: incomingFrameReadIdle}:
+			case <-c.ctx.Done():
+				return
+			}
+			waitingForPing = true
+			continue
+		}
 		event := incomingFrame{err: err}
 		if err == nil {
-			event = copyIncomingFrame(frame)
+			waitingForPing = false
+			if headers, ok := frame.(*xhttp2.HeadersFrame); ok {
+				event = c.decodeIncomingHeaders(headers)
+			} else {
+				event = incomingFrameFromWire(frame)
+			}
 		}
 		select {
 		case c.events <- event:
 		case <-c.ctx.Done():
 			return
 		}
-		if err != nil {
+		if err != nil || event.err != nil && event.kind != incomingFrameStreamError {
 			return
 		}
 	}
 }
 
-func copyIncomingFrame(frame xhttp2.Frame) incomingFrame {
+func (c *serverConn) decodeIncomingHeaders(frame *xhttp2.HeadersFrame) incomingFrame {
+	event := incomingFrame{
+		kind:        incomingFrameHeaders,
+		streamID:    frame.StreamID,
+		endStream:   frame.StreamEnded(),
+		hasPriority: frame.HasPriority(),
+	}
+	if event.hasPriority {
+		event.dependency = frame.Priority.StreamDep
+	}
+	fieldStorage := acquireIncomingHeaderFields(8)
+	decoded, truncated, invalid, err := c.headerDecoder.decode(
+		c.framer,
+		frame.StreamID,
+		frame,
+		fieldStorage.fields,
+	)
+	event.fields = decoded
+	event.fieldStorage = fieldStorage
+	event.truncated = truncated
+	switch {
+	case err != nil:
+		event.err = err
+	case invalid != nil:
+		event.kind = incomingFrameStreamError
+		event.err = invalid
+		event.errCode = xhttp2.ErrCodeProtocol
+	}
+	return event
+}
+
+// incomingFrameFromWire copies reused x/net frame slices into pooled event
+// storage. HPACK field strings are immutable values owned by the decoder; only
+// the Framer-owned field slice must be copied before the next ReadFrame call.
+func incomingFrameFromWire(frame xhttp2.Frame) incomingFrame {
 	header := frame.Header()
 	event := incomingFrame{streamID: header.StreamID}
 	switch frame := frame.(type) {
@@ -308,7 +473,8 @@ func copyIncomingFrame(frame xhttp2.Frame) incomingFrame {
 		event.kind = incomingFrameSettings
 		event.ack = frame.IsAck()
 		if !event.ack {
-			event.settings = make([]xhttp2.Setting, frame.NumSettings())
+			event.settings = acquireIncomingSettings(frame.NumSettings())
+			event.pooledConfig = true
 			for i := range frame.NumSettings() {
 				event.settings[i] = frame.Setting(i)
 			}
@@ -317,19 +483,18 @@ func copyIncomingFrame(frame xhttp2.Frame) incomingFrame {
 		event.kind = incomingFrameHeaders
 		event.endStream = frame.StreamEnded()
 		event.truncated = frame.Truncated
-		event.fields = make([]hpack.HeaderField, len(frame.Fields))
-		for i, field := range frame.Fields {
-			event.fields[i] = hpack.HeaderField{
-				Name:      strings.Clone(field.Name),
-				Value:     strings.Clone(field.Value),
-				Sensitive: field.Sensitive,
-			}
+		event.hasPriority = frame.HeadersFrame.HasPriority()
+		if event.hasPriority {
+			event.dependency = frame.HeadersFrame.Priority.StreamDep
 		}
+		event.fieldStorage = copyIncomingHeaderFields(frame.Fields)
+		event.fields = event.fieldStorage.fields
 	case *xhttp2.DataFrame:
 		event.kind = incomingFrameData
 		event.endStream = frame.StreamEnded()
 		event.flowLength = int(frame.Header().Length)
-		event.data = bytes.Clone(frame.Data())
+		event.data = copyIncomingData(frame.Data())
+		event.pooledData = len(event.data) != 0
 	case *xhttp2.RSTStreamFrame:
 		event.kind = incomingFrameRST
 		event.errCode = frame.ErrCode
@@ -348,6 +513,9 @@ func copyIncomingFrame(frame xhttp2.Frame) incomingFrame {
 		event.kind = incomingFramePriorityUpdate
 		event.streamID = frame.PrioritizedStreamID
 		event.priority = strings.Clone(frame.Priority)
+	case *xhttp2.PriorityFrame:
+		event.kind = incomingFramePriority
+		event.dependency = frame.PriorityParam.StreamDep
 	case *xhttp2.PushPromiseFrame:
 		event.kind = incomingFrameInvalidPushPromise
 	default:
@@ -356,7 +524,75 @@ func copyIncomingFrame(frame xhttp2.Frame) incomingFrame {
 	return event
 }
 
-func (c *serverConn) processFrame(event incomingFrame) error {
+func copyIncomingHeaderFields(source []hpack.HeaderField) *incomingHeaderFieldStorage {
+	storage := acquireIncomingHeaderFields(len(source))
+	storage.fields = append(storage.fields, source...)
+	return storage
+}
+
+func acquireIncomingHeaderFields(length int) *incomingHeaderFieldStorage {
+	if value := incomingHeaderFieldsPool.Get(); value != nil {
+		storage := value.(*incomingHeaderFieldStorage) //nolint:forcetypeassert
+		if cap(storage.fields) >= length {
+			storage.fields = storage.fields[:0]
+			return storage
+		}
+	}
+	return &incomingHeaderFieldStorage{fields: make([]hpack.HeaderField, 0, length)}
+}
+
+func acquireIncomingSettings(length int) []xhttp2.Setting {
+	if value := incomingSettingsPool.Get(); value != nil {
+		settings := value.([]xhttp2.Setting) //nolint:forcetypeassert
+		if cap(settings) >= length {
+			return settings[:length]
+		}
+	}
+	return make([]xhttp2.Setting, length)
+}
+
+func copyIncomingData(source []byte) []byte {
+	if len(source) == 0 {
+		return nil
+	}
+	var data []byte
+	if value := incomingDataPool.Get(); value != nil {
+		data = value.([]byte) //nolint:forcetypeassert
+	}
+	if cap(data) < len(source) {
+		data = make([]byte, len(source))
+	} else {
+		data = data[:len(source)]
+	}
+	copy(data, source)
+	return data
+}
+
+func releaseIncomingFrame(event *incomingFrame) {
+	if event.fieldStorage != nil {
+		for i := range event.fields {
+			event.fields[i] = hpack.HeaderField{}
+		}
+		if cap(event.fields) <= 128 {
+			event.fieldStorage.fields = event.fields[:0]
+			incomingHeaderFieldsPool.Put(event.fieldStorage)
+		}
+	}
+	if event.pooledData {
+		releaseIncomingData(event.data)
+	}
+	if event.pooledConfig && cap(event.settings) <= 64 {
+		incomingSettingsPool.Put(event.settings[:0])
+	}
+}
+
+func releaseIncomingData(data []byte) {
+	if cap(data) <= 1<<20 {
+		incomingDataPool.Put(data[:0])
+	}
+}
+
+func (c *serverConn) processFrame(event *incomingFrame) error {
 	if !c.receivedSettings {
 		if event.kind != incomingFrameSettings || event.ack {
 			return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: first frame isn't settings")}
@@ -368,16 +604,19 @@ func (c *serverConn) processFrame(event incomingFrame) error {
 	case incomingFrameUnknown:
 		return nil
 	case incomingFrameSettings:
-		return c.processSettings(event)
+		return c.processSettings(*event)
 	case incomingFrameHeaders:
-		return c.processHeaders(event)
+		return c.processHeaders(*event)
 	case incomingFrameData:
 		return c.processData(event)
 	case incomingFrameRST:
-		return c.processRST(event)
+		return c.processRST(*event)
 	case incomingFrameWindowUpdate:
-		return c.processWindowUpdate(event)
+		return c.processWindowUpdate(*event)
 	case incomingFramePing:
+		if event.ack && c.isDraining && event.pingData == shutdownPingData {
+			return c.finishGracefulShutdown()
+		}
 		if !event.ack {
 			return c.framer.WritePing(true, event.pingData)
 		}
@@ -386,12 +625,39 @@ func (c *serverConn) processFrame(event incomingFrame) error {
 		c.isGoingAway = true
 		return nil
 	case incomingFramePriorityUpdate:
-		return c.processPriorityUpdate(event)
+		return c.processPriorityUpdate(*event)
+	case incomingFramePriority:
+		if event.streamID == event.dependency {
+			return c.resetStream(event.streamID, xhttp2.ErrCodeProtocol, errors.New("http2: stream depends on itself"))
+		}
+		return nil
 	case incomingFrameInvalidPushPromise:
 		return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: client sent push promise")}
+	case incomingFrameReadIdle:
+		return c.framer.WritePing(false, [8]byte{'f', 'a', 's', 't', 'h', '2', 0, 1})
+	case incomingFrameStreamError:
+		return c.processHeaderStreamError(*event)
 	default:
 		return nil
 	}
+}
+
+func (c *serverConn) processHeaderStreamError(event incomingFrame) error {
+	if stream := c.streams[event.streamID]; stream != nil {
+		return c.resetStream(event.streamID, event.errCode, event.err)
+	}
+	if event.streamID == 0 || event.streamID&1 == 0 || event.streamID <= c.lastClientStreamID {
+		return &serverError{
+			code: xhttp2.ErrCodeProtocol,
+			err:  errors.New("http2: malformed headers used an invalid client stream id"),
+		}
+	}
+	c.lastClientStreamID = event.streamID
+	c.rememberClosedClientStream(event.streamID)
+	if c.config.countError != nil {
+		c.config.countError("stream_" + strings.ToLower(event.errCode.String()))
+	}
+	return c.framer.WriteRSTStream(event.streamID, event.errCode)
 }
 
 func (c *serverConn) processSettings(event incomingFrame) error {
@@ -399,6 +665,9 @@ func (c *serverConn) processSettings(event incomingFrame) error {
 		return nil
 	}
 	for _, setting := range event.settings {
+		if err := setting.Valid(); err != nil {
+			return &serverError{code: errorCode(err), err: err}
+		}
 		switch setting.ID {
 		case xhttp2.SettingHeaderTableSize:
 			value := setting.Val
@@ -407,6 +676,9 @@ func (c *serverConn) processSettings(event incomingFrame) error {
 			}
 			c.encoder.SetMaxDynamicTableSize(value)
 		case xhttp2.SettingEnablePush:
+			if setting.Val > 1 {
+				return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: invalid SETTINGS_ENABLE_PUSH")}
+			}
 			c.peerAllowsPush = setting.Val == 1
 		case xhttp2.SettingMaxConcurrentStreams:
 			c.peerMaxConcurrentStreams = setting.Val
@@ -420,10 +692,16 @@ func (c *serverConn) processSettings(event incomingFrame) error {
 			}
 			c.peerInitialStreamWindow = int64(setting.Val)
 		case xhttp2.SettingMaxFrameSize:
+			if setting.Val < defaultMaxFrameSize || setting.Val > 1<<24-1 {
+				return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: invalid SETTINGS_MAX_FRAME_SIZE")}
+			}
 			c.peerMaxFrameSize = int(setting.Val)
 		case xhttp2.SettingMaxHeaderListSize:
 			c.peerMaxHeaderListSize = uint64(setting.Val)
 		case xhttp2.SettingEnableConnectProtocol, xhttp2.SettingNoRFC7540Priorities:
+			if setting.Val > 1 {
+				return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: invalid boolean setting")}
+			}
 			// The values affect features initiated by the peer; frame validation
 			// and request validation happen at their use sites.
 		}
@@ -432,11 +710,20 @@ func (c *serverConn) processSettings(event incomingFrame) error {
 }
 
 func (c *serverConn) processHeaders(event incomingFrame) error {
+	if event.hasPriority && event.streamID == event.dependency {
+		return c.resetStream(event.streamID, xhttp2.ErrCodeProtocol, errors.New("http2: stream depends on itself"))
+	}
 	if event.truncated {
 		return c.resetStream(event.streamID, xhttp2.ErrCodeEnhanceYourCalm, errInvalidRequestHeaders)
 	}
 	if existing := c.streams[event.streamID]; existing != nil {
 		return c.processTrailers(existing, event)
+	}
+	if event.streamID != 0 && event.streamID <= c.lastClientStreamID {
+		if _, wasClosed := c.closedClientStreams[event.streamID]; wasClosed {
+			return &serverError{code: xhttp2.ErrCodeStreamClosed, err: errors.New("http2: headers on closed stream")}
+		}
+		return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: reused or skipped client stream id")}
 	}
 	if c.isGoingAway {
 		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeRefusedStream)
@@ -458,12 +745,14 @@ func (c *serverConn) processHeaders(event incomingFrame) error {
 		c.protocolContext.ReleaseRequestCtx(requestCtx)
 		stream.request = nil
 		stream.cancel(err)
+		releaseServerStream(stream)
 		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeProtocol)
 	}
 	if c.server.GetOnly && !requestCtx.Request.Header.IsGet() && !requestCtx.Request.Header.IsHead() {
 		c.protocolContext.ReleaseRequestCtx(requestCtx)
 		stream.request = nil
 		stream.cancel(fasthttp.ErrGetOnly)
+		releaseServerStream(stream)
 		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeRefusedStream)
 	}
 	stream.maxBody = c.server.MaxRequestBodySize
@@ -477,30 +766,30 @@ func (c *serverConn) processHeaders(event incomingFrame) error {
 		}
 	}
 	stream.expectedBody = expectedBody
+	isExtended := len(requestCtx.Request.Header.ConnectProtocol()) != 0
+	if isExtended {
+		stream.maxBody = 0
+	}
 	if value := requestCtx.Request.Header.Peek("Priority"); len(value) != 0 {
 		parsed, parseErr := parsePriority(string(value))
-		if parseErr != nil {
-			c.protocolContext.ReleaseRequestCtx(requestCtx)
-			stream.request = nil
-			stream.cancel(parseErr)
-			return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeProtocol)
+		if parseErr == nil {
+			stream.priority = parsed
 		}
-		stream.priority = parsed
 	}
 	if updated, ok := c.priorityUpdates[event.streamID]; ok {
 		stream.priority = updated
 		delete(c.priorityUpdates, event.streamID)
 	}
-	if expectedBody >= 0 && expectedBody > int64(stream.maxBody) {
+	if stream.maxBody > 0 && expectedBody >= 0 && expectedBody > int64(stream.maxBody) {
 		c.protocolContext.ReleaseRequestCtx(requestCtx)
 		stream.request = nil
 		stream.cancel(errRequestBodyTooLarge)
+		releaseServerStream(stream)
 		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeCancel)
 	}
 	c.streams[event.streamID] = stream
 	c.lastProcessedID = event.streamID
 
-	isExtended := len(requestCtx.Request.Header.ConnectProtocol()) != 0
 	if !event.endStream && (c.server.StreamRequestBody || isExtended) {
 		stream.body = newRequestBody(func(consumed int) {
 			select {
@@ -509,7 +798,7 @@ func (c *serverConn) processHeaders(event incomingFrame) error {
 				streamID: stream.id,
 				consumed: consumed,
 			}:
-			case <-stream.ctx.Done():
+			case <-stream.Done():
 			}
 		})
 		bodySize := -1
@@ -526,7 +815,10 @@ func (c *serverConn) processHeaders(event incomingFrame) error {
 }
 
 func (c *serverConn) processTrailers(stream *serverStream, event incomingFrame) error {
-	if stream.remoteClosed || !event.endStream {
+	if stream.remoteClosed {
+		return c.resetStream(stream.id, xhttp2.ErrCodeStreamClosed, errors.New("http2: headers on half-closed remote stream"))
+	}
+	if !event.endStream {
 		return c.resetStream(stream.id, xhttp2.ErrCodeProtocol, errors.New("http2: invalid request trailers"))
 	}
 	for _, field := range event.fields {
@@ -541,12 +833,16 @@ func (c *serverConn) processTrailers(stream *serverStream, event incomingFrame) 
 	return c.finishRequestBody(stream)
 }
 
-func (c *serverConn) processData(event incomingFrame) error {
+func (c *serverConn) processData(event *incomingFrame) error {
 	stream := c.streams[event.streamID]
+	if stream == nil && event.streamID > c.lastClientStreamID {
+		return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: data on idle stream")}
+	}
 	if stream == nil || stream.remoteClosed {
 		return c.framer.WriteRSTStream(event.streamID, xhttp2.ErrCodeStreamClosed)
 	}
 	flowLength := int64(event.flowLength)
+	payloadLength := len(event.data)
 	c.receiveConnectionWindow -= flowLength
 	stream.recvWindow -= flowLength
 	if c.receiveConnectionWindow < 0 {
@@ -555,8 +851,7 @@ func (c *serverConn) processData(event incomingFrame) error {
 	if stream.recvWindow < 0 {
 		return c.resetStream(stream.id, xhttp2.ErrCodeFlowControl, errors.New("http2: stream receive window exceeded"))
 	}
-
-	stream.bodyBytes += int64(len(event.data))
+	stream.bodyBytes += int64(payloadLength)
 	if stream.expectedBody >= 0 && stream.bodyBytes > stream.expectedBody {
 		c.restoreConnectionWindow(flowLength)
 		return c.resetStream(stream.id, xhttp2.ErrCodeProtocol, errors.New("http2: request body exceeds content-length"))
@@ -565,13 +860,29 @@ func (c *serverConn) processData(event incomingFrame) error {
 		c.restoreConnectionWindow(flowLength)
 		return c.resetStream(stream.id, xhttp2.ErrCodeCancel, errRequestBodyTooLarge)
 	}
+	if stream.discardRequestBody {
+		if err := c.consumeRequestBytes(stream, flowLength); err != nil {
+			return err
+		}
+		if event.endStream {
+			return c.finishRequestBody(stream)
+		}
+		return nil
+	}
 	if stream.body != nil {
-		stream.unconsumedFlow += int64(len(event.data))
-		if err := stream.body.write(event.data); err != nil {
+		stream.unconsumedFlow += int64(payloadLength)
+		var release func([]byte)
+		if event.pooledData {
+			release = releaseIncomingData
+			event.pooledData = false
+		}
+		data := event.data
+		event.data = nil
+		if err := stream.body.writeOwned(data, release); err != nil {
 			c.restoreConnectionWindow(flowLength)
 			return c.resetStream(stream.id, xhttp2.ErrCodeCancel, err)
 		}
-		padding := flowLength - int64(len(event.data))
+		padding := flowLength - int64(payloadLength)
 		if padding > 0 {
 			if err := c.consumeRequestBytes(stream, padding); err != nil {
 				return err
@@ -607,16 +918,32 @@ func (c *serverConn) consumeRequestBytes(stream *serverStream, amount int64) err
 	if amount <= 0 {
 		return nil
 	}
-	c.receiveConnectionWindow += amount
-	stream.recvWindow += amount
 	if amount > math.MaxInt32 {
 		return &serverError{code: xhttp2.ErrCodeFlowControl, err: errors.New("http2: window update overflow")}
 	}
-	increment := uint32(amount)
-	if err := c.framer.WriteWindowUpdate(0, increment); err != nil {
-		return err
+	c.pendingConnectionUpdate += amount
+	connectionIncrement := int64(0)
+	if c.pendingConnectionUpdate >= int64(c.config.connectionWindowSize)/2 {
+		connectionIncrement = c.pendingConnectionUpdate
+		c.pendingConnectionUpdate = 0
+		c.receiveConnectionWindow += connectionIncrement
 	}
-	return c.framer.WriteWindowUpdate(stream.id, increment)
+	stream.pendingWindowUpdate += amount
+	streamIncrement := int64(0)
+	if stream.pendingWindowUpdate >= int64(c.config.streamWindowSize)/2 {
+		streamIncrement = stream.pendingWindowUpdate
+		stream.pendingWindowUpdate = 0
+		stream.recvWindow += streamIncrement
+	}
+	if connectionIncrement != 0 {
+		if err := c.framer.WriteWindowUpdate(0, uint32(connectionIncrement)); err != nil {
+			return err
+		}
+	}
+	if streamIncrement != 0 {
+		return c.framer.WriteWindowUpdate(stream.id, uint32(streamIncrement))
+	}
+	return nil
 }
 
 func (c *serverConn) restoreConnectionWindow(amount int64) {
@@ -628,8 +955,22 @@ func (c *serverConn) restoreConnectionWindow(amount int64) {
 }
 
 func (c *serverConn) processRST(event incomingFrame) error {
+	if event.streamID <= c.lastClientStreamID {
+		now := time.Now()
+		if c.rapidResetWindowStart.IsZero() || now.Sub(c.rapidResetWindowStart) >= time.Second {
+			c.rapidResetWindowStart = now
+			c.rapidResetCount = 0
+		}
+		c.rapidResetCount++
+		if c.rapidResetCount > c.config.maxRapidResetsPerSecond {
+			return &serverError{code: xhttp2.ErrCodeEnhanceYourCalm, err: errors.New("http2: rapid reset limit exceeded")}
+		}
+	}
 	stream := c.streams[event.streamID]
 	if stream == nil {
+		if event.streamID > c.lastClientStreamID {
+			return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: reset on idle stream")}
+		}
 		return nil
 	}
 	stream.isReset = true
@@ -653,13 +994,23 @@ func (c *serverConn) processRST(event incomingFrame) error {
 func (c *serverConn) processWindowUpdate(event incomingFrame) error {
 	if event.streamID == 0 {
 		if c.peerConnectionWindow+int64(event.increment) > math.MaxInt32 {
-			return &serverError{code: xhttp2.ErrCodeFlowControl, err: errors.New("http2: connection send window overflow")}
+			return &serverError{
+				code: xhttp2.ErrCodeFlowControl,
+				err: fmt.Errorf(
+					"http2: server connection send window overflow: current=%d increment=%d",
+					c.peerConnectionWindow,
+					event.increment,
+				),
+			}
 		}
 		c.peerConnectionWindow += int64(event.increment)
 		return nil
 	}
 	stream := c.streams[event.streamID]
 	if stream == nil {
+		if event.streamID > c.lastClientStreamID {
+			return &serverError{code: xhttp2.ErrCodeProtocol, err: errors.New("http2: window update on idle stream")}
+		}
 		return nil
 	}
 	if stream.sendWindow+int64(event.increment) > math.MaxInt32 {
@@ -675,7 +1026,7 @@ func (c *serverConn) processPriorityUpdate(event incomingFrame) error {
 	}
 	updated, err := parsePriority(event.priority)
 	if err != nil {
-		return err
+		return nil
 	}
 	if stream := c.streams[event.streamID]; stream != nil {
 		stream.priority = updated
@@ -702,13 +1053,22 @@ func (c *serverConn) processCommand(command serverCommand) error {
 	case serverCommandHandlerDone:
 		return c.handleHandlerDone(stream, command.requestCtx)
 	case serverCommandInformational:
-		block, err := encodeInformationalHeaders(c.encoder, &c.headerBuffer, command.statusCode, command.header)
+		block, err := encodeInformationalHeaders(
+			c.encoder,
+			&c.headerBuffer,
+			&c.headerStrings,
+			command.statusCode,
+			command.header,
+		)
 		if err == nil {
 			err = c.writeHeaderBlock(stream.id, false, block)
 		}
 		command.result <- err
 		return err
 	case serverCommandBodyConsumed:
+		if stream.discardRequestBody {
+			return nil
+		}
 		stream.unconsumedFlow -= int64(command.consumed)
 		if stream.unconsumedFlow < 0 {
 			return errors.New("http2: request body flow accounting underflow")
@@ -751,6 +1111,12 @@ func (c *serverConn) processCommand(command serverCommand) error {
 			}
 		}
 		return nil
+	case serverCommandResponsePumpDone:
+		stream.responsePumpDone = true
+		if stream.releasePending {
+			c.releaseStream(stream)
+		}
+		return nil
 	case serverCommandStreamHandlerDone:
 		stream.handlerDone = true
 		if !stream.localClosed {
@@ -761,6 +1127,26 @@ func (c *serverConn) processCommand(command serverCommand) error {
 		err := c.handlePush(stream, command.target, command.pushOpts)
 		command.result <- err
 		return nil
+	case serverCommandCloseRead:
+		stream.discardRequestBody = true
+		if stream.unconsumedFlow > 0 {
+			amount := stream.unconsumedFlow
+			stream.unconsumedFlow = 0
+			if err := c.consumeRequestBytes(stream, amount); err != nil {
+				command.result <- err
+				return err
+			}
+		}
+		if stream.body != nil {
+			stream.body.closeWithError(net.ErrClosed)
+		}
+		command.result <- nil
+		return nil
+	case serverCommandCancelStream:
+		if command.result != nil {
+			command.result <- command.err
+		}
+		return c.resetStream(stream.id, xhttp2.ErrCodeCancel, command.err)
 	default:
 		return nil
 	}
@@ -772,18 +1158,20 @@ func (c *serverConn) startHandler(stream *serverStream) {
 	}
 	stream.handlerStarted = true
 	c.workers.Add(1)
-	go func() {
-		defer c.workers.Done()
-		c.server.Handler(stream.request)
-		select {
-		case c.commands <- serverCommand{
-			kind:       serverCommandHandlerDone,
-			streamID:   stream.id,
-			requestCtx: stream.request,
-		}:
-		case <-c.ctx.Done():
-		}
-	}()
+	go c.runHandler(stream)
+}
+
+func (c *serverConn) runHandler(stream *serverStream) {
+	defer c.workers.Done()
+	c.server.Handler(stream.request)
+	select {
+	case c.commands <- serverCommand{
+		kind:       serverCommandHandlerDone,
+		streamID:   stream.id,
+		requestCtx: stream.request,
+	}:
+	case <-c.ctx.Done():
+	}
 }
 
 func (c *serverConn) handleHandlerDone(
@@ -798,17 +1186,39 @@ func (c *serverConn) handleHandlerDone(
 		c.releaseStream(stream)
 		return nil
 	}
+	statusCode := requestCtx.Response.StatusCode()
+	if statusCode == 0 {
+		statusCode = fasthttp.StatusOK
+	}
+	if statusCode >= 100 && statusCode < 200 {
+		return c.resetStream(stream.id, xhttp2.ErrCodeInternal, errors.New("http2: final response cannot be informational"))
+	}
+	if statusCode == fasthttp.StatusNoContent &&
+		(requestCtx.Response.IsBodyStream() || len(requestCtx.Response.Body()) != 0 ||
+			len(requestCtx.Response.Header.Peek(fasthttp.HeaderContentLength)) != 0) {
+		return c.resetStream(stream.id, xhttp2.ErrCodeInternal, errors.New("http2: 204 response cannot contain a body or content-length"))
+	}
 
 	stream.acceptMu.Lock()
 	streamHandler := stream.streamHandler
+	if streamHandler != nil && (statusCode < 200 || statusCode >= 300) {
+		stream.streamHandler = nil
+		streamHandler = nil
+	}
 	stream.acceptMu.Unlock()
 	if streamHandler != nil {
+		if requestCtx.Response.IsBodyStream() || len(requestCtx.Response.Body()) != 0 ||
+			len(requestCtx.Response.Header.PeekTrailerKeys()) != 0 {
+			return c.resetStream(stream.id, xhttp2.ErrCodeInternal, errors.New("http2: accepted stream response cannot have an HTTP body"))
+		}
 		block, err := encodeResponseHeaders(
 			c.encoder,
 			&c.headerBuffer,
+			&c.headerStrings,
 			c.server,
 			&requestCtx.Response,
 			c.peerMaxHeaderListSize,
+			c.protocolContext.ServerDate(),
 		)
 		if err != nil {
 			return c.resetStream(stream.id, xhttp2.ErrCodeInternal, err)
@@ -824,9 +1234,11 @@ func (c *serverConn) handleHandlerDone(
 	block, err := encodeResponseHeaders(
 		c.encoder,
 		&c.headerBuffer,
+		&c.headerStrings,
 		c.server,
 		&requestCtx.Response,
 		c.peerMaxHeaderListSize,
+		c.protocolContext.ServerDate(),
 	)
 	if err != nil {
 		return c.resetStream(stream.id, xhttp2.ErrCodeInternal, err)
@@ -875,11 +1287,19 @@ func (c *serverConn) handleHandlerDone(
 }
 
 func (c *serverConn) startResponsePump(stream *serverStream) {
+	stream.responsePumpStarted = true
 	c.workers.Add(1)
 	go func() {
-		defer c.workers.Done()
+		defer func() {
+			select {
+			case c.commands <- serverCommand{kind: serverCommandResponsePumpDone, streamID: stream.id}:
+			case <-c.ctx.Done():
+			}
+			c.workers.Done()
+		}()
 		reader := stream.request.Response.BodyStream()
-		buffer := make([]byte, defaultMaxFrameSize)
+		buffer := acquireResponsePumpBuffer()
+		defer responsePumpBufferPool.Put(buffer[:0])
 		for {
 			n, readErr := reader.Read(buffer)
 			if n > 0 {
@@ -887,12 +1307,12 @@ func (c *serverConn) startResponsePump(stream *serverStream) {
 				command := serverCommand{
 					kind:     serverCommandResponseData,
 					streamID: stream.id,
-					data:     bytes.Clone(buffer[:n]),
+					data:     buffer[:n],
 					result:   result,
 				}
 				select {
 				case c.commands <- command:
-				case <-stream.ctx.Done():
+				case <-stream.Done():
 					_ = stream.request.Response.CloseBodyStream()
 					return
 				}
@@ -902,7 +1322,7 @@ func (c *serverConn) startResponsePump(stream *serverStream) {
 						_ = stream.request.Response.CloseBodyStream()
 						return
 					}
-				case <-stream.ctx.Done():
+				case <-stream.Done():
 					_ = stream.request.Response.CloseBodyStream()
 					return
 				}
@@ -917,17 +1337,27 @@ func (c *serverConn) startResponsePump(stream *serverStream) {
 					err:      readErr,
 					result:   result,
 				}:
-				case <-stream.ctx.Done():
+				case <-stream.Done():
 					return
 				}
 				select {
 				case <-result:
-				case <-stream.ctx.Done():
+				case <-stream.Done():
 				}
 				return
 			}
 		}
 	}()
+}
+
+func acquireResponsePumpBuffer() []byte {
+	if value := responsePumpBufferPool.Get(); value != nil {
+		buffer := value.([]byte) //nolint:forcetypeassert
+		if cap(buffer) >= defaultMaxFrameSize {
+			return buffer[:defaultMaxFrameSize]
+		}
+	}
+	return make([]byte, defaultMaxFrameSize)
 }
 
 func (c *serverConn) startStreamHandler(
@@ -938,12 +1368,16 @@ func (c *serverConn) startStreamHandler(
 	c.workers.Add(1)
 	go func() {
 		defer c.workers.Done()
-		streamConn := &streamConn{stream: stream, read: stream.body}
+		var reader io.Reader = bytes.NewReader(nil)
+		if stream.body != nil {
+			reader = stream.body
+		}
+		streamConn := &streamConn{stream: stream, read: reader}
 		handler(streamConn)
 		_ = streamConn.Close()
 		select {
 		case c.commands <- serverCommand{kind: serverCommandStreamHandlerDone, streamID: stream.id}:
-		case <-stream.ctx.Done():
+		case <-stream.Done():
 		}
 	}()
 }
@@ -1007,7 +1441,12 @@ func (c *serverConn) flushResponses() error {
 }
 
 func (c *serverConn) writeResponseTrailers(stream *serverStream) error {
-	block, err := encodeTrailerHeaders(c.encoder, &c.headerBuffer, &stream.request.Response.Header)
+	block, err := encodeTrailerHeaders(
+		c.encoder,
+		&c.headerBuffer,
+		&c.headerStrings,
+		&stream.request.Response.Header,
+	)
 	if err != nil {
 		return err
 	}
@@ -1045,7 +1484,7 @@ func (c *serverConn) finishResponse(stream *serverStream) {
 		stream.pendingAck <- nil
 		stream.pendingAck = nil
 	}
-	if stream.streamHandler != nil && !stream.remoteClosed {
+	if stream.streamHandler != nil && !stream.handlerDone {
 		return
 	}
 	if !stream.remoteClosed {
@@ -1071,26 +1510,58 @@ func (c *serverConn) releaseStream(stream *serverStream) {
 	if c.streams[stream.id] != stream {
 		return
 	}
+	if stream.responsePumpStarted && !stream.responsePumpDone {
+		stream.releasePending = true
+		return
+	}
 	delete(c.streams, stream.id)
+	if stream.id&1 == 1 {
+		c.rememberClosedClientStream(stream.id)
+	}
 	if stream.isPush && c.activePushes > 0 {
 		c.activePushes--
 	}
 	stream.cancel(errStreamClosed)
 	if stream.body != nil {
-		stream.body.closeWithError(errStreamClosed)
+		stream.body.discardWithError(errStreamClosed)
 	}
 	if stream.request != nil {
 		c.protocolContext.ReleaseRequestCtx(stream.request)
 		stream.request = nil
 	}
+	releaseServerStream(stream)
+}
+
+func (c *serverConn) rememberClosedClientStream(streamID uint32) {
+	if _, exists := c.closedClientStreams[streamID]; exists {
+		return
+	}
+	c.closedClientStreams[streamID] = struct{}{}
+	limit := int(c.config.maxConcurrentStreams) * 4
+	if len(c.closedClientStreamOrder) < limit {
+		c.closedClientStreamOrder = append(c.closedClientStreamOrder, streamID)
+		return
+	}
+	oldest := c.closedClientStreamOrder[c.closedClientStreamCursor]
+	delete(c.closedClientStreams, oldest)
+	c.closedClientStreamOrder[c.closedClientStreamCursor] = streamID
+	c.closedClientStreamCursor++
+	if c.closedClientStreamCursor == limit {
+		c.closedClientStreamCursor = 0
+	}
 }
 
 func (c *serverConn) releaseAllStreams() {
 	for _, stream := range c.streams {
+		stream.cancel(errStreamClosed)
+		if stream.body != nil {
+			stream.body.discardWithError(errStreamClosed)
+		}
 		if stream.request != nil {
 			c.protocolContext.ReleaseRequestCtx(stream.request)
 			stream.request = nil
 		}
+		releaseServerStream(stream)
 	}
 	c.streams = make(map[uint32]*serverStream)
 }
@@ -1114,6 +1585,17 @@ func (c *serverConn) resetStream(streamID uint32, code xhttp2.ErrCode, cause err
 }
 
 func (c *serverConn) startGracefulShutdown() error {
+	if c.isDraining || c.isGoingAway {
+		return nil
+	}
+	c.isDraining = true
+	if err := c.framer.WriteGoAway(math.MaxInt32, xhttp2.ErrCodeNo, nil); err != nil {
+		return err
+	}
+	return c.framer.WritePing(false, shutdownPingData)
+}
+
+func (c *serverConn) finishGracefulShutdown() error {
 	if c.isGoingAway {
 		return nil
 	}
@@ -1121,11 +1603,18 @@ func (c *serverConn) startGracefulShutdown() error {
 	return c.framer.WriteGoAway(c.lastProcessedID, xhttp2.ErrCodeNo, nil)
 }
 
+var shutdownPingData = [8]byte{'f', 'a', 's', 't', 'h', '2', 'g', 'o'}
+
 func (c *serverConn) failConnection(code xhttp2.ErrCode, cause error) error {
 	if c.config.countError != nil {
 		c.config.countError("connection_" + strings.ToLower(code.String()))
 	}
-	_ = c.framer.WriteGoAway(c.lastProcessedID, code, []byte(cause.Error()))
+	_ = c.framer.WriteGoAway(c.lastProcessedID, code, nil)
+	_ = c.bufferedWriter.Flush()
+	if errors.Is(cause, xhttp2.ErrFrameTooLarge) {
+		_ = c.conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		_, _ = io.CopyN(io.Discard, c.conn, 1<<24)
+	}
 	return cause
 }
 
@@ -1192,6 +1681,7 @@ func (c *serverConn) handlePush(
 	block, err := encodeRequestHeaders(
 		c.encoder,
 		&c.headerBuffer,
+		&c.headerStrings,
 		&requestCtx.Request,
 		c.peerMaxHeaderListSize,
 		false,
@@ -1200,12 +1690,14 @@ func (c *serverConn) handlePush(
 		c.protocolContext.ReleaseRequestCtx(requestCtx)
 		stream.request = nil
 		stream.cancel(err)
+		releaseServerStream(stream)
 		return err
 	}
 	if err := c.writePushPromise(parent.id, streamID, block); err != nil {
 		c.protocolContext.ReleaseRequestCtx(requestCtx)
 		stream.request = nil
 		stream.cancel(err)
+		releaseServerStream(stream)
 		return err
 	}
 	c.nextPushStreamID += 2
@@ -1262,13 +1754,39 @@ type priority struct {
 
 func parsePriority(value string) (priority, error) {
 	result := priority{urgency: 3}
+	seenUrgency := false
+	seenIncremental := false
 	for _, member := range strings.Split(value, ",") {
 		member = strings.TrimSpace(member)
+		if member == "" {
+			return priority{}, errors.New("http2: invalid empty priority member")
+		}
+		item, _, _ := strings.Cut(member, ";")
+		item = strings.TrimSpace(item)
 		switch {
-		case member == "i" || member == "i=?1":
+		case item == "i" || item == "i=?1":
+			if seenIncremental {
+				return priority{}, errors.New("http2: duplicate incremental priority")
+			}
+			seenIncremental = true
 			result.incremental = true
-		case strings.HasPrefix(member, "u="):
-			urgency, err := strconv.Atoi(strings.TrimPrefix(member, "u="))
+		case item == "i=?0":
+			if seenIncremental {
+				return priority{}, errors.New("http2: duplicate incremental priority")
+			}
+			seenIncremental = true
+		case strings.HasPrefix(item, "i="):
+			return priority{}, errors.New("http2: invalid incremental priority")
+		case strings.HasPrefix(item, "u="):
+			if seenUrgency {
+				return priority{}, errors.New("http2: duplicate urgency priority")
+			}
+			seenUrgency = true
+			urgencyText := strings.TrimPrefix(item, "u=")
+			if urgencyText == "" || strings.HasPrefix(urgencyText, "+") {
+				return priority{}, errors.New("http2: invalid priority urgency")
+			}
+			urgency, err := strconv.Atoi(urgencyText)
 			if err != nil || urgency < 0 || urgency > 7 {
 				return priority{}, errors.New("http2: invalid priority urgency")
 			}
@@ -1279,6 +1797,9 @@ func parsePriority(value string) (priority, error) {
 }
 
 func errorCode(err error) xhttp2.ErrCode {
+	if errors.Is(err, xhttp2.ErrFrameTooLarge) {
+		return xhttp2.ErrCodeFrameSize
+	}
 	var connectionError xhttp2.ConnectionError
 	if errors.As(err, &connectionError) {
 		return xhttp2.ErrCode(connectionError)

--- a/http2/server_test.go
+++ b/http2/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"net"
 	stdhttp "net/http"
@@ -20,12 +21,13 @@ import (
 type testServer struct {
 	server    *fasthttp.Server
 	listener  net.Listener
+	scheme    string
 	transport *xhttp2.Transport
 	client    *stdhttp.Client
 	serveDone chan error
 }
 
-func newTestServer(t *testing.T, server *fasthttp.Server, config ServerConfig) *testServer {
+func newTestServer(t testing.TB, server *fasthttp.Server, config ServerConfig) *testServer {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -45,6 +47,7 @@ func newTestServer(t *testing.T, server *fasthttp.Server, config ServerConfig) *
 	result := &testServer{
 		server:    server,
 		listener:  listener,
+		scheme:    "http",
 		transport: transport,
 		client:    &stdhttp.Client{Transport: transport},
 		serveDone: make(chan error, 1),
@@ -70,7 +73,7 @@ func newTestServer(t *testing.T, server *fasthttp.Server, config ServerConfig) *
 }
 
 func (s *testServer) URL(path string) string {
-	return "http://" + s.listener.Addr().String() + path
+	return s.scheme + "://" + s.listener.Addr().String() + path
 }
 
 func TestServerRequestResponse(t *testing.T) {
@@ -229,4 +232,190 @@ func TestServerEarlyHints(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("didn't receive early hints")
 	}
+}
+
+func TestServerRapidResetLimit(t *testing.T) {
+	conn := &serverConn{
+		config:             serverConfig{maxRapidResetsPerSecond: 2},
+		lastClientStreamID: 5,
+		streams:            make(map[uint32]*serverStream),
+	}
+	for _, streamID := range []uint32{1, 3} {
+		if err := conn.processRST(incomingFrame{streamID: streamID}); err != nil {
+			t.Fatalf("processRST(%d) error: %v", streamID, err)
+		}
+	}
+	err := conn.processRST(incomingFrame{streamID: 5})
+	var protocolErr *serverError
+	if !errors.As(err, &protocolErr) || protocolErr.code != xhttp2.ErrCodeEnhanceYourCalm {
+		t.Fatalf("processRST() error = %v, want ENHANCE_YOUR_CALM", err)
+	}
+}
+
+func TestMalformedHeaderStreamIDCannotBeReused(t *testing.T) {
+	var wire bytes.Buffer
+	conn := &serverConn{
+		config:              serverConfig{maxConcurrentStreams: 10},
+		framer:              xhttp2.NewFramer(&wire, nil),
+		streams:             make(map[uint32]*serverStream),
+		closedClientStreams: make(map[uint32]struct{}),
+	}
+	event := incomingFrame{
+		kind:     incomingFrameStreamError,
+		streamID: 1,
+		errCode:  xhttp2.ErrCodeProtocol,
+		err:      errInvalidRequestHeaders,
+	}
+	if err := conn.processHeaderStreamError(event); err != nil {
+		t.Fatalf("first malformed stream error: %v", err)
+	}
+	if conn.lastClientStreamID != 1 {
+		t.Fatalf("last client stream ID = %d, want 1", conn.lastClientStreamID)
+	}
+	if _, ok := conn.closedClientStreams[1]; !ok {
+		t.Fatal("malformed stream wasn't remembered as closed")
+	}
+	err := conn.processHeaderStreamError(event)
+	var protocolErr *serverError
+	if !errors.As(err, &protocolErr) || protocolErr.code != xhttp2.ErrCodeProtocol {
+		t.Fatalf("reused malformed stream error = %v, want connection PROTOCOL_ERROR", err)
+	}
+}
+
+func TestParsePriority(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    priority
+		wantErr bool
+	}{
+		{"u=0", priority{urgency: 0}, false},
+		{"u=7, i", priority{urgency: 7, incremental: true}, false},
+		{"i=?0, u=2", priority{urgency: 2}, false},
+		{"u=1; extension=token, x=ignored", priority{urgency: 1}, false},
+		{"u=8", priority{}, true},
+		{"u=1, u=2", priority{}, true},
+		{"i=?2", priority{}, true},
+		{"u=3,,i", priority{}, true},
+	}
+	for _, test := range tests {
+		t.Run(test.value, func(t *testing.T) {
+			got, err := parsePriority(test.value)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("parsePriority() error = %v, wantErr=%v", err, test.wantErr)
+			}
+			if err == nil && got != test.want {
+				t.Fatalf("parsePriority() = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRequestBodyOwnsAndBoundsChunks(t *testing.T) {
+	const chunks = maxRequestBodyChunks + 2
+	released := 0
+	consumed := 0
+	body := newRequestBody(func(n int) { consumed += n })
+	for i := range chunks {
+		data := []byte{byte(i)}
+		if err := body.writeOwned(data, func([]byte) { released++ }); err != nil {
+			t.Fatalf("writeOwned() error: %v", err)
+		}
+	}
+	if len(body.chunks) > maxRequestBodyChunks {
+		t.Fatalf("queued chunks = %d, want at most %d", len(body.chunks), maxRequestBodyChunks)
+	}
+	body.closeWithError(nil)
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("ReadAll() error: %v", err)
+	}
+	if len(got) != chunks {
+		t.Fatalf("body length = %d, want %d", len(got), chunks)
+	}
+	for i, value := range got {
+		if value != byte(i) {
+			t.Fatalf("body[%d] = %d, want %d", i, value, byte(i))
+		}
+	}
+	if consumed != chunks {
+		t.Fatalf("consumed bytes = %d, want %d", consumed, chunks)
+	}
+	if released != chunks {
+		t.Fatalf("released chunks = %d, want %d", released, chunks)
+	}
+}
+
+func TestRequestBodyCloseReleasesOwnedChunks(t *testing.T) {
+	released := 0
+	body := newRequestBody(nil)
+	if err := body.writeOwned([]byte("body"), func([]byte) { released++ }); err != nil {
+		t.Fatalf("writeOwned() error: %v", err)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatalf("second Close() error: %v", err)
+	}
+	if released != 1 {
+		t.Fatalf("released chunks = %d, want 1", released)
+	}
+	if _, err := body.Read(make([]byte, 1)); !errors.Is(err, errStreamClosed) {
+		t.Fatalf("Read() error = %v, want %v", err, errStreamClosed)
+	}
+}
+
+func TestProcessStreamingDataTransfersOwnershipWithoutConsumingPayload(t *testing.T) {
+	const windowSize = 1 << 20
+	conn := &serverConn{
+		config: serverConfig{
+			connectionWindowSize: windowSize,
+			streamWindowSize:     windowSize,
+		},
+		streams:                 make(map[uint32]*serverStream),
+		receiveConnectionWindow: windowSize,
+		framer:                  xhttp2.NewFramer(io.Discard, nil),
+	}
+	stream := &serverStream{
+		id:           1,
+		conn:         conn,
+		recvWindow:   windowSize,
+		expectedBody: -1,
+	}
+	stream.body = newRequestBody(func(n int) {
+		if err := conn.consumeRequestBytes(stream, int64(n)); err != nil {
+			t.Errorf("consumeRequestBytes() error: %v", err)
+		}
+	})
+	conn.streams[stream.id] = stream
+	event := incomingFrame{
+		kind:       incomingFrameData,
+		streamID:   stream.id,
+		flowLength: 4,
+		data:       []byte("body"),
+	}
+	if err := conn.processData(&event); err != nil {
+		t.Fatalf("processData() error: %v", err)
+	}
+	if conn.pendingConnectionUpdate != 0 {
+		t.Fatalf("pending connection update before body read = %d, want 0", conn.pendingConnectionUpdate)
+	}
+	if stream.unconsumedFlow != 4 {
+		t.Fatalf("unconsumed flow = %d, want 4", stream.unconsumedFlow)
+	}
+	if event.data != nil {
+		t.Fatal("DATA event retained payload after ownership transfer")
+	}
+
+	got := make([]byte, 4)
+	if _, err := io.ReadFull(stream.body, got); err != nil {
+		t.Fatalf("ReadFull() error: %v", err)
+	}
+	if string(got) != "body" {
+		t.Fatalf("body = %q, want body", got)
+	}
+	if conn.pendingConnectionUpdate != 4 {
+		t.Fatalf("pending connection update after body read = %d, want 4", conn.pendingConnectionUpdate)
+	}
+	stream.body.discardWithError(errStreamClosed)
 }

--- a/http2/server_test.go
+++ b/http2/server_test.go
@@ -108,6 +108,9 @@ func TestServerRequestResponse(t *testing.T) {
 	if got := resp.Header.Get("X-Method"); got != stdhttp.MethodPost {
 		t.Fatalf("X-Method = %q, want POST", got)
 	}
+	if resp.ContentLength != int64(len(body)) {
+		t.Fatalf("Content-Length = %d, want %d", resp.ContentLength, len(body))
+	}
 }
 
 func TestServerMultiplexesHandlers(t *testing.T) {

--- a/http2/server_test.go
+++ b/http2/server_test.go
@@ -1,0 +1,232 @@
+package http2
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	stdhttp "net/http"
+	"net/http/httptrace"
+	"net/textproto"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	xhttp2 "golang.org/x/net/http2"
+)
+
+type testServer struct {
+	server    *fasthttp.Server
+	listener  net.Listener
+	transport *xhttp2.Transport
+	client    *stdhttp.Client
+	serveDone chan error
+}
+
+func newTestServer(t *testing.T, server *fasthttp.Server, config ServerConfig) *testServer {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening: %v", err)
+	}
+	if err := ConfigureServer(server, config); err != nil {
+		listener.Close()
+		t.Fatalf("ConfigureServer() error: %v", err)
+	}
+	transport := &xhttp2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+	result := &testServer{
+		server:    server,
+		listener:  listener,
+		transport: transport,
+		client:    &stdhttp.Client{Transport: transport},
+		serveDone: make(chan error, 1),
+	}
+	go func() {
+		result.serveDone <- server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		transport.CloseIdleConnections()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.ShutdownWithContext(ctx)
+		select {
+		case err := <-result.serveDone:
+			if err != nil {
+				t.Errorf("Serve() error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Error("Serve() didn't return")
+		}
+	})
+	return result
+}
+
+func (s *testServer) URL(path string) string {
+	return "http://" + s.listener.Addr().String() + path
+}
+
+func TestServerRequestResponse(t *testing.T) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if got := string(ctx.Request.Header.Protocol()); got != "HTTP/2" {
+				t.Errorf("request protocol = %q, want HTTP/2", got)
+			}
+			ctx.Response.Header.Set("X-Method", string(ctx.Method()))
+			ctx.SetBody(ctx.Request.Body())
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+
+	body := bytes.Repeat([]byte("request-body-"), 10_000)
+	req, err := stdhttp.NewRequest(stdhttp.MethodPost, testServer.URL("/echo?q=1"), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest() error: %v", err)
+	}
+	resp, err := testServer.client.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	defer resp.Body.Close()
+	gotBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("response body length = %d, want %d", len(gotBody), len(body))
+	}
+	if got := resp.Header.Get("X-Method"); got != stdhttp.MethodPost {
+		t.Fatalf("X-Method = %q, want POST", got)
+	}
+}
+
+func TestServerMultiplexesHandlers(t *testing.T) {
+	slowStarted := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if string(ctx.Path()) == "/slow" {
+				close(slowStarted)
+				<-releaseSlow
+			}
+			ctx.SetBodyString(string(ctx.Path()))
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+
+	var slowResponse *stdhttp.Response
+	var slowErr error
+	var wait sync.WaitGroup
+	wait.Go(func() {
+		slowResponse, slowErr = testServer.client.Get(testServer.URL("/slow"))
+	})
+	select {
+	case <-slowStarted:
+	case <-time.After(time.Second):
+		t.Fatal("slow handler didn't start")
+	}
+
+	fastDone := make(chan struct{})
+	var fastResponse *stdhttp.Response
+	var fastErr error
+	go func() {
+		fastResponse, fastErr = testServer.client.Get(testServer.URL("/fast"))
+		close(fastDone)
+	}()
+	select {
+	case <-fastDone:
+	case <-time.After(time.Second):
+		t.Fatal("fast request was blocked by slow handler")
+	}
+	if fastErr != nil {
+		t.Fatalf("fast request error: %v", fastErr)
+	}
+	fastBody, err := io.ReadAll(fastResponse.Body)
+	fastResponse.Body.Close()
+	if err != nil || string(fastBody) != "/fast" {
+		t.Fatalf("fast response = %q, %v", fastBody, err)
+	}
+
+	close(releaseSlow)
+	wait.Wait()
+	if slowErr != nil {
+		t.Fatalf("slow request error: %v", slowErr)
+	}
+	slowResponse.Body.Close()
+}
+
+func TestServerStreamsRequestAndResponse(t *testing.T) {
+	server := &fasthttp.Server{
+		StreamRequestBody: true,
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			body, err := io.ReadAll(ctx.RequestBodyStream())
+			if err != nil {
+				t.Errorf("reading request stream: %v", err)
+				ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+				return
+			}
+			ctx.Response.SetBodyStream(bytes.NewReader(body), len(body))
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+
+	body := bytes.Repeat([]byte("streaming-body"), 20_000)
+	resp, err := testServer.client.Post(testServer.URL("/stream"), "application/octet-stream", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Post() error: %v", err)
+	}
+	defer resp.Body.Close()
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response stream: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("streamed response length = %d, want %d", len(got), len(body))
+	}
+}
+
+func TestServerEarlyHints(t *testing.T) {
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.Response.Header.Set("Link", "</style.css>; rel=preload")
+			if err := ctx.EarlyHints(); err != nil {
+				t.Errorf("EarlyHints() error: %v", err)
+			}
+			ctx.SetBodyString("ok")
+		},
+	}
+	testServer := newTestServer(t, server, ServerConfig{})
+
+	gotStatus := make(chan int, 1)
+	req, err := stdhttp.NewRequest(stdhttp.MethodGet, testServer.URL("/"), nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error: %v", err)
+	}
+	trace := &httptrace.ClientTrace{
+		Got1xxResponse: func(code int, _ textproto.MIMEHeader) error {
+			gotStatus <- code
+			return nil
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	resp, err := testServer.client.Do(req)
+	if err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	resp.Body.Close()
+	select {
+	case status := <-gotStatus:
+		if status != fasthttp.StatusEarlyHints {
+			t.Fatalf("informational status = %d, want 103", status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive early hints")
+	}
+}

--- a/http2/stream.go
+++ b/http2/stream.go
@@ -17,13 +17,22 @@ import (
 var errStreamClosed = errors.New("http2: stream closed")
 
 type requestBody struct {
-	mu       sync.Mutex
-	ready    *sync.Cond
-	buffer   bytes.Buffer
-	err      error
-	consume  func(int)
-	isClosed bool
+	mu          sync.Mutex
+	ready       *sync.Cond
+	chunks      []requestBodyChunk
+	chunkOffset int
+	buffered    int
+	err         error
+	consume     func(int)
+	isClosed    bool
 }
+
+type requestBodyChunk struct {
+	data    []byte
+	release func([]byte)
+}
+
+const maxRequestBodyChunks = 128
 
 type responseBody struct {
 	mu        sync.Mutex
@@ -129,10 +138,10 @@ func newRequestBody(consume func(int)) *requestBody {
 
 func (b *requestBody) Read(p []byte) (int, error) {
 	b.mu.Lock()
-	for b.buffer.Len() == 0 && !b.isClosed {
+	for b.buffered == 0 && !b.isClosed {
 		b.ready.Wait()
 	}
-	if b.buffer.Len() == 0 {
+	if b.buffered == 0 {
 		err := b.err
 		if err == nil {
 			err = io.EOF
@@ -140,30 +149,82 @@ func (b *requestBody) Read(p []byte) (int, error) {
 		b.mu.Unlock()
 		return 0, err
 	}
-	n, err := b.buffer.Read(p)
+	n := 0
+	for n < len(p) && len(b.chunks) != 0 {
+		chunk := &b.chunks[0]
+		copied := copy(p[n:], chunk.data[b.chunkOffset:])
+		n += copied
+		b.buffered -= copied
+		b.chunkOffset += copied
+		if b.chunkOffset != len(chunk.data) {
+			break
+		}
+		if chunk.release != nil {
+			chunk.release(chunk.data)
+		}
+		*chunk = requestBodyChunk{}
+		b.chunks = b.chunks[1:]
+		b.chunkOffset = 0
+	}
 	b.mu.Unlock()
 	if n > 0 && b.consume != nil {
 		b.consume(n)
 	}
-	return n, err
+	return n, nil
 }
 
 func (b *requestBody) Close() error {
-	b.closeWithError(errStreamClosed)
+	b.discardWithError(errStreamClosed)
 	return nil
 }
 
-func (b *requestBody) write(p []byte) error {
+func (b *requestBody) writeOwned(p []byte, release func([]byte)) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.isClosed {
+		if release != nil {
+			release(p)
+		}
 		return errStreamClosed
 	}
-	_, err := b.buffer.Write(p)
-	if err == nil {
-		b.ready.Broadcast()
+	if len(p) == 0 {
+		if release != nil {
+			release(p)
+		}
+		return nil
 	}
-	return err
+	if len(b.chunks) >= maxRequestBodyChunks {
+		b.compactLocked(p, release)
+	} else {
+		b.chunks = append(b.chunks, requestBodyChunk{data: p, release: release})
+		b.buffered += len(p)
+	}
+	b.ready.Broadcast()
+	return nil
+}
+
+func (b *requestBody) compactLocked(incoming []byte, releaseIncoming func([]byte)) {
+	data := make([]byte, b.buffered+len(incoming))
+	offset := 0
+	for i := range b.chunks {
+		chunk := &b.chunks[i]
+		start := 0
+		if i == 0 {
+			start = b.chunkOffset
+		}
+		offset += copy(data[offset:], chunk.data[start:])
+		if chunk.release != nil {
+			chunk.release(chunk.data)
+		}
+		*chunk = requestBodyChunk{}
+	}
+	copy(data[offset:], incoming)
+	if releaseIncoming != nil {
+		releaseIncoming(incoming)
+	}
+	b.chunks = append(b.chunks[:0], requestBodyChunk{data: data})
+	b.chunkOffset = 0
+	b.buffered += len(incoming)
 }
 
 func (b *requestBody) closeWithError(err error) {
@@ -176,11 +237,30 @@ func (b *requestBody) closeWithError(err error) {
 	b.mu.Unlock()
 }
 
+func (b *requestBody) discardWithError(err error) {
+	b.mu.Lock()
+	b.isClosed = true
+	b.err = err
+	for i := range b.chunks {
+		chunk := &b.chunks[i]
+		if chunk.release != nil {
+			chunk.release(chunk.data)
+		}
+		*chunk = requestBodyChunk{}
+	}
+	b.chunks = nil
+	b.chunkOffset = 0
+	b.buffered = 0
+	b.ready.Broadcast()
+	b.mu.Unlock()
+}
+
 type serverStream struct {
 	id             uint32
 	conn           *serverConn
-	ctx            context.Context
-	cancel         context.CancelCauseFunc
+	cancelMu       sync.Mutex
+	done           chan struct{}
+	cancelCause    error
 	request        *fasthttp.RequestCtx
 	body           *requestBody
 	maxBody        int
@@ -188,17 +268,19 @@ type serverStream struct {
 	expectedBody   int64
 	unconsumedFlow int64
 
-	remoteClosed   bool
-	localClosed    bool
-	isReset        bool
-	handlerStarted bool
-	handlerDone    bool
-	isPush         bool
-	pushDepth      uint8
-	priority       priority
+	remoteClosed       bool
+	localClosed        bool
+	isReset            bool
+	handlerStarted     bool
+	handlerDone        bool
+	isPush             bool
+	pushDepth          uint8
+	priority           priority
+	discardRequestBody bool
 
-	sendWindow int64
-	recvWindow int64
+	sendWindow          int64
+	recvWindow          int64
+	pendingWindowUpdate int64
 
 	pendingData         []byte
 	pendingAck          chan error
@@ -207,39 +289,96 @@ type serverStream struct {
 	responseHeaderSent  bool
 	responseBytes       int64
 	expectedResponse    int64
+	responsePumpStarted bool
+	responsePumpDone    bool
+	releasePending      bool
 
 	acceptMu      sync.Mutex
 	streamHandler fasthttp.StreamHandler
 }
 
+var serverStreamPool sync.Pool
+
+var closedStreamDone = func() <-chan struct{} {
+	done := make(chan struct{})
+	close(done)
+	return done
+}()
+
 func newServerStream(conn *serverConn, id uint32) *serverStream {
-	ctx, cancel := context.WithCancelCause(conn.ctx)
-	return &serverStream{
+	var stream *serverStream
+	if value := serverStreamPool.Get(); value != nil {
+		stream = value.(*serverStream) //nolint:forcetypeassert
+	} else {
+		stream = &serverStream{}
+	}
+	*stream = serverStream{
 		id:               id,
 		conn:             conn,
-		ctx:              ctx,
-		cancel:           cancel,
 		sendWindow:       conn.peerInitialStreamWindow,
 		recvWindow:       int64(conn.config.streamWindowSize),
 		expectedBody:     -1,
 		expectedResponse: -1,
 	}
+	return stream
+}
+
+func releaseServerStream(stream *serverStream) {
+	*stream = serverStream{}
+	serverStreamPool.Put(stream)
 }
 
 func (s *serverStream) Deadline() (time.Time, bool) {
-	return s.ctx.Deadline()
+	return time.Time{}, false
 }
 
 func (s *serverStream) Done() <-chan struct{} {
-	return s.ctx.Done()
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	if s.cancelCause != nil {
+		return closedStreamDone
+	}
+	if s.done == nil {
+		s.done = make(chan struct{})
+	}
+	return s.done
 }
 
 func (s *serverStream) Err() error {
-	return s.ctx.Err()
+	s.cancelMu.Lock()
+	canceled := s.cancelCause != nil
+	s.cancelMu.Unlock()
+	if canceled {
+		return context.Canceled
+	}
+	return nil
 }
 
 func (s *serverStream) Value(key any) any {
-	return s.ctx.Value(key)
+	return s.conn.ctx.Value(key)
+}
+
+func (s *serverStream) cancel(cause error) {
+	if cause == nil {
+		cause = context.Canceled
+	}
+	s.cancelMu.Lock()
+	if s.cancelCause == nil {
+		s.cancelCause = cause
+		if s.done != nil {
+			close(s.done)
+		}
+	}
+	s.cancelMu.Unlock()
+}
+
+func (s *serverStream) cause() error {
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	if s.cancelCause == nil {
+		return context.Canceled
+	}
+	return s.cancelCause
 }
 
 func (s *serverStream) WriteInformational(
@@ -261,14 +400,14 @@ func (s *serverStream) WriteInformational(
 	}
 	select {
 	case s.conn.commands <- command:
-	case <-s.ctx.Done():
-		return context.Cause(s.ctx)
+	case <-s.Done():
+		return s.cause()
 	}
 	select {
 	case err := <-result:
 		return err
-	case <-s.ctx.Done():
-		return context.Cause(s.ctx)
+	case <-s.Done():
+		return s.cause()
 	}
 }
 
@@ -291,18 +430,21 @@ func (s *serverStream) Push(target string, opts *fasthttp.PushOptions) error {
 	}
 	select {
 	case s.conn.commands <- command:
-	case <-s.ctx.Done():
-		return context.Cause(s.ctx)
+	case <-s.Done():
+		return s.cause()
 	}
 	select {
 	case err := <-result:
 		return err
-	case <-s.ctx.Done():
-		return context.Cause(s.ctx)
+	case <-s.Done():
+		return s.cause()
 	}
 }
 
 func (s *serverStream) AcceptStream(handler fasthttp.StreamHandler) error {
+	if handler == nil {
+		return errors.New("http2: stream handler is nil")
+	}
 	if !s.conn.config.enableExtendedConnect {
 		return fasthttp.ErrProtocolNotSupported
 	}
@@ -326,10 +468,40 @@ type streamConn struct {
 	readDeadline  time.Time
 	writeDeadline time.Time
 	isClosed      bool
+	readClosed    bool
+	writeClosed   bool
 }
 
 func (c *streamConn) Read(p []byte) (int, error) {
-	return c.read.Read(p)
+	c.mu.Lock()
+	if c.isClosed || c.readClosed {
+		c.mu.Unlock()
+		return 0, net.ErrClosed
+	}
+	deadline := c.readDeadline
+	c.mu.Unlock()
+	if !deadline.IsZero() && time.Until(deadline) <= 0 {
+		return 0, timeoutError{}
+	}
+
+	var expired chan struct{}
+	var timer *time.Timer
+	if !deadline.IsZero() {
+		expired = make(chan struct{})
+		timer = time.AfterFunc(time.Until(deadline), func() {
+			close(expired)
+			c.stream.cancelWithError(timeoutError{})
+		})
+	}
+	n, err := c.read.Read(p)
+	if timer != nil && !timer.Stop() {
+		select {
+		case <-expired:
+			return n, timeoutError{}
+		default:
+		}
+	}
+	return n, err
 }
 
 func (c *streamConn) Write(p []byte) (int, error) {
@@ -338,9 +510,10 @@ func (c *streamConn) Write(p []byte) (int, error) {
 	}
 	c.mu.Lock()
 	isClosed := c.isClosed
+	writeClosed := c.writeClosed
 	deadline := c.writeDeadline
 	c.mu.Unlock()
-	if isClosed {
+	if isClosed || writeClosed {
 		return 0, net.ErrClosed
 	}
 
@@ -358,8 +531,8 @@ func (c *streamConn) Write(p []byte) (int, error) {
 	}
 	select {
 	case c.stream.conn.commands <- command:
-	case <-c.stream.ctx.Done():
-		return 0, context.Cause(c.stream.ctx)
+	case <-c.stream.Done():
+		return 0, c.stream.cause()
 	case <-timer:
 		return 0, timeoutError{}
 	}
@@ -369,8 +542,8 @@ func (c *streamConn) Write(p []byte) (int, error) {
 			return 0, err
 		}
 		return len(p), nil
-	case <-c.stream.ctx.Done():
-		return 0, context.Cause(c.stream.ctx)
+	case <-c.stream.Done():
+		return 0, c.stream.cause()
 	case <-timer:
 		return 0, timeoutError{}
 	}
@@ -383,18 +556,53 @@ func (c *streamConn) Close() error {
 		return nil
 	}
 	c.isClosed = true
+	readClosed := c.readClosed
+	writeClosed := c.writeClosed
 	c.mu.Unlock()
-	return c.CloseWrite()
+	var readErr, writeErr error
+	if !readClosed {
+		readErr = c.CloseRead()
+	}
+	if !writeClosed {
+		writeErr = c.CloseWrite()
+	}
+	return errors.Join(readErr, writeErr)
 }
 
 func (c *streamConn) CloseRead() error {
-	if c.stream.body != nil {
-		return c.stream.body.Close()
+	c.mu.Lock()
+	if c.readClosed {
+		c.mu.Unlock()
+		return nil
 	}
-	return nil
+	c.readClosed = true
+	c.mu.Unlock()
+	result := make(chan error, 1)
+	select {
+	case c.stream.conn.commands <- serverCommand{
+		kind:     serverCommandCloseRead,
+		streamID: c.stream.id,
+		result:   result,
+	}:
+	case <-c.stream.Done():
+		return c.stream.cause()
+	}
+	select {
+	case err := <-result:
+		return err
+	case <-c.stream.Done():
+		return c.stream.cause()
+	}
 }
 
 func (c *streamConn) CloseWrite() error {
+	c.mu.Lock()
+	if c.writeClosed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.writeClosed = true
+	c.mu.Unlock()
 	result := make(chan error, 1)
 	command := serverCommand{
 		kind:     serverCommandResponseEOF,
@@ -403,14 +611,14 @@ func (c *streamConn) CloseWrite() error {
 	}
 	select {
 	case c.stream.conn.commands <- command:
-	case <-c.stream.ctx.Done():
-		return context.Cause(c.stream.ctx)
+	case <-c.stream.Done():
+		return c.stream.cause()
 	}
 	select {
 	case err := <-result:
 		return err
-	case <-c.stream.ctx.Done():
-		return context.Cause(c.stream.ctx)
+	case <-c.stream.Done():
+		return c.stream.cause()
 	}
 }
 
@@ -449,6 +657,19 @@ type timeoutError struct{}
 func (timeoutError) Error() string   { return "http2: stream deadline exceeded" }
 func (timeoutError) Timeout() bool   { return true }
 func (timeoutError) Temporary() bool { return true }
+
+func (s *serverStream) cancelWithError(cause error) {
+	result := make(chan error, 1)
+	select {
+	case s.conn.commands <- serverCommand{
+		kind:     serverCommandCancelStream,
+		streamID: s.id,
+		err:      cause,
+		result:   result,
+	}:
+	case <-s.Done():
+	}
+}
 
 type clientStreamConn struct {
 	stream *clientStream

--- a/http2/stream.go
+++ b/http2/stream.go
@@ -1,0 +1,595 @@
+package http2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	xhttp2 "golang.org/x/net/http2"
+)
+
+var errStreamClosed = errors.New("http2: stream closed")
+
+type requestBody struct {
+	mu       sync.Mutex
+	ready    *sync.Cond
+	buffer   bytes.Buffer
+	err      error
+	consume  func(int)
+	isClosed bool
+}
+
+type responseBody struct {
+	mu        sync.Mutex
+	ready     *sync.Cond
+	buffer    bytes.Buffer
+	err       error
+	isClosed  bool
+	isDone    bool
+	consume   func(int)
+	closeBody func(int)
+	done      func()
+}
+
+func newResponseBody(consume, closeBody func(int), done func()) *responseBody {
+	body := &responseBody{consume: consume, closeBody: closeBody, done: done}
+	body.ready = sync.NewCond(&body.mu)
+	return body
+}
+
+func (b *responseBody) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	for b.buffer.Len() == 0 && !b.isClosed {
+		b.ready.Wait()
+	}
+	if b.buffer.Len() == 0 {
+		err := b.err
+		if err == nil {
+			err = io.EOF
+		}
+		done := b.markDoneLocked()
+		b.mu.Unlock()
+		if done != nil {
+			done()
+		}
+		return 0, err
+	}
+	n, err := b.buffer.Read(p)
+	b.mu.Unlock()
+	if n > 0 && b.consume != nil {
+		b.consume(n)
+	}
+	return n, err
+}
+
+func (b *responseBody) Close() error {
+	b.mu.Lock()
+	if b.isDone {
+		b.mu.Unlock()
+		return nil
+	}
+	discarded := b.buffer.Len()
+	b.buffer.Reset()
+	b.isClosed = true
+	b.err = net.ErrClosed
+	b.ready.Broadcast()
+	done := b.markDoneLocked()
+	b.mu.Unlock()
+	if b.closeBody != nil {
+		b.closeBody(discarded)
+	}
+	if done != nil {
+		done()
+	}
+	return nil
+}
+
+func (b *responseBody) write(p []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.isClosed {
+		return errStreamClosed
+	}
+	_, err := b.buffer.Write(p)
+	if err == nil {
+		b.ready.Broadcast()
+	}
+	return err
+}
+
+func (b *responseBody) closeWithError(err error) {
+	b.mu.Lock()
+	if !b.isClosed {
+		b.isClosed = true
+		b.err = err
+		b.ready.Broadcast()
+	}
+	b.mu.Unlock()
+}
+
+func (b *responseBody) markDoneLocked() func() {
+	if b.isDone {
+		return nil
+	}
+	b.isDone = true
+	return b.done
+}
+
+func newRequestBody(consume func(int)) *requestBody {
+	body := &requestBody{consume: consume}
+	body.ready = sync.NewCond(&body.mu)
+	return body
+}
+
+func (b *requestBody) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	for b.buffer.Len() == 0 && !b.isClosed {
+		b.ready.Wait()
+	}
+	if b.buffer.Len() == 0 {
+		err := b.err
+		if err == nil {
+			err = io.EOF
+		}
+		b.mu.Unlock()
+		return 0, err
+	}
+	n, err := b.buffer.Read(p)
+	b.mu.Unlock()
+	if n > 0 && b.consume != nil {
+		b.consume(n)
+	}
+	return n, err
+}
+
+func (b *requestBody) Close() error {
+	b.closeWithError(errStreamClosed)
+	return nil
+}
+
+func (b *requestBody) write(p []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.isClosed {
+		return errStreamClosed
+	}
+	_, err := b.buffer.Write(p)
+	if err == nil {
+		b.ready.Broadcast()
+	}
+	return err
+}
+
+func (b *requestBody) closeWithError(err error) {
+	b.mu.Lock()
+	if !b.isClosed {
+		b.isClosed = true
+		b.err = err
+		b.ready.Broadcast()
+	}
+	b.mu.Unlock()
+}
+
+type serverStream struct {
+	id             uint32
+	conn           *serverConn
+	ctx            context.Context
+	cancel         context.CancelCauseFunc
+	request        *fasthttp.RequestCtx
+	body           *requestBody
+	maxBody        int
+	bodyBytes      int64
+	expectedBody   int64
+	unconsumedFlow int64
+
+	remoteClosed   bool
+	localClosed    bool
+	isReset        bool
+	handlerStarted bool
+	handlerDone    bool
+	isPush         bool
+	pushDepth      uint8
+	priority       priority
+
+	sendWindow int64
+	recvWindow int64
+
+	pendingData         []byte
+	pendingAck          chan error
+	responseEOF         bool
+	responseHasTrailers bool
+	responseHeaderSent  bool
+	responseBytes       int64
+	expectedResponse    int64
+
+	acceptMu      sync.Mutex
+	streamHandler fasthttp.StreamHandler
+}
+
+func newServerStream(conn *serverConn, id uint32) *serverStream {
+	ctx, cancel := context.WithCancelCause(conn.ctx)
+	return &serverStream{
+		id:               id,
+		conn:             conn,
+		ctx:              ctx,
+		cancel:           cancel,
+		sendWindow:       conn.peerInitialStreamWindow,
+		recvWindow:       int64(conn.config.streamWindowSize),
+		expectedBody:     -1,
+		expectedResponse: -1,
+	}
+}
+
+func (s *serverStream) Deadline() (time.Time, bool) {
+	return s.ctx.Deadline()
+}
+
+func (s *serverStream) Done() <-chan struct{} {
+	return s.ctx.Done()
+}
+
+func (s *serverStream) Err() error {
+	return s.ctx.Err()
+}
+
+func (s *serverStream) Value(key any) any {
+	return s.ctx.Value(key)
+}
+
+func (s *serverStream) WriteInformational(
+	statusCode int,
+	header *fasthttp.ResponseHeader,
+) error {
+	if statusCode < 100 || statusCode >= 200 {
+		return errors.New("http2: informational status must be between 100 and 199")
+	}
+	copyHeader := &fasthttp.ResponseHeader{}
+	header.CopyTo(copyHeader)
+	result := make(chan error, 1)
+	command := serverCommand{
+		kind:       serverCommandInformational,
+		streamID:   s.id,
+		statusCode: statusCode,
+		header:     copyHeader,
+		result:     result,
+	}
+	select {
+	case s.conn.commands <- command:
+	case <-s.ctx.Done():
+		return context.Cause(s.ctx)
+	}
+	select {
+	case err := <-result:
+		return err
+	case <-s.ctx.Done():
+		return context.Cause(s.ctx)
+	}
+}
+
+func (s *serverStream) Push(target string, opts *fasthttp.PushOptions) error {
+	var copiedOpts *fasthttp.PushOptions
+	if opts != nil {
+		copiedOpts = &fasthttp.PushOptions{Method: opts.Method}
+		if opts.Header != nil {
+			copiedOpts.Header = &fasthttp.RequestHeader{}
+			opts.Header.CopyTo(copiedOpts.Header)
+		}
+	}
+	result := make(chan error, 1)
+	command := serverCommand{
+		kind:     serverCommandPush,
+		streamID: s.id,
+		target:   strings.Clone(target),
+		pushOpts: copiedOpts,
+		result:   result,
+	}
+	select {
+	case s.conn.commands <- command:
+	case <-s.ctx.Done():
+		return context.Cause(s.ctx)
+	}
+	select {
+	case err := <-result:
+		return err
+	case <-s.ctx.Done():
+		return context.Cause(s.ctx)
+	}
+}
+
+func (s *serverStream) AcceptStream(handler fasthttp.StreamHandler) error {
+	if !s.conn.config.enableExtendedConnect {
+		return fasthttp.ErrProtocolNotSupported
+	}
+	if len(s.request.Request.Header.ConnectProtocol()) == 0 {
+		return errors.New("http2: request isn't an extended connect")
+	}
+	s.acceptMu.Lock()
+	defer s.acceptMu.Unlock()
+	if s.streamHandler != nil {
+		return errors.New("http2: stream is already accepted")
+	}
+	s.streamHandler = handler
+	return nil
+}
+
+type streamConn struct {
+	stream *serverStream
+	read   io.Reader
+
+	mu            sync.Mutex
+	readDeadline  time.Time
+	writeDeadline time.Time
+	isClosed      bool
+}
+
+func (c *streamConn) Read(p []byte) (int, error) {
+	return c.read.Read(p)
+}
+
+func (c *streamConn) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	c.mu.Lock()
+	isClosed := c.isClosed
+	deadline := c.writeDeadline
+	c.mu.Unlock()
+	if isClosed {
+		return 0, net.ErrClosed
+	}
+
+	result := make(chan error, 1)
+	data := bytes.Clone(p)
+	command := serverCommand{
+		kind:     serverCommandResponseData,
+		streamID: c.stream.id,
+		data:     data,
+		result:   result,
+	}
+	var timer <-chan time.Time
+	if !deadline.IsZero() {
+		timer = time.After(time.Until(deadline))
+	}
+	select {
+	case c.stream.conn.commands <- command:
+	case <-c.stream.ctx.Done():
+		return 0, context.Cause(c.stream.ctx)
+	case <-timer:
+		return 0, timeoutError{}
+	}
+	select {
+	case err := <-result:
+		if err != nil {
+			return 0, err
+		}
+		return len(p), nil
+	case <-c.stream.ctx.Done():
+		return 0, context.Cause(c.stream.ctx)
+	case <-timer:
+		return 0, timeoutError{}
+	}
+}
+
+func (c *streamConn) Close() error {
+	c.mu.Lock()
+	if c.isClosed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.isClosed = true
+	c.mu.Unlock()
+	return c.CloseWrite()
+}
+
+func (c *streamConn) CloseRead() error {
+	if c.stream.body != nil {
+		return c.stream.body.Close()
+	}
+	return nil
+}
+
+func (c *streamConn) CloseWrite() error {
+	result := make(chan error, 1)
+	command := serverCommand{
+		kind:     serverCommandResponseEOF,
+		streamID: c.stream.id,
+		result:   result,
+	}
+	select {
+	case c.stream.conn.commands <- command:
+	case <-c.stream.ctx.Done():
+		return context.Cause(c.stream.ctx)
+	}
+	select {
+	case err := <-result:
+		return err
+	case <-c.stream.ctx.Done():
+		return context.Cause(c.stream.ctx)
+	}
+}
+
+func (c *streamConn) LocalAddr() net.Addr {
+	return c.stream.conn.conn.LocalAddr()
+}
+
+func (c *streamConn) RemoteAddr() net.Addr {
+	return c.stream.conn.conn.RemoteAddr()
+}
+
+func (c *streamConn) SetDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	c.readDeadline = deadline
+	c.writeDeadline = deadline
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *streamConn) SetReadDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	c.readDeadline = deadline
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *streamConn) SetWriteDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	c.writeDeadline = deadline
+	c.mu.Unlock()
+	return nil
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "http2: stream deadline exceeded" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+type clientStreamConn struct {
+	stream *clientStream
+	read   *responseBody
+
+	mu            sync.Mutex
+	readDeadline  time.Time
+	writeDeadline time.Time
+	readClosed    bool
+	writeClosed   bool
+	closed        bool
+}
+
+func (c *clientStreamConn) Read(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.readClosed || c.closed {
+		c.mu.Unlock()
+		return 0, net.ErrClosed
+	}
+	deadline := c.readDeadline
+	c.mu.Unlock()
+	if !deadline.IsZero() && time.Until(deadline) <= 0 {
+		return 0, timeoutError{}
+	}
+
+	var expired chan struct{}
+	var timer *time.Timer
+	if !deadline.IsZero() {
+		expired = make(chan struct{})
+		timer = time.AfterFunc(time.Until(deadline), func() {
+			close(expired)
+			c.stream.conn.resetStream(c.stream.id, xhttp2.ErrCodeCancel, timeoutError{}, false)
+		})
+	}
+	n, err := c.read.Read(p)
+	if timer != nil && !timer.Stop() {
+		select {
+		case <-expired:
+			return n, timeoutError{}
+		default:
+		}
+	}
+	return n, err
+}
+
+func (c *clientStreamConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.writeClosed || c.closed {
+		c.mu.Unlock()
+		return 0, net.ErrClosed
+	}
+	deadline := c.writeDeadline
+	c.mu.Unlock()
+	if err := c.stream.conn.sendData(c.stream, p, false, deadline); err != nil {
+		if errors.Is(err, fasthttp.ErrTimeout) {
+			c.stream.conn.resetStream(c.stream.id, xhttp2.ErrCodeCancel, timeoutError{}, false)
+			return 0, timeoutError{}
+		}
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *clientStreamConn) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	readClosed := c.readClosed
+	writeClosed := c.writeClosed
+	c.readClosed = true
+	c.writeClosed = true
+	deadline := c.writeDeadline
+	c.mu.Unlock()
+	if !readClosed {
+		_ = c.read.Close()
+	}
+	if !writeClosed {
+		return c.stream.conn.sendData(c.stream, nil, true, deadline)
+	}
+	return nil
+}
+
+func (c *clientStreamConn) CloseRead() error {
+	c.mu.Lock()
+	if c.readClosed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.readClosed = true
+	c.mu.Unlock()
+	return c.read.Close()
+}
+
+func (c *clientStreamConn) CloseWrite() error {
+	c.mu.Lock()
+	if c.writeClosed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.writeClosed = true
+	deadline := c.writeDeadline
+	c.mu.Unlock()
+	return c.stream.conn.sendData(c.stream, nil, true, deadline)
+}
+
+func (c *clientStreamConn) LocalAddr() net.Addr {
+	return c.stream.conn.conn.LocalAddr()
+}
+
+func (c *clientStreamConn) RemoteAddr() net.Addr {
+	return c.stream.conn.conn.RemoteAddr()
+}
+
+func (c *clientStreamConn) SetDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	c.readDeadline = deadline
+	c.writeDeadline = deadline
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *clientStreamConn) SetReadDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	c.readDeadline = deadline
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *clientStreamConn) SetWriteDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	c.writeDeadline = deadline
+	c.mu.Unlock()
+	return nil
+}
+
+var _ fasthttp.ProtocolStream = (*serverStream)(nil)
+var _ fasthttp.InformationalResponseWriter = (*serverStream)(nil)
+var _ fasthttp.Pusher = (*serverStream)(nil)
+var _ fasthttp.StreamAccepter = (*serverStream)(nil)
+var _ fasthttp.StreamConn = (*streamConn)(nil)
+var _ fasthttp.StreamConn = (*clientStreamConn)(nil)

--- a/http2/timeouts.go
+++ b/http2/timeouts.go
@@ -1,0 +1,53 @@
+package http2
+
+import (
+	"errors"
+	"net"
+	"time"
+)
+
+type deadlineWriter struct {
+	conn    net.Conn
+	timeout time.Duration
+}
+
+func (w *deadlineWriter) Write(p []byte) (int, error) {
+	if err := w.conn.SetWriteDeadline(time.Now().Add(w.timeout)); err != nil {
+		return 0, err
+	}
+	n, err := w.conn.Write(p)
+	clearErr := w.conn.SetWriteDeadline(time.Time{})
+	if err != nil {
+		return n, err
+	}
+	return n, clearErr
+}
+
+func timerChannel(timer *time.Timer) <-chan time.Time {
+	if timer == nil {
+		return nil
+	}
+	return timer.C
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func resetTimer(timer *time.Timer, duration time.Duration) {
+	stopTimer(timer)
+	timer.Reset(duration)
+}
+
+func isTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/http2/tls.go
+++ b/http2/tls.go
@@ -1,0 +1,38 @@
+package http2
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+)
+
+var errInadequateTLS = errors.New("http2: TLS parameters don't satisfy RFC 9113")
+
+type tlsConnectionStater interface {
+	ConnectionState() tls.ConnectionState
+}
+
+func validateTLSConnection(conn net.Conn) error {
+	tlsConn, ok := conn.(tlsConnectionStater)
+	if !ok {
+		return nil
+	}
+	state := tlsConn.ConnectionState()
+	if state.Version < tls.VersionTLS12 {
+		return errInadequateTLS
+	}
+	if state.Version >= tls.VersionTLS13 {
+		return nil
+	}
+	switch state.CipherSuite {
+	case tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:
+		return nil
+	default:
+		return errInadequateTLS
+	}
+}

--- a/protocol.go
+++ b/protocol.go
@@ -15,7 +15,16 @@ import (
 // ErrProtocolNotSupported is returned when the protocol serving a request
 // doesn't implement an optional operation such as server push or a
 // bidirectional request stream.
-var ErrProtocolNotSupported = errors.New("fasthttp: protocol operation not supported")
+var (
+	ErrProtocolNotSupported = errors.New("fasthttp: protocol operation not supported")
+	// ErrPushDisabled is returned when either endpoint disabled server push.
+	ErrPushDisabled = errors.New("fasthttp: server push is disabled")
+	// ErrPushLimit is returned when a protocol's promised-stream limit is full.
+	ErrPushLimit = errors.New("fasthttp: server push limit reached")
+	// ErrPushNotAllowed is returned when Push is called after the parent stream
+	// can no longer initiate a promised request.
+	ErrPushNotAllowed = errors.New("fasthttp: server push isn't allowed in this stream state")
+)
 
 // ProtocolHandler serves a connection selected by ALPN or a cleartext
 // connection preface.
@@ -122,6 +131,44 @@ type ProtocolServerContext struct {
 	connID       uint64
 	requestCount atomic.Uint64
 	active       atomic.Int32
+}
+
+// ServeProtocolConn serves c directly with handler while applying Server's
+// connection limits, lifecycle accounting, and ConnState callbacks. It is
+// intended for protocol packages that expose a dedicated prior-knowledge
+// listener.
+//
+// ServeProtocolConn closes c before returning.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (s *Server) ServeProtocolConn(c net.Conn, handler ProtocolHandler) error {
+	if isNilProtocolHandler(handler) {
+		return errors.New("fasthttp: protocol handler is nil")
+	}
+	if s.MaxConnsPerIP > 0 {
+		perIPConn := wrapPerIPConn(s, c)
+		if perIPConn == nil {
+			return ErrPerIPConnLimit
+		}
+		c = perIPConn
+	}
+	if !s.tryAcquireConcurrency() {
+		s.writeFastError(c, StatusServiceUnavailable, "The connection cannot be served because Server.Concurrency limit exceeded")
+		_ = c.Close()
+		return ErrConcurrencyLimit
+	}
+	defer s.releaseConcurrency()
+
+	s.open.Add(1)
+	defer s.open.Add(-1)
+	err := s.serveProtocolConn(c, &registeredProtocol{handler: handler})
+	closeErr := c.Close()
+	s.setState(c, StateClosed)
+	if err != nil {
+		return err
+	}
+	return closeErr
 }
 
 // Server returns the Server that dispatched this protocol connection.

--- a/protocol.go
+++ b/protocol.go
@@ -168,6 +168,9 @@ func (s *Server) ServeProtocolConn(c net.Conn, handler ProtocolHandler) error {
 	if err != nil {
 		return err
 	}
+	if errors.Is(closeErr, net.ErrClosed) {
+		return nil
+	}
 	return closeErr
 }
 
@@ -180,6 +183,13 @@ func (ctx *ProtocolServerContext) Server() *Server {
 // serving a standalone connection for which shutdown isn't configured.
 func (ctx *ProtocolServerContext) Done() <-chan struct{} {
 	return ctx.server.done
+}
+
+// ServerDate returns the Server's cached RFC 1123 Date header value. The
+// returned bytes are read-only and remain valid until the next cache refresh.
+func (ctx *ProtocolServerContext) ServerDate() []byte {
+	serverDateOnce.Do(updateServerDate)
+	return *serverDate.Load()
 }
 
 // AcquireRequestCtx obtains a RequestCtx owned by the Server and binds it to a
@@ -337,6 +347,8 @@ func (s *Server) serveProtocolConn(c net.Conn, protocol *registeredProtocol) err
 	connTime := time.Now()
 	idleConnTime := s.registerIdleConn(c, connTime.Add(5*time.Second))
 	defer s.unregisterIdleConn(c, idleConnTime)
+	s.registerProtocolConn(c)
+	defer s.unregisterProtocolConn(c)
 
 	ctx := &ProtocolServerContext{
 		server:       s,
@@ -346,6 +358,21 @@ func (s *Server) serveProtocolConn(c net.Conn, protocol *registeredProtocol) err
 		connID:       nextConnID(),
 	}
 	return protocol.handler.ServeConn(ctx, c)
+}
+
+func (s *Server) registerProtocolConn(c net.Conn) {
+	s.idleConnsMu.Lock()
+	if s.protocolConns == nil {
+		s.protocolConns = make(map[net.Conn]struct{})
+	}
+	s.protocolConns[c] = struct{}{}
+	s.idleConnsMu.Unlock()
+}
+
+func (s *Server) unregisterProtocolConn(c net.Conn) {
+	s.idleConnsMu.Lock()
+	delete(s.protocolConns, c)
+	s.idleConnsMu.Unlock()
 }
 
 func (s *Server) registerIdleConn(c net.Conn, idleAt time.Time) *atomic.Int64 {

--- a/protocol.go
+++ b/protocol.go
@@ -1,0 +1,405 @@
+package fasthttp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+	"sync/atomic"
+	"time"
+)
+
+// ErrProtocolNotSupported is returned when the protocol serving a request
+// doesn't implement an optional operation such as server push or a
+// bidirectional request stream.
+var ErrProtocolNotSupported = errors.New("fasthttp: protocol operation not supported")
+
+// ProtocolHandler serves a connection selected by ALPN or a cleartext
+// connection preface.
+//
+// Experimental: this interface may change before it has shipped in two
+// fasthttp minor releases.
+type ProtocolHandler interface {
+	ServeConn(ctx *ProtocolServerContext, c net.Conn) error
+}
+
+// ProtocolRegistration describes a connection-oriented HTTP protocol that a
+// Server can dispatch before its HTTP/1 parser runs.
+//
+// ALPN and CleartextPreface are copied by RegisterProtocol. At least one must
+// be set. CleartextPreface is matched only on non-TLS connections.
+//
+// Experimental: this type may change before it has shipped in two fasthttp
+// minor releases.
+type ProtocolRegistration struct {
+	ALPN             []string
+	CleartextPreface []byte
+	Handler          ProtocolHandler
+}
+
+type registeredProtocol struct {
+	alpn             []string
+	cleartextPreface []byte
+	handler          ProtocolHandler
+}
+
+// InformationalResponseWriter is implemented by protocols that can write an
+// informational response without completing the request.
+//
+// Experimental: this interface may change before it has shipped in two
+// fasthttp minor releases.
+type InformationalResponseWriter interface {
+	WriteInformational(statusCode int, header *ResponseHeader) error
+}
+
+// Pusher is implemented by protocols that support server push.
+//
+// Experimental: this interface may change before it has shipped in two
+// fasthttp minor releases.
+type Pusher interface {
+	Push(target string, opts *PushOptions) error
+}
+
+// StreamAccepter is implemented by protocols that support accepting a
+// bidirectional stream associated with a request.
+//
+// Experimental: this interface may change before it has shipped in two
+// fasthttp minor releases.
+type StreamAccepter interface {
+	AcceptStream(handler StreamHandler) error
+}
+
+// ProtocolStream supplies request-scoped cancellation and optional protocol
+// operations to RequestCtx.
+//
+// Implementations may additionally implement InformationalResponseWriter,
+// Pusher, and StreamAccepter.
+//
+// Experimental: this interface may change before it has shipped in two
+// fasthttp minor releases.
+type ProtocolStream interface {
+	context.Context
+}
+
+// PushOptions configures a server push request. Method defaults to GET. Header
+// is copied before Push returns.
+//
+// Experimental: this type may change before it has shipped in two fasthttp
+// minor releases.
+type PushOptions struct {
+	Method string
+	Header *RequestHeader
+}
+
+// StreamConn is a request-scoped, bidirectional stream. Closing or applying a
+// deadline to a StreamConn must not affect other streams on the same physical
+// connection.
+//
+// Experimental: this interface may change before it has shipped in two
+// fasthttp minor releases.
+type StreamConn interface {
+	net.Conn
+	CloseRead() error
+	CloseWrite() error
+}
+
+// StreamHandler processes a bidirectional request stream.
+type StreamHandler func(StreamConn)
+
+// ProtocolServerContext connects a ProtocolHandler to one Server. A context is
+// valid only for the duration of ProtocolHandler.ServeConn.
+//
+// Experimental: this type may change before it has shipped in two fasthttp
+// minor releases.
+type ProtocolServerContext struct {
+	server       *Server
+	conn         net.Conn
+	idleConnTime *atomic.Int64
+	connTime     time.Time
+	connID       uint64
+	requestCount atomic.Uint64
+	active       atomic.Int32
+}
+
+// Server returns the Server that dispatched this protocol connection.
+func (ctx *ProtocolServerContext) Server() *Server {
+	return ctx.server
+}
+
+// Done is closed when the Server starts shutting down. It may return nil when
+// serving a standalone connection for which shutdown isn't configured.
+func (ctx *ProtocolServerContext) Done() <-chan struct{} {
+	return ctx.server.done
+}
+
+// AcquireRequestCtx obtains a RequestCtx owned by the Server and binds it to a
+// protocol stream. The caller must pair every successful call with
+// ReleaseRequestCtx after all response and stream work is complete.
+func (ctx *ProtocolServerContext) AcquireRequestCtx(c net.Conn, stream ProtocolStream) *RequestCtx {
+	if c == nil {
+		c = ctx.conn
+	}
+
+	requestCtx := ctx.server.acquireCtx(c)
+	requestCtx.connTime = ctx.connTime
+	requestCtx.time = time.Now()
+	requestCtx.connID = ctx.connID
+	requestCtx.connRequestNum = ctx.requestCount.Add(1)
+	requestCtx.protocolStream = stream
+	requestCtx.protocolOwner = ctx
+
+	if ctx.active.Add(1) == 1 {
+		ctx.idleConnTime.Store(0)
+		ctx.server.setState(ctx.conn, StateActive)
+	}
+
+	return requestCtx
+}
+
+// ReleaseRequestCtx returns a context acquired with AcquireRequestCtx to the
+// Server pool.
+func (ctx *ProtocolServerContext) ReleaseRequestCtx(requestCtx *RequestCtx) {
+	if requestCtx == nil || requestCtx.s != ctx.server || requestCtx.protocolOwner != ctx {
+		panic("BUG: releasing a request context to the wrong protocol server")
+	}
+
+	requestCtx.protocolOwner = nil
+	ctx.server.releaseCtx(requestCtx)
+	active := ctx.active.Add(-1)
+	if active < 0 {
+		panic("BUG: protocol request context released more than once")
+	}
+	if active == 0 {
+		ctx.idleConnTime.Store(time.Now().Unix())
+		ctx.server.setState(ctx.conn, StateIdle)
+	}
+}
+
+// RegisterProtocol registers a connection-oriented HTTP protocol. It must be
+// called before the Server starts serving.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (s *Server) RegisterProtocol(registration ProtocolRegistration) error {
+	if isNilProtocolHandler(registration.Handler) {
+		return errors.New("fasthttp: protocol handler is nil")
+	}
+	if len(registration.ALPN) == 0 && len(registration.CleartextPreface) == 0 {
+		return errors.New("fasthttp: protocol registration has no selector")
+	}
+
+	alpn := append([]string(nil), registration.ALPN...)
+	preface := bytes.Clone(registration.CleartextPreface)
+	seenALPN := make(map[string]struct{}, len(alpn))
+	for _, protocol := range alpn {
+		if protocol == "" {
+			return errors.New("fasthttp: protocol alpn is empty")
+		}
+		if _, ok := seenALPN[protocol]; ok {
+			return fmt.Errorf("fasthttp: protocol alpn %q is duplicated", protocol)
+		}
+		seenALPN[protocol] = struct{}{}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.ln) != 0 || s.open.Load() != 0 {
+		return errors.New("fasthttp: cannot register a protocol after serving starts")
+	}
+
+	for _, existing := range s.protocols {
+		for _, protocol := range alpn {
+			if existing.matchesALPN(protocol) {
+				return fmt.Errorf("fasthttp: protocol alpn %q is already registered", protocol)
+			}
+		}
+		if prefacesConflict(existing.cleartextPreface, preface) {
+			return errors.New("fasthttp: protocol cleartext prefaces conflict")
+		}
+	}
+
+	for _, protocol := range alpn {
+		if _, ok := s.nextProtos[protocol]; ok {
+			return fmt.Errorf("fasthttp: protocol alpn %q is already registered by NextProto", protocol)
+		}
+	}
+
+	s.protocols = append(s.protocols, registeredProtocol{
+		alpn:             alpn,
+		cleartextPreface: preface,
+		handler:          registration.Handler,
+	})
+	if len(alpn) != 0 {
+		s.configTLS()
+		for _, protocol := range alpn {
+			if !containsString(s.TLSConfig.NextProtos, protocol) {
+				s.TLSConfig.NextProtos = append(s.TLSConfig.NextProtos, protocol)
+			}
+		}
+	}
+
+	return nil
+}
+
+func isNilProtocolHandler(handler ProtocolHandler) bool {
+	if handler == nil {
+		return true
+	}
+	value := reflect.ValueOf(handler)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func prefacesConflict(a, b []byte) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	return bytes.HasPrefix(a, b) || bytes.HasPrefix(b, a)
+}
+
+func (p *registeredProtocol) matchesALPN(protocol string) bool {
+	return containsString(p.alpn, protocol)
+}
+
+func (s *Server) protocolByALPN(protocol string) *registeredProtocol {
+	for i := range s.protocols {
+		if s.protocols[i].matchesALPN(protocol) {
+			return &s.protocols[i]
+		}
+	}
+	return nil
+}
+
+func (s *Server) serveProtocolConn(c net.Conn, protocol *registeredProtocol) error {
+	connTime := time.Now()
+	idleConnTime := s.registerIdleConn(c, connTime.Add(5*time.Second))
+	defer s.unregisterIdleConn(c, idleConnTime)
+
+	ctx := &ProtocolServerContext{
+		server:       s,
+		conn:         c,
+		idleConnTime: idleConnTime,
+		connTime:     connTime,
+		connID:       nextConnID(),
+	}
+	return protocol.handler.ServeConn(ctx, c)
+}
+
+func (s *Server) registerIdleConn(c net.Conn, idleAt time.Time) *atomic.Int64 {
+	s.idleConnsMu.Lock()
+	defer s.idleConnsMu.Unlock()
+	if s.idleConns == nil {
+		s.idleConns = make(map[net.Conn]*atomic.Int64)
+	}
+	if idleConnTime := s.idleConns[c]; idleConnTime != nil {
+		idleConnTime.Store(idleAt.Unix())
+		return idleConnTime
+	}
+
+	value := idleConnTimePool.Get()
+	if value == nil {
+		value = &atomic.Int64{}
+	}
+	idleConnTime := value.(*atomic.Int64) //nolint:forcetypeassert
+	idleConnTime.Store(idleAt.Unix())
+	s.idleConns[c] = idleConnTime
+	return idleConnTime
+}
+
+func (s *Server) unregisterIdleConn(c net.Conn, idleConnTime *atomic.Int64) {
+	s.idleConnsMu.Lock()
+	if s.idleConns[c] == idleConnTime {
+		delete(s.idleConns, c)
+	}
+	s.idleConnsMu.Unlock()
+	idleConnTimePool.Put(idleConnTime)
+}
+
+type replayConn struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (c *replayConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+func (s *Server) detectCleartextProtocol(c net.Conn) (*registeredProtocol, net.Conn, error) {
+	if _, isTLS := c.(tlsConn); isTLS {
+		return nil, c, nil
+	}
+
+	candidates := make([]*registeredProtocol, 0, len(s.protocols))
+	maxPrefaceLen := 0
+	for i := range s.protocols {
+		preface := s.protocols[i].cleartextPreface
+		if len(preface) == 0 {
+			continue
+		}
+		candidates = append(candidates, &s.protocols[i])
+		if len(preface) > maxPrefaceLen {
+			maxPrefaceLen = len(preface)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, c, nil
+	}
+
+	if s.ReadTimeout > 0 {
+		if err := c.SetReadDeadline(time.Now().Add(s.ReadTimeout)); err != nil {
+			return nil, c, err
+		}
+	}
+
+	prefix := make([]byte, 0, maxPrefaceLen)
+	var one [1]byte
+	for len(candidates) != 0 {
+		n, err := c.Read(one[:])
+		if n > 0 {
+			prefix = append(prefix, one[0])
+			remaining := candidates[:0]
+			for _, candidate := range candidates {
+				preface := candidate.cleartextPreface
+				if bytes.Equal(prefix, preface) {
+					replayed := newReplayConn(c, prefix)
+					return candidate, replayed, nil
+				}
+				if len(prefix) < len(preface) && bytes.Equal(prefix, preface[:len(prefix)]) {
+					remaining = append(remaining, candidate)
+				}
+			}
+			candidates = remaining
+			if len(candidates) == 0 {
+				return nil, newReplayConn(c, prefix), nil
+			}
+		}
+		if err != nil {
+			return nil, newReplayConn(c, prefix), err
+		}
+	}
+
+	return nil, newReplayConn(c, prefix), nil
+}
+
+func newReplayConn(c net.Conn, prefix []byte) net.Conn {
+	return &replayConn{
+		Conn:   c,
+		reader: io.MultiReader(bytes.NewReader(prefix), c),
+	}
+}

--- a/protocol_client.go
+++ b/protocol_client.go
@@ -93,6 +93,13 @@ func (ctx *ProtocolClientContext) Deadline() (time.Time, bool) {
 	return ctx.deadline, !ctx.deadline.IsZero()
 }
 
+// RoundTripHTTP1 executes the request with HostClient's configured HTTP/1
+// transport. Protocol transports use it after a host has previously selected
+// HTTP/1 with ALPN.
+func (ctx *ProtocolClientContext) RoundTripHTTP1(req *Request, resp *Response) (bool, error) {
+	return ctx.hostClient.transport().RoundTrip(ctx.hostClient, req, resp)
+}
+
 // AcquireConn reserves one of HostClient's physical connection slots and
 // dials a connection. nextProtos is advertised with ALPN for TLS clients.
 // The caller owns the returned connection until it calls Close or
@@ -144,6 +151,13 @@ func (c *ProtocolClientConn) Conn() net.Conn {
 // connections.
 func (c *ProtocolClientConn) NegotiatedProtocol() string {
 	return c.negotiatedProtocol
+}
+
+// ApplyResponseMetadata records physical-connection metadata on resp.
+func (c *ProtocolClientConn) ApplyResponseMetadata(resp *Response) {
+	if resp != nil {
+		resp.raddr = c.conn.RemoteAddr()
+	}
 }
 
 // Close closes the physical connection and releases its HostClient slot.

--- a/protocol_client.go
+++ b/protocol_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"sync/atomic"
 	"time"
 )
@@ -58,11 +59,23 @@ func (c *HostClient) RegisterProtocolTransport(transport ProtocolRoundTripper) e
 	if c.protocolTransport != nil {
 		return errors.New("fasthttp: protocol transport is already registered")
 	}
+	http1Transport := c.Transport
+	if http1Transport == nil {
+		http1Transport = DefaultTransport
+	}
+	if !isDefaultRoundTripper(http1Transport) {
+		return errors.New("fasthttp: protocol transport cannot preserve the configured HTTP/1 transport")
+	}
 	if atomic.LoadInt32(&c.pendingRequests) != 0 || c.ConnsCount() != 0 {
 		return errors.New("fasthttp: cannot register a protocol transport after use")
 	}
 	c.protocolTransport = transport
 	return nil
+}
+
+func isDefaultRoundTripper(roundTripper RoundTripper) bool {
+	builtIn, ok := roundTripper.(*transport)
+	return ok && builtIn == defaultTransport
 }
 
 func isNilProtocolTransport(transport ProtocolRoundTripper) bool {
@@ -160,6 +173,17 @@ func (c *ProtocolClientConn) ApplyResponseMetadata(resp *Response) {
 	}
 }
 
+// PrepareResponseBody ensures resp can buffer at least size body bytes without
+// growing its backing buffer. Protocol transports may call it after validating
+// a response Content-Length.
+func (c *ProtocolClientConn) PrepareResponseBody(resp *Response, size int) {
+	if resp == nil || size <= 0 {
+		return
+	}
+	body := resp.bodyBuffer()
+	body.B = slices.Grow(body.B, size)
+}
+
 // Close closes the physical connection and releases its HostClient slot.
 func (c *ProtocolClientConn) Close() error {
 	if !c.isReleased.CompareAndSwap(false, true) {
@@ -183,8 +207,14 @@ func (c *ProtocolClientConn) RoundTripHTTP1(req *Request, resp *Response) (bool,
 
 func (c *HostClient) newProtocolClientContext(req *Request) ProtocolClientContext {
 	ctx := ProtocolClientContext{hostClient: c}
-	if req.timeout > 0 {
-		ctx.deadline = time.Now().Add(req.timeout)
+	timeout := req.timeout
+	for _, configured := range [...]time.Duration{c.ReadTimeout, c.WriteTimeout} {
+		if configured > 0 && (timeout <= 0 || configured < timeout) {
+			timeout = configured
+		}
+	}
+	if timeout > 0 {
+		ctx.deadline = time.Now().Add(timeout)
 	}
 	return ctx
 }
@@ -280,6 +310,9 @@ func (c *HostClient) dialHostHardWithALPN(
 			}
 			tlsConfig = baseConfig.Clone()
 			tlsConfig.NextProtos = mergeNextProtos(nextProtos, tlsConfig.NextProtos)
+			if containsString(nextProtos, "h2") && tlsConfig.MinVersion < tls.VersionTLS12 {
+				tlsConfig.MinVersion = tls.VersionTLS12
+			}
 		}
 
 		conn, err := dialAddr(
@@ -346,14 +379,14 @@ func mergeNextProtos(preferred, existing []string) []string {
 }
 
 // OpenStream opens a bidirectional request stream using the configured
-// transport.
+// transport. resp must be non-nil and remains owned by the caller for the
+// stream lifetime.
 //
 // Experimental: this method may change before it has shipped in two fasthttp
 // minor releases.
 func (c *HostClient) OpenStream(req *Request, resp *Response) (StreamConn, error) {
 	if resp == nil {
-		resp = AcquireResponse()
-		defer ReleaseResponse(resp)
+		return nil, errors.New("fasthttp: OpenStream response cannot be nil")
 	}
 	if err := c.prepareRequestResponse(req, resp); err != nil {
 		return nil, err

--- a/protocol_client.go
+++ b/protocol_client.go
@@ -1,0 +1,395 @@
+package fasthttp
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"sync/atomic"
+	"time"
+)
+
+// ProtocolRoundTripper is an optional extension to RoundTripper for transports
+// that own multiplexed or otherwise protocol-specific connections.
+//
+// Experimental: this interface may change before it has shipped in two
+// fasthttp minor releases.
+type ProtocolRoundTripper interface {
+	RoundTripWithContext(
+		ctx *ProtocolClientContext,
+		hc *HostClient,
+		req *Request,
+		resp *Response,
+	) (retry bool, err error)
+}
+
+// StreamRoundTripper is implemented by transports that can open a
+// bidirectional request stream.
+//
+// Experimental: this interface may change before it has shipped in two
+// fasthttp minor releases.
+type StreamRoundTripper interface {
+	OpenStreamWithContext(
+		ctx *ProtocolClientContext,
+		hc *HostClient,
+		req *Request,
+		resp *Response,
+	) (StreamConn, error)
+}
+
+// ProtocolTransportCloser is implemented by protocol transports that retain
+// idle connections outside HostClient's HTTP/1 connection pool.
+type ProtocolTransportCloser interface {
+	CloseIdleConnections(hc *HostClient)
+}
+
+// RegisterProtocolTransport installs a protocol transport while preserving
+// HostClient.Transport as its fallback. It must be called before the
+// HostClient is used.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (c *HostClient) RegisterProtocolTransport(transport ProtocolRoundTripper) error {
+	if isNilProtocolTransport(transport) {
+		return errors.New("fasthttp: protocol transport is nil")
+	}
+	if c.protocolTransport != nil {
+		return errors.New("fasthttp: protocol transport is already registered")
+	}
+	if atomic.LoadInt32(&c.pendingRequests) != 0 || c.ConnsCount() != 0 {
+		return errors.New("fasthttp: cannot register a protocol transport after use")
+	}
+	c.protocolTransport = transport
+	return nil
+}
+
+func isNilProtocolTransport(transport ProtocolRoundTripper) bool {
+	if transport == nil {
+		return true
+	}
+	value := reflect.ValueOf(transport)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+// ProtocolClientContext supplies one request attempt with its deadline and a
+// HostClient-aware connection dialer.
+//
+// Experimental: this type may change before it has shipped in two fasthttp
+// minor releases.
+type ProtocolClientContext struct {
+	hostClient *HostClient
+	deadline   time.Time
+}
+
+// Deadline returns the absolute request deadline, if one was configured.
+func (ctx *ProtocolClientContext) Deadline() (time.Time, bool) {
+	return ctx.deadline, !ctx.deadline.IsZero()
+}
+
+// AcquireConn reserves one of HostClient's physical connection slots and
+// dials a connection. nextProtos is advertised with ALPN for TLS clients.
+// The caller owns the returned connection until it calls Close or
+// RoundTripHTTP1.
+func (ctx *ProtocolClientContext) AcquireConn(nextProtos []string) (*ProtocolClientConn, error) {
+	timeout := time.Duration(0)
+	if !ctx.deadline.IsZero() {
+		timeout = time.Until(ctx.deadline)
+		if timeout <= 0 {
+			return nil, ErrTimeout
+		}
+	}
+
+	if err := ctx.hostClient.reserveProtocolConn(timeout); err != nil {
+		return nil, err
+	}
+	conn, negotiatedProtocol, err := ctx.hostClient.dialHostHardWithALPN(timeout, nextProtos)
+	if err != nil {
+		ctx.hostClient.releaseProtocolConnSlot()
+		return nil, err
+	}
+
+	return &ProtocolClientConn{
+		hostClient:         ctx.hostClient,
+		conn:               conn,
+		negotiatedProtocol: negotiatedProtocol,
+		createdTime:        time.Now(),
+	}, nil
+}
+
+// ProtocolClientConn is a physical connection leased from a HostClient.
+//
+// Experimental: this type may change before it has shipped in two fasthttp
+// minor releases.
+type ProtocolClientConn struct {
+	hostClient         *HostClient
+	conn               net.Conn
+	negotiatedProtocol string
+	createdTime        time.Time
+	isReleased         atomic.Bool
+}
+
+// Conn returns the physical connection.
+func (c *ProtocolClientConn) Conn() net.Conn {
+	return c.conn
+}
+
+// NegotiatedProtocol returns the TLS ALPN result. It is empty for cleartext
+// connections.
+func (c *ProtocolClientConn) NegotiatedProtocol() string {
+	return c.negotiatedProtocol
+}
+
+// Close closes the physical connection and releases its HostClient slot.
+func (c *ProtocolClientConn) Close() error {
+	if !c.isReleased.CompareAndSwap(false, true) {
+		return nil
+	}
+	err := c.conn.Close()
+	c.hostClient.releaseProtocolConnSlot()
+	return err
+}
+
+// RoundTripHTTP1 transfers the connection to HostClient's HTTP/1 transport.
+// The ProtocolClientConn must not be used after this method returns.
+func (c *ProtocolClientConn) RoundTripHTTP1(req *Request, resp *Response) (bool, error) {
+	if !c.isReleased.CompareAndSwap(false, true) {
+		return false, errors.New("fasthttp: protocol client connection is already released")
+	}
+	cc := acquireClientConn(c.conn)
+	cc.createdTime = c.createdTime
+	return defaultTransport.roundTripConn(c.hostClient, cc, req, resp)
+}
+
+func (c *HostClient) newProtocolClientContext(req *Request) ProtocolClientContext {
+	ctx := ProtocolClientContext{hostClient: c}
+	if req.timeout > 0 {
+		ctx.deadline = time.Now().Add(req.timeout)
+	}
+	return ctx
+}
+
+func (c *HostClient) reserveProtocolConn(reqTimeout time.Duration) error {
+	waitTimeout := c.MaxConnWaitTimeout
+	if reqTimeout > 0 && (waitTimeout <= 0 || reqTimeout < waitTimeout) {
+		waitTimeout = reqTimeout
+	}
+
+	var timer *time.Timer
+	if c.MaxConnWaitTimeout > 0 {
+		timer = AcquireTimer(waitTimeout)
+		defer ReleaseTimer(timer)
+	}
+
+	for {
+		c.connsLock.Lock()
+		maxConns := c.MaxConns
+		if maxConns <= 0 {
+			maxConns = DefaultMaxConnsPerHost
+		}
+		if c.connsCount < maxConns {
+			c.connsCount++
+			c.connsLock.Unlock()
+			return nil
+		}
+		if c.MaxConnWaitTimeout <= 0 {
+			c.connsLock.Unlock()
+			return ErrNoFreeConns
+		}
+		if c.connSlotAvailable == nil {
+			c.connSlotAvailable = make(chan struct{})
+		}
+		available := c.connSlotAvailable
+		c.connsLock.Unlock()
+
+		select {
+		case <-available:
+		case <-timer.C:
+			if reqTimeout > 0 && reqTimeout <= c.MaxConnWaitTimeout {
+				return ErrTimeout
+			}
+			return ErrNoFreeConns
+		}
+	}
+}
+
+func (c *HostClient) releaseProtocolConnSlot() {
+	c.connsLock.Lock()
+	c.connsCount--
+	c.signalConnSlotAvailableLocked()
+	c.connsLock.Unlock()
+}
+
+func (c *HostClient) signalConnSlotAvailableLocked() {
+	if c.connSlotAvailable == nil {
+		return
+	}
+	close(c.connSlotAvailable)
+	c.connSlotAvailable = nil
+}
+
+func (c *HostClient) dialHostHardWithALPN(
+	dialTimeout time.Duration,
+	nextProtos []string,
+) (net.Conn, string, error) {
+	c.addrsLock.Lock()
+	n := len(c.addrs)
+	c.addrsLock.Unlock()
+	if n == 0 {
+		n = 1
+	}
+
+	timeout := c.ReadTimeout + c.WriteTimeout
+	if timeout <= 0 {
+		timeout = DefaultDialTimeout
+	}
+	deadline := time.Now().Add(timeout)
+	if dialTimeout > 0 && time.Now().Add(dialTimeout).Before(deadline) {
+		deadline = time.Now().Add(dialTimeout)
+	}
+
+	var lastErr error
+	for range n {
+		addr := c.nextAddr()
+		var tlsConfig *tls.Config
+		if c.IsTLS {
+			baseConfig, err := c.cachedTLSConfig(addr)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			tlsConfig = baseConfig.Clone()
+			tlsConfig.NextProtos = mergeNextProtos(nextProtos, tlsConfig.NextProtos)
+		}
+
+		conn, err := dialAddr(
+			addr,
+			c.Dial,
+			c.DialTimeout,
+			c.DialDualStack,
+			c.IsTLS,
+			tlsConfig,
+			dialTimeout,
+			c.WriteTimeout,
+		)
+		if err != nil {
+			lastErr = err
+			if time.Now().After(deadline) {
+				break
+			}
+			continue
+		}
+		if !c.IsTLS {
+			return conn, "", nil
+		}
+
+		tlsConnection, ok := conn.(tlsConn)
+		if !ok {
+			_ = conn.Close()
+			return nil, "", errors.New("fasthttp: tls dial returned a connection without handshake support")
+		}
+		if err := conn.SetDeadline(deadline); err != nil {
+			_ = conn.Close()
+			return nil, "", err
+		}
+		if err := tlsConnection.Handshake(); err != nil {
+			_ = conn.Close()
+			lastErr = err
+			continue
+		}
+		if err := conn.SetDeadline(time.Time{}); err != nil {
+			_ = conn.Close()
+			return nil, "", err
+		}
+		return conn, tlsConnection.ConnectionState().NegotiatedProtocol, nil
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("fasthttp: protocol dial failed")
+	}
+	return nil, "", fmt.Errorf("dialling protocol connection: %w", lastErr)
+}
+
+func mergeNextProtos(preferred, existing []string) []string {
+	merged := make([]string, 0, len(preferred)+len(existing))
+	for _, protocol := range preferred {
+		if protocol != "" && !containsString(merged, protocol) {
+			merged = append(merged, protocol)
+		}
+	}
+	for _, protocol := range existing {
+		if protocol != "" && !containsString(merged, protocol) {
+			merged = append(merged, protocol)
+		}
+	}
+	return merged
+}
+
+// OpenStream opens a bidirectional request stream using the configured
+// transport.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (c *HostClient) OpenStream(req *Request, resp *Response) (StreamConn, error) {
+	if resp == nil {
+		resp = AcquireResponse()
+		defer ReleaseResponse(resp)
+	}
+	if err := c.prepareRequestResponse(req, resp); err != nil {
+		return nil, err
+	}
+
+	transport, ok := c.protocolTransport.(StreamRoundTripper)
+	if !ok {
+		return nil, ErrProtocolNotSupported
+	}
+	atomic.AddInt32(&c.pendingRequests, 1)
+	defer atomic.AddInt32(&c.pendingRequests, -1)
+	ctx := c.newProtocolClientContext(req)
+	return transport.OpenStreamWithContext(&ctx, c, req, resp)
+}
+
+// OpenStream opens a bidirectional request stream using the HostClient selected
+// from req's URI.
+//
+// ConfigureClient must be called before the first request when a protocol
+// transport is installed through Client.ConfigureClient.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (c *Client) OpenStream(req *Request, resp *Response) (StreamConn, error) {
+	if req == nil {
+		panic("BUG: req cannot be nil")
+	}
+	uri := req.URI()
+	host := uri.Host()
+	if len(host) == 0 {
+		return nil, ErrorInvalidURI
+	}
+	if bytes.IndexByte(host, ',') >= 0 {
+		return nil, fmt.Errorf("invalid host %q: use a host client for multiple hosts", host)
+	}
+
+	isTLS := uri.isHTTPS()
+	if !isTLS && !uri.isHTTP() {
+		return nil, fmt.Errorf("unsupported protocol %q. http and https are supported", uri.Scheme())
+	}
+	c.mOnce.Do(func() {
+		c.m = make(map[string]*HostClient)
+		c.ms = make(map[string]*HostClient)
+	})
+	hc, err := c.hostClient(host, isTLS)
+	if err != nil {
+		return nil, err
+	}
+
+	atomic.AddInt32(&hc.pendingClientRequests, 1)
+	defer atomic.AddInt32(&hc.pendingClientRequests, -1)
+	return hc.OpenStream(req, resp)
+}

--- a/protocol_client_test.go
+++ b/protocol_client_test.go
@@ -1,0 +1,195 @@
+package fasthttp
+
+import (
+	"bufio"
+	"crypto/tls"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type testProtocolTransport struct {
+	roundTripCalled         atomic.Bool
+	protocolRoundTripCalled atomic.Bool
+	closeIdleCalled         atomic.Bool
+}
+
+func (t *testProtocolTransport) RoundTrip(
+	_ *HostClient,
+	_ *Request,
+	_ *Response,
+) (bool, error) {
+	t.roundTripCalled.Store(true)
+	return false, nil
+}
+
+func (t *testProtocolTransport) RoundTripWithContext(
+	_ *ProtocolClientContext,
+	_ *HostClient,
+	_ *Request,
+	_ *Response,
+) (bool, error) {
+	t.protocolRoundTripCalled.Store(true)
+	return false, nil
+}
+
+func (t *testProtocolTransport) CloseIdleConnections(_ *HostClient) {
+	t.closeIdleCalled.Store(true)
+}
+
+func TestHostClientProtocolRoundTripper(t *testing.T) {
+	transport := &testProtocolTransport{}
+	hc := &HostClient{
+		Addr: "example.com:80",
+	}
+	if err := hc.RegisterProtocolTransport(transport); err != nil {
+		t.Fatalf("RegisterProtocolTransport() error: %v", err)
+	}
+	req := AcquireRequest()
+	defer ReleaseRequest(req)
+	resp := AcquireResponse()
+	defer ReleaseResponse(resp)
+	req.SetRequestURI("http://example.com/")
+
+	if err := hc.Do(req, resp); err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	if !transport.protocolRoundTripCalled.Load() {
+		t.Fatal("Do() didn't call ProtocolRoundTripper")
+	}
+	if transport.roundTripCalled.Load() {
+		t.Fatal("Do() called the legacy RoundTripper path")
+	}
+
+	hc.CloseIdleConnections()
+	if !transport.closeIdleCalled.Load() {
+		t.Fatal("CloseIdleConnections() didn't notify the protocol transport")
+	}
+}
+
+func TestProtocolClientContextAcquireConnALPN(t *testing.T) {
+	certData, keyData, err := GenerateTestCertificate("localhost")
+	if err != nil {
+		t.Fatalf("generating certificate: %v", err)
+	}
+	certificate, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		t.Fatalf("parsing certificate: %v", err)
+	}
+
+	serverConn, clientConn := net.Pipe()
+	serverError := make(chan error, 1)
+	go func() {
+		serverTLS := tls.Server(serverConn, &tls.Config{
+			Certificates: []tls.Certificate{certificate},
+			NextProtos:   []string{"h2", "http/1.1"},
+		})
+		if err := serverTLS.Handshake(); err != nil {
+			serverError <- err
+			return
+		}
+		var one [1]byte
+		_, err := serverTLS.Read(one[:])
+		if err != nil && err != io.EOF {
+			serverError <- err
+			return
+		}
+		serverError <- nil
+		_ = serverTLS.Close()
+	}()
+
+	hc := &HostClient{
+		Addr:  "localhost:443",
+		IsTLS: true,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Test-only self-signed certificate.
+		},
+		DialTimeout: func(string, time.Duration) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+	ctx := ProtocolClientContext{
+		hostClient: hc,
+		deadline:   time.Now().Add(time.Second),
+	}
+	conn, err := ctx.AcquireConn([]string{"h2", "http/1.1"})
+	if err != nil {
+		t.Fatalf("AcquireConn() error: %v", err)
+	}
+	if got := conn.NegotiatedProtocol(); got != "h2" {
+		t.Fatalf("NegotiatedProtocol() = %q, want %q", got, "h2")
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+	if err := <-serverError; err != nil {
+		t.Fatalf("server handshake error: %v", err)
+	}
+	if got := hc.ConnsCount(); got != 0 {
+		t.Fatalf("ConnsCount() = %d, want 0", got)
+	}
+}
+
+func TestProtocolClientConnRoundTripHTTP1(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	serverError := make(chan error, 1)
+	go func() {
+		defer serverConn.Close()
+		reader := bufio.NewReader(serverConn)
+		var req Request
+		if err := req.Read(reader); err != nil {
+			serverError <- err
+			return
+		}
+		_, err := io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+		serverError <- err
+	}()
+
+	hc := &HostClient{
+		Addr: "example.com:80",
+		DialTimeout: func(string, time.Duration) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+	ctx := ProtocolClientContext{hostClient: hc}
+	conn, err := ctx.AcquireConn(nil)
+	if err != nil {
+		t.Fatalf("AcquireConn() error: %v", err)
+	}
+
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	var resp Response
+	retry, err := conn.RoundTripHTTP1(&req, &resp)
+	if err != nil {
+		t.Fatalf("RoundTripHTTP1() error: %v (retry=%v)", err, retry)
+	}
+	if got := string(resp.Body()); got != "ok" {
+		t.Fatalf("response body = %q, want %q", got, "ok")
+	}
+	if err := <-serverError; err != nil {
+		t.Fatalf("server error: %v", err)
+	}
+
+	hc.CloseIdleConnections()
+	if got := hc.ConnsCount(); got != 0 {
+		t.Fatalf("ConnsCount() after CloseIdleConnections = %d, want 0", got)
+	}
+}
+
+func TestHostClientOpenStreamUnsupported(t *testing.T) {
+	hc := &HostClient{Addr: "example.com:80"}
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	var resp Response
+
+	stream, err := hc.OpenStream(&req, &resp)
+	if stream != nil {
+		t.Fatal("OpenStream() returned a stream for the default transport")
+	}
+	if err != ErrProtocolNotSupported {
+		t.Fatalf("OpenStream() error = %v, want ErrProtocolNotSupported", err)
+	}
+}

--- a/protocol_client_test.go
+++ b/protocol_client_test.go
@@ -10,6 +10,19 @@ import (
 	"time"
 )
 
+func TestProtocolClientConnPrepareResponseBody(t *testing.T) {
+	var response Response
+	response.AppendBodyString("prefix")
+	(&ProtocolClientConn{}).PrepareResponseBody(&response, 1024)
+	if got := string(response.Body()); got != "prefix" {
+		t.Fatalf("body = %q, want prefix", got)
+	}
+	if available := cap(response.bodyBuffer().B) - len(response.bodyBuffer().B); available < 1024 {
+		t.Fatalf("available body capacity = %d, want at least 1024", available)
+	}
+	response.ResetBody()
+}
+
 type testProtocolTransport struct {
 	roundTripCalled         atomic.Bool
 	protocolRoundTripCalled atomic.Bool
@@ -66,6 +79,17 @@ func TestHostClientProtocolRoundTripper(t *testing.T) {
 	hc.CloseIdleConnections()
 	if !transport.closeIdleCalled.Load() {
 		t.Fatal("CloseIdleConnections() didn't notify the protocol transport")
+	}
+}
+
+func TestHostClientProtocolTransportRejectsCustomHTTP1Fallback(t *testing.T) {
+	transport := &testProtocolTransport{}
+	hc := &HostClient{
+		Addr:      "example.com:80",
+		Transport: transport,
+	}
+	if err := hc.RegisterProtocolTransport(transport); err == nil {
+		t.Fatal("RegisterProtocolTransport() accepted a custom HTTP/1 fallback")
 	}
 }
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1,0 +1,302 @@
+package fasthttp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+)
+
+type protocolHandlerFunc func(*ProtocolServerContext, net.Conn) error
+
+func (f protocolHandlerFunc) ServeConn(ctx *ProtocolServerContext, c net.Conn) error {
+	return f(ctx, c)
+}
+
+type testProtocolStream struct {
+	context.Context
+
+	mu                  sync.Mutex
+	informationalStatus int
+	pushTarget          string
+	accepted            bool
+}
+
+func (s *testProtocolStream) WriteInformational(statusCode int, _ *ResponseHeader) error {
+	s.mu.Lock()
+	s.informationalStatus = statusCode
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *testProtocolStream) Push(target string, _ *PushOptions) error {
+	s.mu.Lock()
+	s.pushTarget = target
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *testProtocolStream) AcceptStream(_ StreamHandler) error {
+	s.mu.Lock()
+	s.accepted = true
+	s.mu.Unlock()
+	return nil
+}
+
+func TestServerRegisterProtocol(t *testing.T) {
+	validHandler := protocolHandlerFunc(func(*ProtocolServerContext, net.Conn) error { return nil })
+	tests := []struct {
+		name          string
+		registrations []ProtocolRegistration
+		wantError     bool
+	}{
+		{
+			name: "missing handler",
+			registrations: []ProtocolRegistration{{
+				ALPN: []string{"example"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "missing selector",
+			registrations: []ProtocolRegistration{{
+				Handler: validHandler,
+			}},
+			wantError: true,
+		},
+		{
+			name: "duplicate alpn in registration",
+			registrations: []ProtocolRegistration{{
+				ALPN:    []string{"example", "example"},
+				Handler: validHandler,
+			}},
+			wantError: true,
+		},
+		{
+			name: "duplicate registered alpn",
+			registrations: []ProtocolRegistration{
+				{ALPN: []string{"example"}, Handler: validHandler},
+				{ALPN: []string{"example"}, Handler: validHandler},
+			},
+			wantError: true,
+		},
+		{
+			name: "conflicting prefaces",
+			registrations: []ProtocolRegistration{
+				{CleartextPreface: []byte("PROTO"), Handler: validHandler},
+				{CleartextPreface: []byte("PROTOCOL"), Handler: validHandler},
+			},
+			wantError: true,
+		},
+		{
+			name: "alpn and preface",
+			registrations: []ProtocolRegistration{{
+				ALPN:             []string{"example"},
+				CleartextPreface: []byte("PROTOCOL"),
+				Handler:          validHandler,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{}
+			var err error
+			for _, registration := range tt.registrations {
+				err = s.RegisterProtocol(registration)
+				if err != nil {
+					break
+				}
+			}
+			if (err != nil) != tt.wantError {
+				t.Fatalf("RegisterProtocol() error = %v, wantError = %v", err, tt.wantError)
+			}
+			if err == nil && !slices.Contains(s.TLSConfig.NextProtos, "example") {
+				t.Fatal("RegisterProtocol() didn't add the ALPN protocol")
+			}
+		})
+	}
+}
+
+func TestServerRegisterProtocolCopiesSelectors(t *testing.T) {
+	alpn := []string{"example"}
+	preface := []byte("PROTOCOL")
+	s := &Server{}
+	err := s.RegisterProtocol(ProtocolRegistration{
+		ALPN:             alpn,
+		CleartextPreface: preface,
+		Handler:          protocolHandlerFunc(func(*ProtocolServerContext, net.Conn) error { return nil }),
+	})
+	if err != nil {
+		t.Fatalf("RegisterProtocol() error: %v", err)
+	}
+
+	alpn[0] = "changed"
+	preface[0] = 'X'
+	if got := s.protocols[0].alpn[0]; got != "example" {
+		t.Fatalf("registered ALPN = %q, want %q", got, "example")
+	}
+	if got := string(s.protocols[0].cleartextPreface); got != "PROTOCOL" {
+		t.Fatalf("registered preface = %q, want %q", got, "PROTOCOL")
+	}
+}
+
+func TestServerCleartextProtocolDispatch(t *testing.T) {
+	const preface = "PROTOCOL-PREFACE"
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	requestHandled := make(chan struct{})
+	states := make(chan ConnState, 2)
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			if got := string(ctx.Request.Header.Protocol()); got != "EXAMPLE/1" {
+				t.Errorf("request protocol = %q, want %q", got, "EXAMPLE/1")
+			}
+			close(requestHandled)
+		},
+		ConnState: func(_ net.Conn, state ConnState) {
+			if state == StateActive || state == StateIdle {
+				states <- state
+			}
+		},
+	}
+	err := s.RegisterProtocol(ProtocolRegistration{
+		CleartextPreface: []byte(preface),
+		Handler: protocolHandlerFunc(func(ctx *ProtocolServerContext, c net.Conn) error {
+			got := make([]byte, len(preface))
+			if _, err := io.ReadFull(c, got); err != nil {
+				return err
+			}
+			if !bytes.Equal(got, []byte(preface)) {
+				return errors.New("protocol preface wasn't replayed")
+			}
+
+			stream := &testProtocolStream{Context: context.Background()}
+			requestCtx := ctx.AcquireRequestCtx(c, stream)
+			requestCtx.Request.Header.SetProtocol("EXAMPLE/1")
+			ctx.Server().Handler(requestCtx)
+			ctx.ReleaseRequestCtx(requestCtx)
+			return nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("RegisterProtocol() error: %v", err)
+	}
+
+	serveError := make(chan error, 1)
+	go func() {
+		serveError <- s.ServeConn(serverConn)
+	}()
+	if _, err := io.WriteString(clientConn, preface); err != nil {
+		t.Fatalf("writing preface: %v", err)
+	}
+
+	select {
+	case <-requestHandled:
+	case <-time.After(time.Second):
+		t.Fatal("protocol handler didn't run")
+	}
+	if err := <-serveError; err != nil {
+		t.Fatalf("ServeConn() error: %v", err)
+	}
+	if got := []ConnState{<-states, <-states}; !slices.Equal(got, []ConnState{StateActive, StateIdle}) {
+		t.Fatalf("connection states = %v, want [active idle]", got)
+	}
+}
+
+func TestServerCleartextProtocolFallsBackToHTTP1(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			ctx.SetBodyString("ok")
+		},
+	}
+	err := s.RegisterProtocol(ProtocolRegistration{
+		CleartextPreface: []byte("PROTOCOL-PREFACE"),
+		Handler: protocolHandlerFunc(func(*ProtocolServerContext, net.Conn) error {
+			return errors.New("unexpected protocol dispatch")
+		}),
+	})
+	if err != nil {
+		t.Fatalf("RegisterProtocol() error: %v", err)
+	}
+
+	serveError := make(chan error, 1)
+	go func() {
+		serveError <- s.ServeConn(serverConn)
+	}()
+	if _, err := io.WriteString(clientConn, "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"); err != nil {
+		t.Fatalf("writing request: %v", err)
+	}
+
+	var response Response
+	if err := response.Read(bufio.NewReader(clientConn)); err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	if got := string(response.Body()); got != "ok" {
+		t.Fatalf("response body = %q, want %q", got, "ok")
+	}
+	if err := <-serveError; err != nil {
+		t.Fatalf("ServeConn() error: %v", err)
+	}
+}
+
+func TestRequestCtxProtocolOperations(t *testing.T) {
+	base, cancel := context.WithCancel(context.Background())
+	stream := &testProtocolStream{Context: base}
+	ctx := &RequestCtx{
+		s:              fakeServer,
+		protocolStream: stream,
+	}
+	ctx.Response.Header.Add("Link", "</style.css>; rel=preload")
+
+	if err := ctx.EarlyHints(); err != nil {
+		t.Fatalf("EarlyHints() error: %v", err)
+	}
+	if err := ctx.Push("/style.css", nil); err != nil {
+		t.Fatalf("Push() error: %v", err)
+	}
+	if err := ctx.AcceptStream(func(StreamConn) {}); err != nil {
+		t.Fatalf("AcceptStream() error: %v", err)
+	}
+
+	stream.mu.Lock()
+	status := stream.informationalStatus
+	target := stream.pushTarget
+	accepted := stream.accepted
+	stream.mu.Unlock()
+	if status != StatusEarlyHints || target != "/style.css" || !accepted {
+		t.Fatalf("protocol operations = (%d, %q, %v)", status, target, accepted)
+	}
+
+	cancel()
+	<-ctx.Done()
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("Err() = %v, want context.Canceled", ctx.Err())
+	}
+}
+
+func TestRequestHeaderConnectProtocol(t *testing.T) {
+	var src RequestHeader
+	src.SetConnectProtocol("websocket")
+
+	var dst RequestHeader
+	src.CopyTo(&dst)
+	if got := string(dst.ConnectProtocol()); got != "websocket" {
+		t.Fatalf("copied connect protocol = %q, want %q", got, "websocket")
+	}
+
+	dst.Reset()
+	if len(dst.ConnectProtocol()) != 0 {
+		t.Fatalf("ConnectProtocol() after Reset = %q, want empty", dst.ConnectProtocol())
+	}
+}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -250,6 +250,68 @@ func TestServerCleartextProtocolFallsBackToHTTP1(t *testing.T) {
 	}
 }
 
+func TestServerShutdownDeadlineClosesProtocolConnections(t *testing.T) {
+	const preface = "PROTOCOL-PREFACE"
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error: %v", err)
+	}
+	handlerStarted := make(chan struct{})
+	handlerDone := make(chan struct{})
+	server := &Server{}
+	if err := server.RegisterProtocol(ProtocolRegistration{
+		CleartextPreface: []byte(preface),
+		Handler: protocolHandlerFunc(func(_ *ProtocolServerContext, conn net.Conn) error {
+			defer close(handlerDone)
+			got := make([]byte, len(preface))
+			if _, err := io.ReadFull(conn, got); err != nil {
+				return err
+			}
+			close(handlerStarted)
+			var one [1]byte
+			_, err := conn.Read(one[:])
+			return err
+		}),
+	}); err != nil {
+		t.Fatalf("RegisterProtocol() error: %v", err)
+	}
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- server.Serve(listener) }()
+
+	client, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial() error: %v", err)
+	}
+	defer client.Close()
+	if _, err := io.WriteString(client, preface); err != nil {
+		t.Fatalf("writing protocol preface: %v", err)
+	}
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("protocol handler didn't start")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := server.ShutdownWithContext(shutdownCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ShutdownWithContext() error = %v, want deadline exceeded", err)
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("protocol connection wasn't closed after the shutdown deadline")
+	}
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Fatalf("Serve() error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve() didn't return")
+	}
+}
+
 func TestRequestCtxProtocolOperations(t *testing.T) {
 	base, cancel := context.WithCancel(context.Background())
 	stream := &testProtocolStream{Context: base}

--- a/server.go
+++ b/server.go
@@ -241,6 +241,7 @@ type Server struct {
 	FormValueFunc FormValueFunc
 
 	nextProtos map[string]ServeHandler
+	protocols  []registeredProtocol
 
 	concurrencyCh chan struct{}
 
@@ -645,6 +646,8 @@ type RequestCtx struct {
 	connID           uint64
 	connRequestNum   uint64
 	hijackNoResponse bool
+	protocolStream   ProtocolStream
+	protocolOwner    *ProtocolServerContext
 }
 
 // EarlyHints allows the server to hint to the browser what resources a page would need
@@ -669,6 +672,13 @@ type RequestCtx struct {
 //	}
 func (ctx *RequestCtx) EarlyHints() error {
 	links := ctx.Response.Header.PeekAll(b2s(strLink))
+	if len(links) > 0 && ctx.protocolStream != nil {
+		writer, ok := ctx.protocolStream.(InformationalResponseWriter)
+		if !ok {
+			return ErrProtocolNotSupported
+		}
+		return writer.WriteInformational(StatusEarlyHints, &ctx.Response.Header)
+	}
 	if len(links) > 0 {
 		c := acquireWriter(ctx)
 		defer releaseWriter(ctx.s, c)
@@ -711,6 +721,34 @@ func (ctx *RequestCtx) EarlyHints() error {
 		}
 	}
 	return nil
+}
+
+// Push starts a server push request associated with ctx.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (ctx *RequestCtx) Push(target string, opts *PushOptions) error {
+	pusher, ok := ctx.protocolStream.(Pusher)
+	if !ok {
+		return ErrProtocolNotSupported
+	}
+	return pusher.Push(target, opts)
+}
+
+// AcceptStream accepts a bidirectional request stream. It does not change the
+// connection-oriented semantics of Hijack.
+//
+// Experimental: this method may change before it has shipped in two fasthttp
+// minor releases.
+func (ctx *RequestCtx) AcceptStream(handler StreamHandler) error {
+	if handler == nil {
+		return errors.New("fasthttp: stream handler is nil")
+	}
+	accepter, ok := ctx.protocolStream.(StreamAccepter)
+	if !ok {
+		return ErrProtocolNotSupported
+	}
+	return accepter.AcceptStream(handler)
 }
 
 // HijackHandler must process the hijacked connection c.
@@ -916,6 +954,8 @@ func (ctx *RequestCtx) reset() {
 
 	ctx.hijackHandler = nil
 	ctx.hijackNoResponse = false
+	ctx.protocolStream = nil
+	ctx.protocolOwner = nil
 }
 
 type firstByteReader struct {
@@ -2330,6 +2370,31 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 
 		return handler(c)
 	}
+	if len(s.protocols) != 0 {
+		if protocol := s.protocolByALPN(proto); protocol != nil {
+			if s.ReadTimeout > 0 || s.WriteTimeout > 0 {
+				if err := c.SetDeadline(zeroTime); err != nil {
+					return err
+				}
+			}
+			return s.serveProtocolConn(c, protocol)
+		}
+		if proto == "" {
+			protocol, detectedConn, detectErr := s.detectCleartextProtocol(c)
+			c = detectedConn
+			if detectErr != nil && protocol == nil {
+				return detectErr
+			}
+			if protocol != nil {
+				if s.ReadTimeout > 0 {
+					if err := c.SetReadDeadline(zeroTime); err != nil {
+						return err
+					}
+				}
+				return s.serveProtocolConn(c, protocol)
+			}
+		}
+	}
 
 	connTime := time.Now()
 
@@ -2985,6 +3050,9 @@ func (ctx *RequestCtx) Init(req *Request, remoteAddr net.Addr, logger Logger) {
 // This method always returns 0, false and is only present to make
 // RequestCtx implement the context interface.
 func (ctx *RequestCtx) Deadline() (deadline time.Time, ok bool) {
+	if ctx.protocolStream != nil {
+		return ctx.protocolStream.Deadline()
+	}
 	return time.Time{}, false
 }
 
@@ -2995,6 +3063,9 @@ func (ctx *RequestCtx) Deadline() (deadline time.Time, ok bool) {
 // Note: Because creating a new channel for every request is just too expensive, so
 // RequestCtx.s.done is only closed when the server is shutting down.
 func (ctx *RequestCtx) Done() <-chan struct{} {
+	if ctx.protocolStream != nil {
+		return ctx.protocolStream.Done()
+	}
 	return ctx.s.done
 }
 
@@ -3008,6 +3079,9 @@ func (ctx *RequestCtx) Done() <-chan struct{} {
 // Note: Because creating a new channel for every request is just too expensive, so
 // RequestCtx.s.done is only closed when the server is shutting down.
 func (ctx *RequestCtx) Err() error {
+	if ctx.protocolStream != nil {
+		return ctx.protocolStream.Err()
+	}
 	select {
 	case <-ctx.Done():
 		return context.Canceled

--- a/server.go
+++ b/server.go
@@ -245,8 +245,9 @@ type Server struct {
 
 	concurrencyCh chan struct{}
 
-	idleConns map[net.Conn]*atomic.Int64
-	done      chan struct{}
+	idleConns     map[net.Conn]*atomic.Int64
+	protocolConns map[net.Conn]struct{}
+	done          chan struct{}
 
 	// Server name for sending in response headers.
 	//
@@ -2131,6 +2132,7 @@ func (s *Server) ShutdownWithContext(ctx context.Context) (err error) {
 		// while Wait() is waiting.
 		select {
 		case <-ctx.Done():
+			s.closeProtocolConns()
 			return ctx.Err()
 		case <-ticker.C:
 			continue
@@ -3225,6 +3227,14 @@ func (s *Server) closeIdleConns() {
 			// and stores into it, so only that goroutine may return it.
 			delete(s.idleConns, c)
 		}
+	}
+	s.idleConnsMu.Unlock()
+}
+
+func (s *Server) closeProtocolConns() {
+	s.idleConnsMu.Lock()
+	for conn := range s.protocolConns {
+		_ = conn.Close()
 	}
 	s.idleConnsMu.Unlock()
 }


### PR DESCRIPTION
## Summary

This Draft adds an opt-in, native, experimental HTTP/2 client and server to fasthttp. It maps directly to `fasthttp.Request`, `Response`, and `RequestCtx`; it does not adapt through `net/http`.

Related to #144. This intentionally does not close the issue while the API remains experimental and the Draft checklist is open.

The implementation follows [RFC 9113](https://www.rfc-editor.org/rfc/rfc9113.html), [RFC 7541](https://www.rfc-editor.org/rfc/rfc7541.html), [RFC 9218](https://www.rfc-editor.org/rfc/rfc9218.html), and [RFC 8441](https://www.rfc-editor.org/rfc/rfc8441.html). TLS uses ALPN `h2`; cleartext supports explicitly configured prior knowledge and same-port preface dispatch. The obsolete HTTP/1 `Upgrade: h2c` path is not implemented.

## Why this design

The HTTP/1 connection-ownership model discussed in #144 cannot represent HTTP/2 multiplexing safely. PR #1457 improves adaptors, but an adaptor still does not provide native stream ownership, flow control, cancellation, or scheduling.

This is an independent implementation. No code was copied from `dgrr/http2`: in addition to its different concurrency model, that repository is Apache-2.0 while fasthttp is MIT. The existing `golang.org/x/net/http2.Framer` and `hpack` dependency is used behind a private codec boundary for framing and compression primitives.

Each server connection has one owner goroutine for stream state, SETTINGS, HPACK, flow-control windows, GOAWAY, and scheduling; a bounded reader publishes immutable events; handlers run independently per stream; and all output is serialized through a bounded, RFC 9218-aware writer. The client uses the same ownership rule and resets only the affected stream on request cancellation or timeout.

## Public surface

- Experimental protocol registration and per-stream lifecycle hooks in the root package, without changing the unconfigured HTTP/1 path.
- `http2.ConfigureServer`, `ServeConn`, `ConfigureHostClient`, `ConfigureClient`, and `NewTransport`.
- TLS `PreferHTTP2` with same-connection HTTP/1 fallback, `RequireHTTP2`, and cleartext `PriorKnowledge`.
- Protocol-neutral `RequestCtx.Push`, `AcceptStream`, `StreamConn`, and client `OpenStream`.
- `RequestHeader.ConnectProtocol` for HTTP/2/3 `:protocol` without overloading the HTTP-version string.

The root boundary contains request lifecycle, cancellation, push, informational responses, priority semantics, and bidirectional stream semantics only. TCP, HTTP/2 frames, HPACK, and HTTP/2 windows stay private. A future HTTP/3 package can therefore use QUIC, control streams, QPACK, and QUIC flow control directly rather than emulating HTTP/2.

## Implemented behavior

- RFC 9113 stream states, SETTINGS/ACK, PING, flow control, RST_STREAM, GOAWAY, CONTINUATION validation, trailers, 1xx/103, streaming request/response bodies, and graceful two-stage shutdown.
- TLS ALPN, lossless HTTP/1 fallback on the negotiated connection, and explicit cleartext prior knowledge.
- Server push, disabled by default, with origin/method/depth/concurrency limits and client accept/handle callbacks.
- RFC 8441 extended CONNECT, disabled by default, exposed as a stream-scoped virtual `net.Conn` with half-close, deadline, and cancellation behavior.
- RFC 9218 `Priority`/`PRIORITY_UPDATE`, urgency and incremental scheduling, and `SETTINGS_NO_RFC7540_PRIORITIES=1`; legacy priority frames are validated without rebuilding the obsolete dependency tree.
- Bounded frame/header/HPACK/control queues, concurrent stream limits, 31-bit window checks, closed-stream tombstones, Rapid Reset termination, continuation/header-bomb defenses, and secure error logging.

## Verification

Local environment: Apple M4, macOS 15.7.8 arm64, Go 1.26.5.

- `h2spec --strict`: **147 tests, 146 passed, 1 skipped, 0 failed**.
- Native server against Go `http2.Transport`, native client against Go `http2.Server`, and native/native tests.
- TLS h2, HTTP/1 fallback without a second dial, RequireHTTP2 failure, prior knowledge, and same-port H1/H2 dispatch.
- Push, trailers, 103, streaming, extended CONNECT byte echo, half-close, priority updates, GOAWAY, shutdown draining, timeout isolation, and Rapid Reset tests.
- `go test -shuffle=on ./http2 .`: pass.
- `go test -race -shuffle=on ./http2 .`: pass.
- All repository packages except the known local `fasthttpproxy` network test: ordinary and race/shuffle pass.
- Four native fuzz targets ran locally for 5 seconds each without a failure.
- `go vet ./...`, `gopls check` on changed Go files, and `govulncheck ./...`: pass; no called vulnerability found.

`go test [-race] -shuffle=on ./...` has one pre-existing, environment-dependent failure here: `fasthttpproxy/TestDialerGetDialFuncForTLSNoProxy` expects a documentation address dial to fail, but the address is reachable from this machine. This was recorded before implementation and is not changed in this PR. Linux CI remains authoritative.

## Performance

Commands, methodology, caveats, and the full table are in `http2/PERFORMANCE.md`. Ten 500 ms samples were measured over prewarmed loopback TCP, with identical endpoints/settings for each comparison.

| Scenario | Native fasthttp H2 | Go H2 | Advantage |
| --- | ---: | ---: | ---: |
| Small GET, 100 concurrent streams | 3.969 us | 6.596 us | 1.66x |
| Small GET, 1,000 concurrent streams | 4.284 us | 6.929 us | 1.62x |
| Server only, 100 streams | 3.988 us | 7.460 us | 1.87x |
| TLS small GET, 100 streams | 3.064 us | 6.695 us | 2.19x |
| 1 MiB buffered GET | 204 us | 567 us | 2.79x |
| 1 MiB streaming response | 219 us | 581 us | 2.65x |
| 1 MiB streaming request | 316 us | 378 us | 1.20x |

At 100 streams the native end-to-end path uses 4 allocs / 164 B per request versus 32 allocs / about 3.52 KiB for Go. HTTP/1 regression guards remain at 0 alloc/op, with no measured throughput regression.

This does **not** claim a 10x HTTP/2 throughput advantage. The latest CPU profile spends 47% of samples in raw syscalls, with most remaining time in kqueue and scheduler sleep/wakeup paths; handler startup is not a meaningful hotspot. A fixed handler pool would add head-of-line blocking without profile evidence. The next high-value target is reducing bidirectional flow-control wakeups while preserving fairness and per-stream cancellation.

## Draft checklist

- [x] Native server and client core
- [x] Streaming, trailers, 103, GOAWAY, and graceful shutdown
- [x] Push, RFC 9218 priority, and RFC 8441 extended CONNECT
- [x] Security/resource hardening and Rapid Reset coverage
- [x] Native/native and Go interoperability tests
- [x] Strict local h2spec run
- [x] HTTP/1 zero-allocation regression guard
- [x] Profile-driven batching, pooling, private header codec, and segmented streaming buffers
- [ ] Confirm the full Go 1.25/1.26 Linux/macOS/Windows GitHub matrix
- [ ] Confirm CIFuzz/OSS-Fuzz execution and register the new package targets externally if the existing project harness does not discover them
- [ ] Resolve review feedback and collect real-world API experience before freezing the experimental surface
- [ ] Continue flow-control/wakeup optimization if a 10x throughput target is a Ready-for-review gate

The package remains opt-in and Experimental for at least two fasthttp minor releases. Push and extended CONNECT remain disabled by default; existing `NextProto`, custom protocol handlers, and unconfigured HTTP/1 users do not need to migrate.
