### PR TITLE
Rename ChunkedBodyWriterTo to BodyWriterTo and use in more places

### DIFF
--- a/http.go
+++ b/http.go
@@ -242,7 +242,10 @@ func (resp *Response) SendFile(path string) error {
 //
 // When bodySize < 0 (chunked transfer encoding), fasthttp may frame the body
 // using WriteTo instead of Read for *bytes.Reader, *bytes.Buffer, and streams
-// implementing ChunkedBodyWriterTo.
+// implementing BodyWriterTo that return true from SupportsBodyWriteTo.
+//
+// See BodyWriterTo for controlling whether fasthttp may use WriteTo instead of
+// Read when consuming bodyStream.
 //
 // bodyStream.Close() is called after finishing reading all body data
 // if it implements io.Closer.
@@ -265,7 +268,10 @@ func (req *Request) SetBodyStream(bodyStream io.Reader, bodySize int) {
 //
 // When bodySize < 0 (chunked transfer encoding), fasthttp may frame the body
 // using WriteTo instead of Read for *bytes.Reader, *bytes.Buffer, and streams
-// implementing ChunkedBodyWriterTo.
+// implementing BodyWriterTo that return true from SupportsBodyWriteTo.
+//
+// See BodyWriterTo for controlling whether fasthttp may use WriteTo instead of
+// Read when consuming bodyStream.
 //
 // bodyStream.Close() is called after finishing reading all body data
 // if it implements io.Closer.
@@ -439,7 +445,7 @@ func (resp *Response) Body() []byte {
 	if resp.bodyStream != nil {
 		bodyBuf := resp.bodyBuffer()
 		bodyBuf.Reset()
-		_, err := copyZeroAlloc(bodyBuf, resp.bodyStream)
+		_, err := copyBodyStream(bodyBuf, resp.bodyStream)
 		resp.closeBodyStream(err) //nolint:errcheck
 		if err != nil {
 			bodyBuf.SetString(err.Error())
@@ -465,7 +471,7 @@ func (req *Request) bodyBytes() []byte {
 	if req.bodyStream != nil {
 		bodyBuf := req.bodyBuffer()
 		bodyBuf.Reset()
-		_, err := copyZeroAlloc(bodyBuf, req.bodyStream)
+		_, err := copyBodyStream(bodyBuf, req.bodyStream)
 		req.closeBodyStream() //nolint:errcheck
 		if err != nil {
 			bodyBuf.SetString(err.Error())
@@ -731,7 +737,7 @@ func (resp *Response) BodyUncompressedWithLimit(maxBodySize int) ([]byte, error)
 // BodyWriteTo writes request body to w.
 func (req *Request) BodyWriteTo(w io.Writer) error {
 	if req.bodyStream != nil {
-		_, err := copyZeroAlloc(w, req.bodyStream)
+		_, err := copyBodyStream(w, req.bodyStream)
 		req.closeBodyStream() //nolint:errcheck
 		return err
 	}
@@ -745,7 +751,7 @@ func (req *Request) BodyWriteTo(w io.Writer) error {
 // BodyWriteTo writes response body to w.
 func (resp *Response) BodyWriteTo(w io.Writer) error {
 	if resp.bodyStream != nil {
-		_, err := copyZeroAlloc(w, resp.bodyStream)
+		_, err := copyBodyStream(w, resp.bodyStream)
 		resp.closeBodyStream(err) //nolint:errcheck
 		return err
 	}
@@ -861,7 +867,7 @@ func (resp *Response) SwapBody(body []byte) []byte {
 
 	if resp.bodyStream != nil {
 		bb.Reset()
-		_, err := copyZeroAlloc(bb, resp.bodyStream)
+		_, err := copyBodyStream(bb, resp.bodyStream)
 		resp.closeBodyStream(err) //nolint:errcheck
 		if err != nil {
 			bb.Reset()
@@ -886,7 +892,7 @@ func (req *Request) SwapBody(body []byte) []byte {
 
 	if req.bodyStream != nil {
 		bb.Reset()
-		_, err := copyZeroAlloc(bb, req.bodyStream)
+		_, err := copyBodyStream(bb, req.bodyStream)
 		req.closeBodyStream() //nolint:errcheck
 		if err != nil {
 			bb.Reset()
@@ -2166,7 +2172,7 @@ func compressBrotliBodyStream(sw *bufio.Writer, bodyStream io.Reader, level int)
 		wf: zw,
 		bw: sw,
 	}
-	_, wErr := copyZeroAlloc(fw, bodyStream)
+	_, wErr := copyBodyStream(fw, bodyStream)
 	releaseStacklessBrotliWriter(zw, level)
 	return wErr
 }
@@ -2177,7 +2183,7 @@ func compressGzipBodyStream(sw *bufio.Writer, bodyStream io.Reader, level int) e
 		wf: zw,
 		bw: sw,
 	}
-	_, wErr := copyZeroAlloc(fw, bodyStream)
+	_, wErr := copyBodyStream(fw, bodyStream)
 	releaseStacklessGzipWriter(zw, level)
 	return wErr
 }
@@ -2188,7 +2194,7 @@ func compressDeflateBodyStream(sw *bufio.Writer, bodyStream io.Reader, level int
 		wf: zw,
 		bw: sw,
 	}
-	_, wErr := copyZeroAlloc(fw, bodyStream)
+	_, wErr := copyBodyStream(fw, bodyStream)
 	releaseStacklessDeflateWriter(zw, level)
 	return wErr
 }
@@ -2199,7 +2205,7 @@ func compressZstdBodyStream(sw *bufio.Writer, bodyStream io.Reader, level int) e
 		wf: zw,
 		bw: sw,
 	}
-	_, wErr := copyZeroAlloc(fw, bodyStream)
+	_, wErr := copyBodyStream(fw, bodyStream)
 	releaseStacklessZstdWriter(zw, level)
 	return wErr
 }
@@ -2512,19 +2518,24 @@ type httpWriter interface {
 	Write(w *bufio.Writer) error
 }
 
-// ChunkedBodyWriterTo lets a body opt into zero-copy chunked framing via
-// WriteTo. It is consulted only for unknown-size bodies (bodySize < 0) written
-// with chunked transfer encoding.
+// BodyWriterTo lets a body stream control whether fasthttp may use WriteTo
+// instead of Read when consuming the stream.
 //
-// SupportsChunkedBodyWriteTo must return true only when WriteTo can safely
-// replace Read, including any pacing, accounting, transformations, or other
-// observable side effects Read performs — emitting the same eventual bytes is
-// not enough. A bare io.WriterTo check is avoided because a WriteTo promoted
-// from an embedded reader would opt in by accident and bypass an overridden
-// Read; the bool also lets an embedding type opt back out.
-type ChunkedBodyWriterTo interface {
+// Returning false from SupportsBodyWriteTo forces fasthttp to use Read.
+// Returning true permits fasthttp to use WriteTo. Existing body-copy paths
+// retain their historical io.WriterTo behavior for streams that do not
+// implement BodyWriterTo, while direct unknown-size chunked framing uses Read
+// for unmarked streams.
+//
+// SupportsBodyWriteTo must return true only when WriteTo can safely replace
+// Read, including any pacing, accounting, transformations, or other observable
+// side effects Read performs — emitting the same eventual bytes is not enough.
+// A bare io.WriterTo check is avoided for direct chunked framing because a
+// WriteTo promoted from an embedded reader would opt in by accident and bypass
+// an overridden Read; the bool also lets an embedding type opt back out.
+type BodyWriterTo interface {
 	io.WriterTo
-	SupportsChunkedBodyWriteTo() bool
+	SupportsBodyWriteTo() bool
 }
 
 type chunkedBodyWriter struct {
@@ -2553,8 +2564,8 @@ func writeBodyChunked(w *bufio.Writer, r io.Reader) error {
 	case *bytes.Buffer:
 		wt = v
 	default:
-		if cw, ok := r.(ChunkedBodyWriterTo); ok && cw.SupportsChunkedBodyWriteTo() {
-			wt = cw
+		if bwt, ok := r.(BodyWriterTo); ok && bwt.SupportsBodyWriteTo() {
+			wt = bwt
 		}
 	}
 	if wt != nil {
@@ -2622,12 +2633,28 @@ func writeBodyFixedSize(w *bufio.Writer, r io.Reader, size int64) error {
 		}
 	}
 
-	n, err := copyZeroAlloc(w, r)
+	n, err := copyBodyStream(w, r)
 
 	if n != size && err == nil {
 		err = fmt.Errorf("copied %d bytes from body stream instead of %d bytes", n, size)
 	}
 	return err
+}
+
+func copyBodyStream(w io.Writer, r io.Reader) (int64, error) {
+	if bwt, ok := r.(BodyWriterTo); ok {
+		if bwt.SupportsBodyWriteTo() {
+			return bwt.WriteTo(w)
+		}
+
+		vbuf := copyBufPool.Get()
+		buf := vbuf.([]byte) //nolint:forcetypeassert
+		n, err := copyBuffer(w, r, buf)
+		copyBufPool.Put(vbuf)
+		return n, err
+	}
+
+	return copyZeroAlloc(w, r)
 }
 
 // copyZeroAlloc optimizes io.Copy by calling ReadFrom or WriteTo only when

--- a/http_test.go
+++ b/http_test.go
@@ -3808,7 +3808,7 @@ func (b *chunkedOptInBody) WriteTo(w io.Writer) (int64, error) {
 	return b.r.WriteTo(w)
 }
 
-func (b *chunkedOptInBody) SupportsChunkedBodyWriteTo() bool { return true }
+func (b *chunkedOptInBody) SupportsBodyWriteTo() bool { return true }
 
 func TestWriteBodyChunkedWriterToOptIn(t *testing.T) {
 	t.Parallel()
@@ -3878,12 +3878,12 @@ func TestWriteBodyChunkedPromotedWriterToNotOptIn(t *testing.T) {
 	stream := &promotedWriterToBody{embeddedWriterTo: inner}
 
 	// The promoted WriteTo makes stream satisfy io.WriterTo, but not
-	// ChunkedBodyWriterTo.
+	// BodyWriterTo.
 	if _, ok := any(stream).(io.WriterTo); !ok {
 		t.Fatal("test setup: stream must satisfy io.WriterTo via promotion")
 	}
-	if _, ok := any(stream).(ChunkedBodyWriterTo); ok {
-		t.Fatal("test setup: stream must NOT satisfy ChunkedBodyWriterTo")
+	if _, ok := any(stream).(BodyWriterTo); ok {
+		t.Fatal("test setup: stream must NOT satisfy BodyWriterTo")
 	}
 
 	var resp Response
@@ -3915,20 +3915,24 @@ func TestWriteBodyChunkedPromotedWriterToNotOptIn(t *testing.T) {
 }
 
 // optInInner supports zero-copy framing; optOutBody embeds it but overrides
-// SupportsChunkedBodyWriteTo to return false, opting back out.
+// SupportsBodyWriteTo to return false, opting back out.
 type optInInner struct {
 	r        *bytes.Reader
+	readCnt  int
 	writeCnt int
 }
 
-func (e *optInInner) Read(p []byte) (int, error) { return e.r.Read(p) }
+func (e *optInInner) Read(p []byte) (int, error) {
+	e.readCnt++
+	return e.r.Read(p)
+}
 
 func (e *optInInner) WriteTo(w io.Writer) (int64, error) {
 	e.writeCnt++
 	return e.r.WriteTo(w)
 }
 
-func (e *optInInner) SupportsChunkedBodyWriteTo() bool { return true }
+func (e *optInInner) SupportsBodyWriteTo() bool { return true }
 
 type optOutBody struct {
 	*optInInner
@@ -3941,7 +3945,181 @@ func (b *optOutBody) Read(p []byte) (int, error) {
 	return b.optInInner.Read(p)
 }
 
-func (b *optOutBody) SupportsChunkedBodyWriteTo() bool { return false }
+func (b *optOutBody) SupportsBodyWriteTo() bool { return false }
+
+func TestBodyStreamOperationsPreserveLegacyWriterToUnlessOverridden(t *testing.T) {
+	t.Parallel()
+
+	body := createFixedBody(10001)
+	operations := []struct {
+		name string
+		run  func(io.Reader) ([]byte, error)
+	}{
+		{
+			name: "response Body",
+			run: func(stream io.Reader) ([]byte, error) {
+				var resp Response
+				resp.SetBodyStream(stream, -1)
+				return resp.Body(), nil
+			},
+		},
+		{
+			name: "request Body",
+			run: func(stream io.Reader) ([]byte, error) {
+				var req Request
+				req.SetBodyStream(stream, -1)
+				return req.Body(), nil
+			},
+		},
+		{
+			name: "response BodyWriteTo",
+			run: func(stream io.Reader) ([]byte, error) {
+				var resp Response
+				resp.SetBodyStream(stream, -1)
+
+				var dst bytes.Buffer
+				if err := resp.BodyWriteTo(&dst); err != nil {
+					return nil, err
+				}
+				return dst.Bytes(), nil
+			},
+		},
+		{
+			name: "request BodyWriteTo",
+			run: func(stream io.Reader) ([]byte, error) {
+				var req Request
+				req.SetBodyStream(stream, -1)
+
+				var dst bytes.Buffer
+				if err := req.BodyWriteTo(&dst); err != nil {
+					return nil, err
+				}
+				return dst.Bytes(), nil
+			},
+		},
+		{
+			name: "response SwapBody",
+			run: func(stream io.Reader) ([]byte, error) {
+				var resp Response
+				resp.SetBodyStream(stream, -1)
+				return resp.SwapBody(nil), nil
+			},
+		},
+		{
+			name: "request SwapBody",
+			run: func(stream io.Reader) ([]byte, error) {
+				var req Request
+				req.SetBodyStream(stream, -1)
+				return req.SwapBody(nil), nil
+			},
+		},
+		{
+			name: "fixed-size response write",
+			run: func(stream io.Reader) ([]byte, error) {
+				var resp Response
+				resp.SetBodyStream(stream, len(body))
+
+				var dst bytes.Buffer
+				bw := bufio.NewWriter(&dst)
+				if err := resp.Write(bw); err != nil {
+					return nil, err
+				}
+				if err := bw.Flush(); err != nil {
+					return nil, err
+				}
+
+				var decoded Response
+				if err := decoded.Read(bufio.NewReader(&dst)); err != nil {
+					return nil, err
+				}
+				return decoded.Body(), nil
+			},
+		},
+		{
+			name: "gzip response write",
+			run: func(stream io.Reader) ([]byte, error) {
+				var resp Response
+				resp.Header.SetContentType("text/plain")
+				resp.SetBodyStream(stream, -1)
+
+				var dst bytes.Buffer
+				bw := bufio.NewWriter(&dst)
+				if err := resp.WriteGzip(bw); err != nil {
+					return nil, err
+				}
+				if err := bw.Flush(); err != nil {
+					return nil, err
+				}
+
+				var decoded Response
+				if err := decoded.Read(bufio.NewReader(&dst)); err != nil {
+					return nil, err
+				}
+				return decoded.BodyGunzip()
+			},
+		},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			t.Run("unmarked WriterTo keeps legacy behavior", func(t *testing.T) {
+				inner := &embeddedWriterTo{r: bytes.NewReader(body)}
+				stream := &promotedWriterToBody{embeddedWriterTo: inner}
+
+				got, err := operation.run(stream)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !bytes.Equal(got, body) {
+					t.Fatalf("unexpected body of len %d. Expecting len %d", len(got), len(body))
+				}
+				if inner.writeCnt != 1 {
+					t.Fatalf("WriteTo must be called once, got %d", inner.writeCnt)
+				}
+				if stream.readCnt != 0 {
+					t.Fatalf("Read must not be called for an unmarked legacy WriterTo, got %d", stream.readCnt)
+				}
+			})
+
+			t.Run("explicit opt-in uses WriterTo", func(t *testing.T) {
+				stream := &optInInner{r: bytes.NewReader(body)}
+
+				got, err := operation.run(stream)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !bytes.Equal(got, body) {
+					t.Fatalf("unexpected body of len %d. Expecting len %d", len(got), len(body))
+				}
+				if stream.writeCnt != 1 {
+					t.Fatalf("WriteTo must be called once, got %d", stream.writeCnt)
+				}
+				if stream.readCnt != 0 {
+					t.Fatalf("Read must not be called for an opted-in BodyWriterTo, got %d", stream.readCnt)
+				}
+			})
+
+			t.Run("explicit opt-out uses Read", func(t *testing.T) {
+				inner := &optInInner{r: bytes.NewReader(body)}
+				stream := &optOutBody{optInInner: inner}
+
+				got, err := operation.run(stream)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !bytes.Equal(got, body) {
+					t.Fatalf("unexpected body of len %d. Expecting len %d", len(got), len(body))
+				}
+				if inner.writeCnt != 0 {
+					t.Fatalf("WriteTo must not be called after opting out, got %d", inner.writeCnt)
+				}
+				if stream.readCnt == 0 {
+					t.Fatal("Read must be called after opting out")
+				}
+			})
+		})
+	}
+}
 
 func TestWriteBodyChunkedOptOutOverride(t *testing.T) {
 	t.Parallel()
@@ -3950,10 +4128,10 @@ func TestWriteBodyChunkedOptOutOverride(t *testing.T) {
 	inner := &optInInner{r: bytes.NewReader([]byte(body))}
 	stream := &optOutBody{optInInner: inner}
 
-	// stream implements ChunkedBodyWriterTo (the method is promoted/overridden),
-	// but its SupportsChunkedBodyWriteTo returns false, so it must use Read.
-	if _, ok := any(stream).(ChunkedBodyWriterTo); !ok {
-		t.Fatal("test setup: stream must implement ChunkedBodyWriterTo")
+	// stream implements BodyWriterTo (the method is promoted/overridden), but
+	// its SupportsBodyWriteTo returns false, so it must use Read.
+	if _, ok := any(stream).(BodyWriterTo); !ok {
+		t.Fatal("test setup: stream must implement BodyWriterTo")
 	}
 
 	var resp Response
@@ -3985,7 +4163,7 @@ func TestWriteBodyChunkedOptOutOverride(t *testing.T) {
 }
 
 // Standard bytes types take the zero-copy path without implementing
-// ChunkedBodyWriterTo; the output must still be correct.
+// BodyWriterTo; the output must still be correct.
 func TestWriteBodyChunkedConcreteTypes(t *testing.T) {
 	t.Parallel()
 

--- a/server.go
+++ b/server.go
@@ -1625,7 +1625,8 @@ func (ctx *RequestCtx) PostBody() []byte {
 //
 // If bodySize < 0, then bodyStream is read until io.EOF.
 //
-// See ChunkedBodyWriterTo for custom streams writing unknown-size chunked bodies.
+// See BodyWriterTo for controlling whether fasthttp may use WriteTo instead of
+// Read when consuming bodyStream.
 //
 // See also SetBodyStreamWriter.
 func (ctx *RequestCtx) SetBodyStream(bodyStream io.Reader, bodySize int) {


### PR DESCRIPTION
We still fall back to `copyZeroAlloc()` for backwards compatibility. So nobody gets a performance degration if they don't implement `BodyWriterTo`.
But it allows developers to implement `BodyWriterTo` and have `SupportsBodyWriteTo` return false.

Not backwards compatible, but `ChunkedBodyWriterTo` wasn't tagged in a release yet, so acceptable.