### PR TITLE
HTTP/1 behavior fixes split from the HTTP/2 PR

### DIFF
--- a/client.go
+++ b/client.go
@@ -1829,8 +1829,37 @@ var ErrTimeout = &timeoutError{}
 // SetMaxConns sets up the maximum number of connections which may be established to all hosts listed in Addr.
 func (c *HostClient) SetMaxConns(newMaxConns int) {
 	c.connsLock.Lock()
+	defer c.connsLock.Unlock()
 	c.MaxConns = newMaxConns
-	c.connsLock.Unlock()
+	// Grown capacity must reach requests already parked in the wait queue.
+	for c.connsCount < c.maxConnsLocked() && c.serveWaiterLocked() {
+		c.connsCount++
+	}
+}
+
+// maxConnsLocked is MaxConns with its default applied. connsLock must be held.
+func (c *HostClient) maxConnsLocked() int {
+	if c.MaxConns <= 0 {
+		return DefaultMaxConnsPerHost
+	}
+	return c.MaxConns
+}
+
+// serveWaiterLocked hands a connection slot to the next parked waiter and
+// reports whether one took it. connsLock must be held.
+func (c *HostClient) serveWaiterLocked() bool {
+	for q := c.connsWait; q != nil && q.len() > 0; {
+		if w := q.popFront(); w.waiting() {
+			// The connection dialed for the waiter is pooled on release.
+			if !c.connsCleanerRun {
+				c.connsCleanerRun = true
+				go c.connsCleaner()
+			}
+			go c.dialConnFor(w)
+			return true
+		}
+	}
+	return false
 }
 
 func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool) (cc *clientConn, err error) {
@@ -1841,11 +1870,7 @@ func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool)
 	c.connsLock.Lock()
 	n = len(c.conns)
 	if n == 0 {
-		maxConns := c.MaxConns
-		if maxConns <= 0 {
-			maxConns = DefaultMaxConnsPerHost
-		}
-		if c.connsCount < maxConns {
+		if c.connsCount < c.maxConnsLocked() {
 			c.connsCount++
 			createConn = true
 			if !c.connsCleanerRun && !connectionClose {
@@ -2049,18 +2074,13 @@ func (c *HostClient) decConnsCount() {
 
 	c.connsLock.Lock()
 	defer c.connsLock.Unlock()
-	dialed := false
-	if q := c.connsWait; q != nil {
-		for q.len() > 0 {
-			w := q.popFront()
-			if w.waiting() {
-				go c.dialConnFor(w)
-				dialed = true
-				break
-			}
-		}
+	if c.connsCount > c.maxConnsLocked() {
+		// The limit shrank while this slot was held; retire it so the count
+		// converges on the new cap instead of handing it to a waiter.
+		c.connsCount--
+		return
 	}
-	if !dialed {
+	if !c.serveWaiterLocked() {
 		c.connsCount--
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5699,3 +5699,132 @@ func TestClientRetryIfErrUpstream(t *testing.T) {
 		}
 	})
 }
+
+func TestSetMaxConnsWakesQueuedWaiters(t *testing.T) {
+	t.Parallel()
+
+	dialed := make(chan net.Conn, 4)
+	hc := &HostClient{
+		Addr:               "example.com:80",
+		MaxConns:           1,
+		MaxConnWaitTimeout: 5 * time.Second,
+		Dial: func(string) (net.Conn, error) {
+			left, right := net.Pipe()
+			dialed <- right
+			return left, nil
+		},
+	}
+	hc.connsLock.Lock()
+	hc.connsCount = 1
+	hc.connsLock.Unlock()
+
+	acquired := make(chan error, 1)
+	go func() {
+		_, err := hc.AcquireConn(0, false)
+		acquired <- err
+	}()
+	for i := 0; ; i++ {
+		hc.connsLock.Lock()
+		queued := hc.connsWait != nil && hc.connsWait.len() > 0
+		hc.connsLock.Unlock()
+		if queued {
+			break
+		}
+		if i > 1000 {
+			t.Fatal("waiter never queued")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	hc.SetMaxConns(2)
+	select {
+	case err := <-acquired:
+		if err != nil {
+			t.Fatalf("queued acquire error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SetMaxConns() didn't wake the queued waiter")
+	}
+	if got := hc.ConnsCount(); got != 2 {
+		t.Fatalf("ConnsCount() = %d, want 2", got)
+	}
+}
+
+// A connection dialed for a queued waiter is pooled on release, so the idle
+// cleaner must run for it even when no earlier connection started one.
+func TestSetMaxConnsStartsIdleCleanerForWaiter(t *testing.T) {
+	t.Parallel()
+
+	hc := &HostClient{
+		Addr:                "example.com:80",
+		MaxConns:            1,
+		MaxConnWaitTimeout:  5 * time.Second,
+		MaxIdleConnDuration: 10 * time.Millisecond,
+		Dial: func(string) (net.Conn, error) {
+			left, _ := net.Pipe()
+			return left, nil
+		},
+	}
+	// A Connection: close request does not start the cleaner.
+	first, err := hc.AcquireConn(0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acquired := make(chan error, 1)
+	go func() {
+		cc, err := hc.AcquireConn(0, false)
+		if err == nil {
+			hc.ReleaseConn(cc)
+		}
+		acquired <- err
+	}()
+	for i := 0; ; i++ {
+		hc.connsLock.Lock()
+		queued := hc.connsWait != nil && hc.connsWait.len() > 0
+		hc.connsLock.Unlock()
+		if queued {
+			break
+		}
+		if i > 1000 {
+			t.Fatal("waiter never queued")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	hc.SetMaxConns(2)
+	if err := <-acquired; err != nil {
+		t.Fatalf("queued acquire error: %v", err)
+	}
+	hc.CloseConn(first)
+	deadline := time.Now().Add(testTimeout(2 * time.Second))
+	for hc.IdleConnsCount() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("IdleConnsCount() = %d, want the waiter's connection expired", hc.IdleConnsCount())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestReleasedConnsConvergeAfterMaxConnsShrink(t *testing.T) {
+	t.Parallel()
+
+	hc := &HostClient{
+		Addr:               "example.com:80",
+		MaxConns:           2,
+		MaxConnWaitTimeout: 5 * time.Second,
+	}
+	hc.connsLock.Lock()
+	hc.connsCount = 2
+	hc.connsLock.Unlock()
+
+	hc.SetMaxConns(1)
+	hc.decConnsCount()
+	if got := hc.ConnsCount(); got != 1 {
+		t.Fatalf("ConnsCount() after shrink = %d, want the retired slot gone", got)
+	}
+	hc.decConnsCount()
+	if got := hc.ConnsCount(); got != 0 {
+		t.Fatalf("ConnsCount() = %d, want 0", got)
+	}
+}

--- a/fasthttpadaptor/adaptor.go
+++ b/fasthttpadaptor/adaptor.go
@@ -64,10 +64,23 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 		go func() {
 			defer func() {
 				if rec := recover(); rec != nil {
-					ctx.Logger().Printf("panic in net/http handler: %v", rec)
+					// ErrAbortHandler is net/http's quiet give-up.
+					mode := modePanicked
+					if rec == http.ErrAbortHandler {
+						mode = modeAborted
+					}
+					if w.pw != nil {
+						// The stream is the server's now: the exit is recorded
+						// while the request is still ours, then the pipe error
+						// cuts the connection.
+						w.stream.fail(ctx, rec)
+						_ = w.pw.CloseWithError(io.ErrUnexpectedEOF)
+					} else if mode == modePanicked {
+						ctx.Logger().Printf("panic in net/http handler: %v", rec)
+					}
 
 					select {
-					case w.modeCh <- modePanicked:
+					case w.modeCh <- mode:
 					default:
 					}
 				} else {
@@ -115,8 +128,9 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 			releaseWriter(w)
 
 		case modeFlushed:
-			// Streaming: send headers and start SetBodyStreamWriter.
+			// Streaming: send the headers now and hand the body to SetBodyStream.
 			ctx.SetStatusCode(w.status())
+			ctx.Response.ImmediateHeaderFlush = true
 
 			haveContentType := false
 			for k, vv := range w.Header() {
@@ -140,35 +154,11 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 				w.mu.Unlock()
 			}
 
-			ctx.SetBodyStreamWriter(func(bw *bufio.Writer) {
-				// Ensure cleanup only after the stream completes.
-				defer releaseWriter(w)
-
-				// Send pre-flush bytes.
-				if b := w.consumePreflush(); len(b) > 0 {
-					_, _ = bw.Write(b)
-					_ = bw.Flush()
-				}
-
-				// Stream subsequent writes from the pipe until EOF.
-				buf := bufferPool.Get().(*[]byte) //nolint:forcetypeassert
-				defer bufferPool.Put(buf)
-
-				for {
-					n, err := w.pr.Read(*buf)
-					if n > 0 {
-						if _, e := bw.Write((*buf)[:n]); e != nil {
-							return
-						}
-						if e := bw.Flush(); e != nil {
-							return
-						}
-					}
-					if err != nil {
-						return
-					}
-				}
-			})
+			// The pipe feeds fasthttp's chunked writer directly, so the
+			// server truncates the response and drops the connection when a
+			// handler exit closes the pipe with an error.
+			w.stream = &streamBody{pre: w.consumePreflush(), w: w}
+			ctx.Response.SetBodyStream(w.stream, -1)
 
 			// Signal the writer that streaming is ready so Flush() can return.
 			close(w.streamReady)
@@ -177,10 +167,79 @@ func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
 			releaseWriter(w)
 			return
 
+		case modeAborted:
+			releaseWriter(w)
+			// Hijacking skips the response write and leaves teardown to the
+			// server, so a pooled per-IP wrapper is closed exactly once; the
+			// handler's Close only acts when KeepHijackedConns is set.
+			ctx.HijackSetNoResponse(true)
+			ctx.Hijack(func(c net.Conn) { _ = c.Close() })
+
 		case modePanicked:
 			panic("net/http handler panicked")
 		}
 	}
+}
+
+// streamBody feeds a flushed response through fasthttp's chunked writer and
+// recycles the writer once the server is done with it.
+type streamBody struct {
+	mu     sync.Mutex
+	pre    []byte // pooled pre-flush bytes, recycled by Close
+	w      *writer
+	err    error
+	closed bool
+}
+
+func (b *streamBody) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return 0, io.ErrClosedPipe
+	}
+	if len(b.pre) > 0 {
+		n := copy(p, b.pre)
+		b.pre = b.pre[n:]
+		b.mu.Unlock()
+		return n, nil
+	}
+	b.mu.Unlock()
+	// The pipe is read without the lock, so Close and fail never wait on it.
+	return b.w.pr.Read(p)
+}
+
+// fail records a handler exit while the server still owns the request; a
+// closed stream may belong to a request already released or reused.
+func (b *streamBody) fail(ctx *fasthttp.RequestCtx, rec any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.err = io.ErrUnexpectedEOF
+	if rec != http.ErrAbortHandler {
+		ctx.Logger().Printf("panic in net/http handler: %v", rec)
+	}
+}
+
+// Close fails further reads before the pre-flush buffer is recycled, since a
+// discarded body may still be read by a compression goroutine, and reports
+// a handler exit the server has not read.
+func (b *streamBody) Close() error {
+	_ = b.w.pr.Close()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.closed {
+		b.closed = true
+		releaseWriter(b.w)
+	}
+	return b.err
+}
+
+// CloseWithError reports the handler's exit when CompressHandler's goroutine,
+// not the server, closes the stream.
+func (b *streamBody) CloseWithError(error) error {
+	return b.Close()
 }
 
 var bufferPool = sync.Pool{
@@ -195,6 +254,7 @@ const (
 	modeFlushed
 	modeHijacked
 	modePanicked
+	modeAborted
 )
 
 // Writer implements http.ResponseWriter + http.Flusher + http.Hijacker for the adaptor.
@@ -207,8 +267,9 @@ type writer struct {
 	responseBody []byte
 	bufPool      *[]byte
 
-	pr *io.PipeReader
-	pw *io.PipeWriter
+	pr     *io.PipeReader
+	stream *streamBody
+	pw     *io.PipeWriter
 
 	hijacked atomic.Bool
 
@@ -221,15 +282,11 @@ type writer struct {
 }
 
 func acquireWriter(ctx *fasthttp.RequestCtx) *writer {
-	pr, pw := io.Pipe()
 	return &writer{
-		ctx:          ctx,
-		h:            make(http.Header),
-		responseBody: nil,
-		pr:           pr,
-		pw:           pw,
-		modeCh:       make(chan int, 1),
-		streamReady:  make(chan struct{}),
+		ctx:         ctx,
+		h:           make(http.Header),
+		modeCh:      make(chan int, 1),
+		streamReady: make(chan struct{}),
 	}
 }
 
@@ -278,7 +335,11 @@ func (w *writer) Write(p []byte) (int, error) {
 }
 
 func (w *writer) Flush() {
+	if w.hijacked.Load() {
+		return
+	}
 	w.flushOnce.Do(func() {
+		w.pr, w.pw = io.Pipe()
 		select {
 		case w.modeCh <- modeFlushed:
 		default:
@@ -337,8 +398,9 @@ func (w *writer) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 func (w *writer) Close() error {
 	w.closeOnce.Do(func() {
-		_ = w.pw.Close()
-		_ = w.pr.Close()
+		if w.pw != nil {
+			_ = w.pw.Close()
+		}
 	})
 	return nil
 }

--- a/fasthttpadaptor/adaptor_test.go
+++ b/fasthttpadaptor/adaptor_test.go
@@ -3,6 +3,7 @@ package fasthttpadaptor
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -10,6 +11,9 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -455,6 +459,11 @@ func TestHijackFlush(t *testing.T) {
 			if c, rw, err := f.Hijack(); err != nil {
 				t.Error(err)
 			} else {
+				// Flushing the ResponseWriter after Hijack must not block.
+				if fl, ok := w.(http.Flusher); ok {
+					fl.Flush()
+				}
+
 				if _, err := rw.WriteString("bar"); err != nil {
 					t.Error(err)
 				}
@@ -717,6 +726,8 @@ func TestWriterWriteRechecksStreamingReadyAfterLock(t *testing.T) {
 	}()
 
 	time.Sleep(10 * time.Millisecond)
+	// Flush builds the pipe before it makes streaming ready; do the same here.
+	w.pr, w.pw = io.Pipe()
 	close(w.streamReady)
 
 	readCh := make(chan []byte, 1)
@@ -799,5 +810,325 @@ func TestNewFastHTTPHandlerPresetStatusCodeOverriddenByHandler(t *testing.T) {
 	if ctx.Response.StatusCode() != fasthttp.StatusNotFound {
 		t.Fatalf("unexpected status code: %d. Expecting %d (handler's WriteHeader should win)",
 			ctx.Response.StatusCode(), fasthttp.StatusNotFound)
+	}
+}
+
+// A client vanishing mid-stream must not race the request's teardown.
+func TestHandlerStreamClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	s := &fasthttp.Server{Handler: NewFastHTTPHandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("chunk"))
+		w.(http.Flusher).Flush() //nolint:forcetypeassert
+		for range 50 {
+			if _, err := w.Write([]byte("more")); err != nil {
+				return
+			}
+		}
+	})}
+	ln := fasthttputil.NewInmemoryListener()
+	go s.Serve(ln) //nolint:errcheck
+	defer ln.Close()
+
+	for range 50 {
+		c, err := ln.Dial()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Write([]byte("GET / HTTP/1.1\r\nHost: a\r\n\r\n")); err != nil {
+			t.Fatal(err)
+		}
+		buf := make([]byte, 64)
+		_, _ = c.Read(buf)
+		_ = c.Close()
+	}
+}
+
+// A HEAD response discards the stream while CompressHandler's goroutine may
+// still be reading it; the pre-flush buffer must not be recycled under it.
+func TestHandlerFlushedHeadWithCompression(t *testing.T) {
+	t.Parallel()
+
+	s := &fasthttp.Server{Handler: fasthttp.CompressHandler(NewFastHTTPHandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("a"), 32*1024))
+		w.(http.Flusher).Flush() //nolint:forcetypeassert
+	}))}
+	ln := fasthttputil.NewInmemoryListener()
+	go s.Serve(ln) //nolint:errcheck
+	defer ln.Close()
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			c, err := ln.Dial()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer c.Close()
+			br := bufio.NewReader(c)
+			for range 100 {
+				if _, err := c.Write([]byte("HEAD / HTTP/1.1\r\nHost: a\r\nAccept-Encoding: gzip\r\n\r\n")); err != nil {
+					t.Error(err)
+					return
+				}
+				var resp fasthttp.Response
+				resp.SkipBody = true
+				if err := resp.Read(br); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// panic(http.ErrAbortHandler) gives up on the response without crashing.
+func TestHandlerAbortIsQuiet(t *testing.T) {
+	t.Parallel()
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.SetRequestURI("/")
+	ctx.Request.Header.SetHost("example.com")
+
+	NewFastHTTPHandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic(http.ErrAbortHandler)
+	})(ctx)
+}
+
+// An abort before the first write sends nothing, and the server tears the
+// connection down exactly once — through the per-IP wrapper too.
+func TestHandlerAbortWithPerIPLimit(t *testing.T) {
+	t.Parallel()
+
+	for _, keep := range []bool{false, true} {
+		s := &fasthttp.Server{
+			Handler: NewFastHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/abort" {
+					panic(http.ErrAbortHandler)
+				}
+				_, _ = w.Write([]byte("ok"))
+			}),
+			MaxConnsPerIP:     1,
+			KeepHijackedConns: keep,
+		}
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		go s.Serve(ln) //nolint:errcheck
+
+		c, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Write([]byte("GET /abort HTTP/1.1\r\nHost: a\r\n\r\n")); err != nil {
+			t.Fatal(err)
+		}
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		if b, err := io.ReadAll(c); err != nil || len(b) != 0 {
+			t.Fatalf("keep=%v: aborted response carried %q (err=%v), want nothing", keep, b, err)
+		}
+		_ = c.Close()
+
+		// The per-IP slot must free up and the server must still be serving.
+		var follow string
+		for range 50 {
+			c2, err := net.Dial("tcp", ln.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = c2.Write([]byte("GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n"))
+			_ = c2.SetReadDeadline(time.Now().Add(2 * time.Second))
+			b, _ := io.ReadAll(c2)
+			_ = c2.Close()
+			follow = string(b)
+			if strings.Contains(follow, " 200 ") && strings.HasSuffix(follow, "ok") {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if !strings.Contains(follow, " 200 ") || !strings.HasSuffix(follow, "ok") {
+			t.Fatalf("keep=%v: follow-up response %q, want a 200 with body ok", keep, follow)
+		}
+		_ = ln.Close()
+	}
+}
+
+type logRecorder struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *logRecorder) Printf(format string, args ...any) {
+	l.mu.Lock()
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+	l.mu.Unlock()
+}
+
+func (l *logRecorder) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.lines, "\n")
+}
+
+// A panic after a Flush must neither hang the client on a body that never
+// completes nor let the connection serve a pipelined request, as in net/http;
+// an abort stays quiet, any other panic is logged once. Under CompressHandler
+// the response completes, but the log and the close remain.
+func TestHandlerPanicAfterFlush(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		prefix     string
+		panic      any
+		compressed bool
+		wantLog    string
+	}{
+		{"abort", "partial", http.ErrAbortHandler, false, ""},
+		{"abort-headers-only", "", http.ErrAbortHandler, false, ""},
+		{"panic", "partial", "boom", false, "panic in net/http handler: boom"},
+		{"panic-eof", "partial", io.ErrUnexpectedEOF, false, "panic in net/http handler: unexpected EOF"},
+		{"abort-compressed", "partial", http.ErrAbortHandler, true, ""},
+		{"panic-compressed", "partial", "boom", true, "panic in net/http handler: boom"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var secondServed atomic.Bool
+			logs := &logRecorder{}
+			closed := make(chan struct{}, 1)
+			h := NewFastHTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/" {
+					secondServed.Store(true)
+					return
+				}
+				_, _ = w.Write([]byte(tc.prefix))
+				w.(http.Flusher).Flush() //nolint:forcetypeassert
+				panic(tc.panic)
+			})
+			if tc.compressed {
+				h = fasthttp.CompressHandler(h)
+			}
+			s := &fasthttp.Server{
+				Handler: h,
+				Logger:  logs,
+				ConnState: func(_ net.Conn, st fasthttp.ConnState) {
+					if st == fasthttp.StateClosed {
+						select {
+						case closed <- struct{}{}:
+						default:
+						}
+					}
+				},
+			}
+			ln := fasthttputil.NewInmemoryListener()
+			go s.Serve(ln) //nolint:errcheck
+			defer ln.Close()
+
+			c, err := ln.Dial()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			if _, err := c.Write([]byte(
+				"GET / HTTP/1.1\r\nHost: a\r\nAccept-Encoding: gzip\r\n\r\nGET /second HTTP/1.1\r\nHost: a\r\n\r\n")); err != nil {
+				t.Fatal(err)
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				br := bufio.NewReader(c)
+				resp, err := http.ReadResponse(br, nil)
+				if err != nil {
+					done <- fmt.Errorf("reading the flushed headers: %w", err)
+					return
+				}
+				defer resp.Body.Close()
+				first := make([]byte, len(tc.prefix))
+				if _, err := io.ReadFull(resp.Body, first); err != nil {
+					done <- err
+					return
+				}
+				if _, err := io.ReadAll(resp.Body); err == nil && !tc.compressed {
+					done <- errors.New("the aborted body ended in a clean EOF")
+					return
+				}
+				if resp2, err := http.ReadResponse(br, nil); err == nil {
+					_ = resp2.Body.Close()
+					done <- errors.New("the connection served a second response after the abort")
+					return
+				}
+				done <- nil
+			}()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("the body of an aborted flushed response never ended")
+			}
+			if secondServed.Load() {
+				t.Fatal("the handler ran for a pipelined request after the abort")
+			}
+			// The server logs, if at all, before it reports the connection closed.
+			<-closed
+			if got := logs.String(); !strings.Contains(got, tc.wantLog) || (tc.wantLog == "" && got != "") {
+				t.Fatalf("server log = %q, want %q", got, tc.wantLog)
+			}
+		})
+	}
+}
+
+// Flush() without a body puts the headers on the wire, as in net/http.
+func TestHandlerFlushSendsHeaders(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	s := &fasthttp.Server{Handler: NewFastHTTPHandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Early", "1")
+		w.(http.Flusher).Flush() //nolint:forcetypeassert
+		<-release
+	})}
+	ln := fasthttputil.NewInmemoryListener()
+	go s.Serve(ln) //nolint:errcheck
+	defer ln.Close()
+	defer close(release)
+
+	c, err := ln.Dial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if _, err := c.Write([]byte("GET / HTTP/1.1\r\nHost: a\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	headers := make(chan error, 1)
+	go func() {
+		resp, err := http.ReadResponse(bufio.NewReader(c), nil)
+		if err != nil {
+			headers <- err
+			return
+		}
+		defer resp.Body.Close()
+		if resp.Header.Get("X-Early") != "1" {
+			headers <- fmt.Errorf("X-Early = %q, want 1", resp.Header.Get("X-Early"))
+			return
+		}
+		headers <- nil
+		// Let the handler finish so Close can drain the body.
+		<-release
+	}()
+	select {
+	case err := <-headers:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the flushed headers did not arrive while the handler was still running")
 	}
 }

--- a/fasthttpadaptor/request.go
+++ b/fasthttpadaptor/request.go
@@ -25,13 +25,20 @@ func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) e
 	}
 
 	r.Method = b2s(ctx.Method())
-	r.Proto = b2s(ctx.Request.Header.Protocol())
-	if r.Proto == "HTTP/2" {
-		r.ProtoMajor = 2
-	} else {
-		r.ProtoMajor = 1
+	// net/http spells the HTTP/2 version "HTTP/2.0", and its minor version is 0.
+	switch r.Proto = b2s(ctx.Request.Header.Protocol()); r.Proto {
+	case "HTTP/1.1":
+		r.ProtoMajor, r.ProtoMinor = 1, 1
+	case "HTTP/1.0":
+		r.ProtoMajor, r.ProtoMinor = 1, 0
+	case "HTTP/2", "HTTP/2.0":
+		r.Proto, r.ProtoMajor, r.ProtoMinor = "HTTP/2.0", 2, 0
+	default:
+		var ok bool
+		if r.ProtoMajor, r.ProtoMinor, ok = http.ParseHTTPVersion(r.Proto); !ok {
+			r.ProtoMajor, r.ProtoMinor = 1, 1
+		}
 	}
-	r.ProtoMinor = 1
 	r.ContentLength = int64(len(body))
 	r.RemoteAddr = ctx.RemoteAddr().String()
 	r.Host = b2s(ctx.Host())

--- a/fasthttpadaptor/request_test.go
+++ b/fasthttpadaptor/request_test.go
@@ -55,3 +55,31 @@ func BenchmarkConvertRequest(b *testing.B) {
 		_ = ConvertRequest(ctx, &httpReq, true)
 	}
 }
+
+func TestConvertRequestProtocolVersion(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		protocol, wantProto  string
+		wantMajor, wantMinor int
+	}{
+		{"HTTP/2", "HTTP/2.0", 2, 0},
+		{"HTTP/1.0", "HTTP/1.0", 1, 0},
+		{"HTTP/1.1", "HTTP/1.1", 1, 1},
+	} {
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+		ctx.Request.SetRequestURI("/")
+		ctx.Request.Header.SetHost("example.com")
+		ctx.Request.Header.SetProtocol(tc.protocol)
+
+		var r http.Request
+		if err := ConvertRequest(ctx, &r, true); err != nil {
+			t.Fatalf("ConvertRequest(%s) error: %v", tc.protocol, err)
+		}
+		if r.Proto != tc.wantProto || r.ProtoMajor != tc.wantMajor || r.ProtoMinor != tc.wantMinor {
+			t.Errorf("%s -> %q %d.%d, want %q %d.%d",
+				tc.protocol, r.Proto, r.ProtoMajor, r.ProtoMinor, tc.wantProto, tc.wantMajor, tc.wantMinor)
+		}
+	}
+}

--- a/peripconn.go
+++ b/peripconn.go
@@ -4,13 +4,12 @@ import (
 	"crypto/tls"
 	"net"
 	"sync"
+	"sync/atomic"
 )
 
 type perIPConnCounter struct {
-	perIPConnPool    sync.Pool
-	perIPTLSConnPool sync.Pool
-	m                map[uint32]int
-	lock             sync.Mutex
+	m    map[uint32]int
+	lock sync.Mutex
 }
 
 func (cc *perIPConnCounter) Register(ip uint32) int {
@@ -39,13 +38,15 @@ func (cc *perIPConnCounter) Unregister(ip uint32) {
 	}
 }
 
+// A per-IP wrapper is not recycled: Shutdown closes the connection from
+// another goroutine while the serving one may still use the wrapper.
 type perIPConn struct {
 	net.Conn
 
 	perIPConnCounter *perIPConnCounter
 
-	ip   uint32
-	lock sync.Mutex
+	ip     uint32
+	closed atomic.Bool
 }
 
 type perIPTLSConn struct {
@@ -53,69 +54,40 @@ type perIPTLSConn struct {
 
 	perIPConnCounter *perIPConnCounter
 
-	ip   uint32
-	lock sync.Mutex
+	ip     uint32
+	closed atomic.Bool
 }
 
-func acquirePerIPConn(conn net.Conn, ip uint32, counter *perIPConnCounter) net.Conn {
+func newPerIPConn(conn net.Conn, ip uint32, counter *perIPConnCounter) net.Conn {
 	if tlsConn, ok := conn.(*tls.Conn); ok {
-		v := counter.perIPTLSConnPool.Get()
-		if v == nil {
-			return &perIPTLSConn{
-				perIPConnCounter: counter,
-				Conn:             tlsConn,
-				ip:               ip,
-			}
-		}
-		c := v.(*perIPTLSConn) //nolint:forcetypeassert
-		c.Conn = tlsConn
-		c.ip = ip
-		return c
-	}
-
-	v := counter.perIPConnPool.Get()
-	if v == nil {
-		return &perIPConn{
+		return &perIPTLSConn{
 			perIPConnCounter: counter,
-			Conn:             conn,
+			Conn:             tlsConn,
 			ip:               ip,
 		}
 	}
-	c := v.(*perIPConn) //nolint:forcetypeassert
-	c.Conn = conn
-	c.ip = ip
-	return c
+	return &perIPConn{
+		perIPConnCounter: counter,
+		Conn:             conn,
+		ip:               ip,
+	}
 }
 
 func (c *perIPConn) Close() error {
-	c.lock.Lock()
-	cc := c.Conn
-	c.Conn = nil
-	c.lock.Unlock()
-
-	if cc == nil {
+	if c.closed.Swap(true) {
 		return nil
 	}
-
-	err := cc.Close()
+	err := c.Conn.Close()
 	c.perIPConnCounter.Unregister(c.ip)
-	c.perIPConnCounter.perIPConnPool.Put(c)
 	return err
 }
 
 func (c *perIPTLSConn) Close() error {
-	c.lock.Lock()
-	cc := c.Conn
-	c.Conn = nil
-	c.lock.Unlock()
-
-	if cc == nil {
+	if c.closed.Swap(true) {
 		return nil
 	}
-
-	err := cc.Close()
+	err := c.Conn.Close()
 	c.perIPConnCounter.Unregister(c.ip)
-	c.perIPConnCounter.perIPTLSConnPool.Put(c)
 	return err
 }
 

--- a/server.go
+++ b/server.go
@@ -852,26 +852,30 @@ type tlsConn interface {
 	ConnectionState() tls.ConnectionState
 }
 
+// tlsConnection unwraps ctx.c to its TLS connection, if it is one.
+// The cast is to (tlsConn) instead of (*tls.Conn), since it catches
+// cases with overridden tls.Conn such as:
+//
+//	type customConn struct {
+//	    *tls.Conn
+//
+//	    // other custom fields here
+//	}
+func (ctx *RequestCtx) tlsConnection() (tlsConn, bool) {
+	conn := ctx.c
+	// perIPConn wraps the net.Conn in the Conn field.
+	if pic, ok := conn.(*perIPConn); ok {
+		conn = pic.Conn
+	}
+	tc, ok := conn.(tlsConn)
+	return tc, ok
+}
+
 // IsTLS returns true if the underlying connection is tls.Conn.
 //
 // tls.Conn is an encrypted connection (aka SSL, HTTPS).
 func (ctx *RequestCtx) IsTLS() bool {
-	// cast to (tlsConn) instead of (*tls.Conn), since it catches
-	// cases with overridden tls.Conn such as:
-	//
-	// type customConn struct {
-	//     *tls.Conn
-	//
-	//     // other custom fields here
-	// }
-
-	// perIPConn wraps the net.Conn in the Conn field
-	if pic, ok := ctx.c.(*perIPConn); ok {
-		_, ok := pic.Conn.(tlsConn)
-		return ok
-	}
-
-	_, ok := ctx.c.(tlsConn)
+	_, ok := ctx.tlsConnection()
 	return ok
 }
 
@@ -882,7 +886,7 @@ func (ctx *RequestCtx) IsTLS() bool {
 // The returned state may be used for verifying TLS version, client certificates,
 // etc.
 func (ctx *RequestCtx) TLSConnectionState() *tls.ConnectionState {
-	tc, ok := ctx.c.(tlsConn)
+	tc, ok := ctx.tlsConnection()
 	if !ok {
 		return nil
 	}

--- a/server.go
+++ b/server.go
@@ -988,8 +988,11 @@ func (ctx *RequestCtx) String() string {
 }
 
 // ID returns unique ID of the request.
+//
+// ConnID occupies the high 32 bits and ConnRequestNum the low 32, so the ID
+// repeats once either passes 2^32. Use those accessors to avoid the wrap.
 func (ctx *RequestCtx) ID() uint64 {
-	return (ctx.connID << 32) | ctx.connRequestNum
+	return (ctx.connID << 32) | (ctx.connRequestNum & 0xffffffff)
 }
 
 // ConnID returns unique connection ID.

--- a/server.go
+++ b/server.go
@@ -242,7 +242,8 @@ type Server struct {
 
 	nextProtos map[string]ServeHandler
 
-	concurrencyCh chan struct{}
+	concurrencyCh     chan struct{}
+	concurrencyChOnce sync.Once
 
 	idleConns map[net.Conn]*atomic.Int64
 	done      chan struct{}
@@ -498,7 +499,7 @@ func TimeoutWithCodeHandler(h RequestHandler, timeout time.Duration, msg string,
 	}
 
 	return func(ctx *RequestCtx) {
-		concurrencyCh := ctx.s.concurrencyCh
+		concurrencyCh := ctx.s.getConcurrencyCh()
 		select {
 		case concurrencyCh <- struct{}{}:
 		default:
@@ -1992,9 +1993,7 @@ func (s *Server) Serve(ln net.Listener) error {
 	if s.done == nil {
 		s.done = make(chan struct{})
 	}
-	if s.concurrencyCh == nil {
-		s.concurrencyCh = make(chan struct{}, maxWorkersCount)
-	}
+	s.getConcurrencyCh()
 	s.mu.Unlock()
 
 	wp := &workerPool{
@@ -2300,6 +2299,15 @@ func (s *Server) getConcurrency() int {
 		n = DefaultConcurrency
 	}
 	return n
+}
+
+// getConcurrencyCh returns the gate TimeoutHandler admits requests through.
+// Serve allocates it up front; ServeConn never calls Serve.
+func (s *Server) getConcurrencyCh() chan struct{} {
+	s.concurrencyChOnce.Do(func() {
+		s.concurrencyCh = make(chan struct{}, s.getConcurrency())
+	})
+	return s.concurrencyCh
 }
 
 var globalConnID uint64
@@ -3063,8 +3071,6 @@ func (ctx *RequestCtx) Value(key any) any {
 
 var fakeServer = &Server{
 	done: make(chan struct{}),
-	// Initialize concurrencyCh for TimeoutHandler
-	concurrencyCh: make(chan struct{}, DefaultConcurrency),
 }
 
 type fakeAddrer struct {

--- a/server.go
+++ b/server.go
@@ -2420,28 +2420,35 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 			}
 		}
 
+		var firstByte bool
 		if !s.ReduceMemoryUsage || br != nil {
 			if br == nil {
 				br = acquireReader(ctx)
 			}
 
-			// If this is a keep-alive connection we want to try and read the first bytes
-			// within the idle time.
-			if connRequestNum > 1 {
-				var b []byte
-				b, err = br.Peek(1)
-				if len(b) == 0 {
-					// If reading from a keep-alive connection returns nothing it means
-					// the connection was closed (either timeout or from the other side).
-					if err != io.EOF {
-						err = ErrNothingRead{error: err}
-					}
+			// Wait for the first byte under the deadline set above: ReadTimeout on
+			// a new connection, the idle time on a keep-alive one.
+			var b []byte
+			b, err = br.Peek(1)
+			if len(b) == 0 {
+				// Nothing arrived, so the connection was closed (either timeout or
+				// from the other side).
+				if err != io.EOF {
+					err = ErrNothingRead{error: err}
 				}
 			}
+			firstByte = len(b) != 0
 		} else {
 			// On keep-alive connections acquireByteReader will read the first byte
 			// while the idle timeout is active.
 			br, err = acquireByteReader(&ctx)
+			firstByte = err == nil
+		}
+		if firstByte {
+			// Active from the first byte, so Shutdown never reclaims a request
+			// in flight; a peer that sends nothing stays idle.
+			idleConnTime.Store(0)
+			s.setState(c, StateActive)
 		}
 
 		ctx.Request.isTLS = isTLS
@@ -2455,10 +2462,10 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		ctx.Response.secureErrorLogMessage = s.SecureErrorLogMessage
 
 		if err == nil {
-			idleConnTime.Store(0)
-			s.setState(c, StateActive)
-
-			if s.ReadTimeout > 0 {
+			// ReadTimeout restarts at the first byte after an idle wait or a
+			// byte-reader read; a new connection's peek keeps the deadline
+			// armed when it opened.
+			if s.ReadTimeout > 0 && (connRequestNum > 1 || s.ReduceMemoryUsage) {
 				if err = c.SetReadDeadline(time.Now().Add(s.ReadTimeout)); err != nil {
 					break
 				}
@@ -2556,6 +2563,11 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 				} else {
 					err = nr.error
 				}
+			}
+			// A connection the server closed itself, as Shutdown does with an
+			// idle one, gets no error response.
+			if err != nil && errors.Is(err, net.ErrClosed) {
+				err = nil
 			}
 
 			if err != nil {

--- a/server.go
+++ b/server.go
@@ -2184,7 +2184,7 @@ func wrapPerIPConn(s *Server, c net.Conn) net.Conn {
 		c.Close()
 		return nil
 	}
-	return acquirePerIPConn(c, ip, &s.perIPConnCounter)
+	return newPerIPConn(c, ip, &s.perIPConnCounter)
 }
 
 var defaultLogger = Logger(log.New(os.Stderr, "", log.LstdFlags))

--- a/server_test.go
+++ b/server_test.go
@@ -3650,6 +3650,32 @@ func TestServerConnStateSeesIdleMarkers(t *testing.T) {
 	}
 }
 
+func TestRequestCtxIDKeepsRequestNumberInItsField(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		connID, requestNum uint64
+		otherConnID        uint64
+	}{
+		{"one past the field", 0, 1 << 32, 1},
+		{"twice past the field", 5, 2 << 32, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var overflowed, other RequestCtx
+			overflowed.connID = tc.connID
+			overflowed.connRequestNum = tc.requestNum
+			other.connID = tc.otherConnID
+
+			if overflowed.ID() == other.ID() {
+				t.Fatalf("connection %d request %d has the same ID as connection %d request 0: %#016x",
+					tc.connID, tc.requestNum, tc.otherConnID, other.ID())
+			}
+			if got := overflowed.ID() >> 32; got != tc.connID {
+				t.Fatalf("connection field = %d, want %d", got, tc.connID)
+			}
+		})
+	}
+}
+
 func TestServerGetOnly(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -3676,6 +3676,205 @@ func TestRequestCtxIDKeepsRequestNumberInItsField(t *testing.T) {
 	}
 }
 
+func TestServerShutdownClosesConnectionThatSentNothing(t *testing.T) {
+	t.Parallel()
+
+	// The per-IP wrapper goes back to its pool when Shutdown closes the
+	// connection, so the serving goroutine must not answer the failed read.
+	for _, tc := range []struct {
+		name  string
+		perIP int
+	}{{"plain", 0}, {"perIP", 1}} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := &Server{Handler: func(ctx *RequestCtx) { ctx.SetBodyString("ok") }, MaxConnsPerIP: tc.perIP}
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listening: %v", err)
+			}
+			served := make(chan error, 1)
+			go func() { served <- server.Serve(listener) }()
+
+			conn, err := net.Dial("tcp", listener.Addr().String())
+			if err != nil {
+				t.Fatalf("dialing: %v", err)
+			}
+			defer conn.Close()
+			// The peer connects and then says nothing at all. Serve counts it as
+			// closeable once the accept-time grace has passed, so Shutdown must not
+			// wait on it forever.
+			time.Sleep(testTimeout(100 * time.Millisecond))
+
+			stopped := make(chan error, 1)
+			go func() { stopped <- server.Shutdown() }()
+			select {
+			case err := <-stopped:
+				if err != nil {
+					t.Fatalf("Shutdown() error: %v", err)
+				}
+			case <-time.After(testTimeout(30 * time.Second)):
+				t.Fatal("Shutdown() did not return for a connection that sent nothing")
+			}
+			if err := <-served; err != nil {
+				t.Fatalf("Serve() error: %v", err)
+			}
+		})
+	}
+}
+
+// A peer that sends garbage gets its 400 on a connection that went active.
+func TestServerConnStateActiveOnMalformedRequest(t *testing.T) {
+	var mu sync.Mutex
+	var states []string
+	s := &Server{
+		Handler:   func(*RequestCtx) {},
+		ConnState: func(_ net.Conn, st ConnState) { mu.Lock(); states = append(states, st.String()); mu.Unlock() },
+	}
+	ln := fasthttputil.NewInmemoryListener()
+	serveDone := make(chan struct{})
+	go func() { defer close(serveDone); _ = s.Serve(ln) }()
+	defer func() { _ = ln.Close(); <-serveDone }()
+
+	c, err := ln.Dial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Write([]byte("GARBAGE NOSPACE\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := io.ReadAll(c); !bytes.Contains(b, []byte("400")) {
+		t.Fatalf("response %q, want a 400", b)
+	}
+	_ = c.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		got := strings.Join(states, ",")
+		mu.Unlock()
+		if got == "new,active,closed" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("states = %q, want new,active,closed", got)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// Shutdown must not reclaim a keep-alive connection whose next request has
+// started arriving: the connection is active from its first byte.
+func TestServerShutdownWaitsForPartialKeepAliveRequest(t *testing.T) {
+	active := make(chan struct{}, 4)
+	s := &Server{
+		Handler: func(ctx *RequestCtx) { ctx.SetBodyString("ok") },
+		ConnState: func(_ net.Conn, st ConnState) {
+			if st == StateActive {
+				active <- struct{}{}
+			}
+		},
+	}
+	ln := fasthttputil.NewInmemoryListener()
+	served := make(chan error, 1)
+	go func() { served <- s.Serve(ln) }()
+
+	c, err := ln.Dial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	br := bufio.NewReader(c)
+	if _, err := c.Write([]byte("GET /1 HTTP/1.1\r\nHost: a\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	<-active
+	var first Response
+	if err := first.Read(br); err != nil {
+		t.Fatalf("first response: %v", err)
+	}
+
+	// Start the second request but hold back its final CRLF.
+	if _, err := c.Write([]byte("GET /2 HTTP/1.1\r\nHost: a\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-active:
+	case <-time.After(time.Second):
+		t.Fatal("connection did not go active on the first byte of a partial request")
+	}
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- s.Shutdown() }()
+	// Give Shutdown a sweep over the idle connections before completing the request.
+	time.Sleep(testTimeout(50 * time.Millisecond))
+	if _, err := c.Write([]byte("\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	var second Response
+	if err := second.Read(br); err != nil {
+		t.Fatalf("second response after Shutdown began: %v", err)
+	}
+	if second.StatusCode() != StatusOK {
+		t.Fatalf("second response status = %d, want 200", second.StatusCode())
+	}
+	if err := <-stopped; err != nil {
+		t.Fatalf("Shutdown() error: %v", err)
+	}
+	if err := <-served; err != nil {
+		t.Fatalf("Serve() error: %v", err)
+	}
+}
+
+// The wait for a first request that never arrives ends in a 408 once
+// ReadTimeout expires; a request sent after that is not served.
+func TestServerFirstRequestAfterReadTimeout(t *testing.T) {
+	t.Parallel()
+
+	readTimeout := testTimeout(100 * time.Millisecond)
+	accepted := make(chan struct{})
+	s := &Server{
+		Handler:     func(ctx *RequestCtx) { ctx.SetBodyString("ok") },
+		ReadTimeout: readTimeout,
+		ConnState: func(_ net.Conn, st ConnState) {
+			if st == StateNew {
+				close(accepted)
+			}
+		},
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serveDone := make(chan struct{})
+	go func() { defer close(serveDone); _ = s.Serve(ln) }()
+	defer func() { _ = ln.Close(); <-serveDone }()
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	// The server arms ReadTimeout once it has accepted the connection.
+	<-accepted
+	if err := c.SetReadDeadline(time.Now().Add(readTimeout + readTimeout/2)); err != nil {
+		t.Fatal(err)
+	}
+	br := bufio.NewReader(c)
+	var resp Response
+	if err := resp.Read(br); err != nil {
+		// Nothing answered the timeout, so the request arrives after it.
+		_ = c.SetReadDeadline(time.Time{})
+		_, _ = c.Write([]byte("GET / HTTP/1.1\r\nHost: a\r\n\r\n"))
+		if err := resp.Read(br); err != nil {
+			t.Fatalf("no response on the timed-out connection: %v", err)
+		}
+	}
+	if resp.StatusCode() != StatusRequestTimeout {
+		t.Fatalf("status = %d, want %d", resp.StatusCode(), StatusRequestTimeout)
+	}
+}
+
 func TestServerGetOnly(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -5489,3 +5489,24 @@ func TestRequestCtxInitShouldNotBeCanceledIssue1879(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TimeoutHandler must admit requests on a server driven by ServeConn, which
+// never allocates the concurrency gate that Serve does.
+func TestTimeoutHandlerViaServeConn(t *testing.T) {
+	s := &Server{Handler: TimeoutHandler(func(ctx *RequestCtx) {
+		ctx.SetBodyString("ok")
+	}, time.Second, "timeout")}
+
+	rw := &readWriter{}
+	rw.r.WriteString("GET / HTTP/1.1\r\nHost: a.com\r\n\r\n")
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("ServeConn() error: %v", err)
+	}
+	var resp Response
+	if err := resp.Read(bufio.NewReader(&rw.w)); err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	if resp.StatusCode() != StatusOK {
+		t.Fatalf("status = %d, want 200 (no requests were in flight)", resp.StatusCode())
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -5510,3 +5510,34 @@ func TestTimeoutHandlerViaServeConn(t *testing.T) {
 		t.Fatalf("status = %d, want 200 (no requests were in flight)", resp.StatusCode())
 	}
 }
+
+// IsTLS unwraps perIPConn; TLSConnectionState must agree with it.
+func TestTLSConnectionStateThroughPerIPConn(t *testing.T) {
+	certData, keyData, err := GenerateTestCertificate("localhost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverSide, clientSide := net.Pipe()
+	defer clientSide.Close()
+	tlsServer := tls.Server(serverSide, &tls.Config{Certificates: []tls.Certificate{cert}})
+	go func() {
+		c := tls.Client(clientSide, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+		_ = c.Handshake()
+	}()
+	if err := tlsServer.Handshake(); err != nil {
+		t.Fatal(err)
+	}
+
+	var ctx RequestCtx
+	ctx.c = &perIPConn{Conn: tlsServer}
+	if !ctx.IsTLS() {
+		t.Fatal("IsTLS() = false through perIPConn")
+	}
+	if ctx.TLSConnectionState() == nil {
+		t.Fatal("IsTLS() reports TLS but TLSConnectionState() is nil")
+	}
+}


### PR DESCRIPTION
Seven fixes split out of #2347 per review. Each one changes an observable HTTP/1 behavior — that is why they were moved out of the HTTP/2 PR into their own compatibility review — and each comes with a regression test that fails without the fix. They are independent commits; happy to split further into one PR per change if preferred.

Per review, everything trailer-specific was moved out of this PR into a follow-up covering request and response trailer parsing/serialization together (same-name upfront/trailer provenance included), with size/allocation benchmarks.

Current behavior → fixed behavior:

- **`RequestCtx.ID()`** — the request counter is ORed into the connection-ID half of the value, so past 2³² requests on one connection it corrupts the connection ID. Not reachable in practice, but the invariant shouldn't depend on that arithmetic. The counter is now masked to its 32-bit field.
- **`ConnState`** — a connection was marked `StateActive` on accept, before it sent a single byte. It is now marked active on its first byte — before the header completes, so `Shutdown` never cuts a request in flight, and whether or not that request then parses — matching net/http. This also means `Shutdown` can close a connection that connected and never sent anything, instead of waiting for it.
- **`SetMaxConns`** — growing the limit did nothing for requests already queued waiting for a connection slot; they kept waiting for a release or timed out with `ErrNoFreeConns`. Queued waiters are now served as soon as the limit grows.
- **`fasthttpadaptor`** — handlers written against net/http met an adaptor that broke under contracts their server honored: `panic(http.ErrAbortHandler)` surfaced as a crash, `Flush` after `Hijack` blocked forever, and HTTP/1.0 and HTTP/2 requests both reported minor version 1. The flushed body now feeds fasthttp's chunked writer directly, so an abnormal handler exit travels in-band: the server truncates the response and drops the connection, flushed bytes always reach the peer first, a pre-write abort sends nothing and hands the connection back to the server for teardown, and nothing touches the request after the server released it. Where the two servers merely differ in style — a status set after the body started, `Host` in the header map, `ContentLength` for buffered bodies, writes after `Hijack`, bodies on 204/304 — the adaptor deliberately keeps fasthttp's own semantics.
- **`TimeoutHandler`** — on a server driven by `ServeConn` every request was rejected with 429, because the admission channel is only allocated by `Serve` and a nil channel in a select always takes the default. The gate is now allocated on demand.
- **`TLSConnectionState()`** — returns nil when `MaxConnsPerIP` is set even though `IsTLS()` reports true, because only `IsTLS` unwraps the per-IP wrapper. Both now unwrap it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)