### PR TITLE
fix: wait for streaming reads before releasing pooled resources

### DIFF
--- a/client.go
+++ b/client.go
@@ -3233,6 +3233,62 @@ var DefaultTransport RoundTripper = &transport{}
 
 type transport struct{}
 
+// clientStreamBody keeps pooled response resources alive until every in-flight
+// Read has returned. interrupt must unblock network reads without releasing the
+// connection wrapper or reader pools; release performs that cleanup afterward.
+type clientStreamBody struct {
+	reader      io.Reader
+	interrupt   func()
+	release     func(bool)
+	forceClose  bool
+	closed      atomic.Bool
+	fullyRead   atomic.Bool
+	activeReads atomic.Int32
+	readersLock sync.RWMutex
+	closeDone   chan struct{}
+}
+
+func (s *clientStreamBody) Read(p []byte) (int, error) {
+	if s.closed.Load() {
+		return 0, io.ErrClosedPipe
+	}
+
+	s.readersLock.RLock()
+	s.activeReads.Add(1)
+	defer func() {
+		s.activeReads.Add(-1)
+		s.readersLock.RUnlock()
+	}()
+	if s.closed.Load() {
+		return 0, io.ErrClosedPipe
+	}
+
+	n, err := s.reader.Read(p)
+	if errors.Is(err, io.EOF) {
+		s.fullyRead.Store(true)
+	}
+	return n, err
+}
+
+func (s *clientStreamBody) CloseWithError(err error) error {
+	if !s.closed.CompareAndSwap(false, true) {
+		<-s.closeDone
+		return nil
+	}
+	defer close(s.closeDone)
+
+	closeConnection := s.forceClose || err != nil || !s.fullyRead.Load() || s.activeReads.Load() > 0
+	if closeConnection {
+		// Interrupt before waiting on readersLock so a blocked network Read can exit.
+		s.interrupt()
+	}
+
+	s.readersLock.Lock()
+	defer s.readersLock.Unlock()
+	s.release(closeConnection)
+	return nil
+}
+
 func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (retry bool, err error) {
 	customSkipBody := resp.SkipBody
 	customStreamBody := resp.StreamBody
@@ -3324,22 +3380,31 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	closeConn := resetConnection || req.ConnectionClose() || resp.ConnectionClose()
 	if customStreamBody && resp.bodyStream != nil {
 		rbs := resp.bodyStream
-		var closed atomic.Bool
-		resp.bodyStream = newCloseReaderWithError(rbs, func(wErr error) error {
-			if !closed.CompareAndSwap(false, true) {
-				return nil
-			}
-			hc.ReleaseReader(br)
-			if r, ok := rbs.(*requestStream); ok {
-				releaseRequestStream(r)
-			}
-			if closeConn || resp.ConnectionClose() || wErr != nil {
-				hc.CloseConn(cc)
-			} else {
-				hc.ReleaseConn(cc)
-			}
-			return nil
-		})
+		bodyStream := &clientStreamBody{
+			reader:     rbs,
+			forceClose: closeConn,
+			closeDone:  make(chan struct{}),
+			interrupt: func() {
+				_ = conn.Close()
+			},
+			release: func(closeConnection bool) {
+				hc.ReleaseReader(br)
+				if r, ok := rbs.(*requestStream); ok {
+					releaseRequestStream(r)
+				}
+				if closeConnection {
+					hc.CloseConn(cc)
+				} else {
+					hc.ReleaseConn(cc)
+				}
+			},
+		}
+		if _, ok := rbs.(*requestStream); !ok {
+			// The network body is already buffered, so closing this in-memory stream
+			// does not prevent the connection from being reused.
+			bodyStream.fullyRead.Store(true)
+		}
+		resp.bodyStream = bodyStream
 		return false, nil
 	}
 	hc.ReleaseReader(br)

--- a/client.go
+++ b/client.go
@@ -3233,18 +3233,18 @@ var DefaultTransport RoundTripper = &transport{}
 
 type transport struct{}
 
-// clientStreamBody keeps pooled response resources alive until every in-flight
-// Read has returned. interrupt must unblock network reads without releasing the
-// connection wrapper or reader pools; release performs that cleanup afterward.
+// clientStreamBody serializes reads and keeps pooled response resources alive
+// until an in-flight Read has returned. interrupt must unblock network reads
+// without releasing the connection wrapper or reader pools; release performs
+// that cleanup afterward.
 type clientStreamBody struct {
-	reader      io.Reader
-	interrupt   func()
-	release     func(bool)
-	forceClose  bool
-	closed      atomic.Bool
-	fullyRead   atomic.Bool
-	readersLock sync.RWMutex
-	closeOnce   sync.Once
+	reader    io.Reader
+	interrupt func()
+	release   func(bool)
+	closed    atomic.Bool
+	fullyRead bool
+	readLock  sync.Mutex
+	closeOnce sync.Once
 }
 
 func (s *clientStreamBody) Read(p []byte) (int, error) {
@@ -3252,15 +3252,15 @@ func (s *clientStreamBody) Read(p []byte) (int, error) {
 		return 0, io.ErrClosedPipe
 	}
 
-	s.readersLock.RLock()
-	defer s.readersLock.RUnlock()
+	s.readLock.Lock()
+	defer s.readLock.Unlock()
 	if s.closed.Load() {
 		return 0, io.ErrClosedPipe
 	}
 
 	n, err := s.reader.Read(p)
 	if errors.Is(err, io.EOF) {
-		s.fullyRead.Store(true)
+		s.fullyRead = true
 	}
 	return n, err
 }
@@ -3268,20 +3268,18 @@ func (s *clientStreamBody) Read(p []byte) (int, error) {
 func (s *clientStreamBody) CloseWithError(err error) error {
 	s.closeOnce.Do(func() {
 		s.closed.Store(true)
-		closeConnection := s.forceClose || err != nil || !s.fullyRead.Load()
-		locked := s.readersLock.TryLock()
-		if !locked {
-			closeConnection = true
-		}
-		if closeConnection {
+		locked := s.readLock.TryLock()
+		discard := err != nil || !locked
+		if discard || !s.fullyRead {
+			discard = true
 			s.interrupt()
 		}
 		if !locked {
-			// The interrupt lets a blocked network Read release readersLock.
-			s.readersLock.Lock()
+			// The interrupt lets a blocked network Read release readLock.
+			s.readLock.Lock()
 		}
-		defer s.readersLock.Unlock()
-		s.release(closeConnection)
+		defer s.readLock.Unlock()
+		s.release(discard)
 	})
 	return nil
 }
@@ -3375,33 +3373,25 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	}
 
 	closeConn := resetConnection || req.ConnectionClose() || resp.ConnectionClose()
-	if customStreamBody && resp.bodyStream != nil {
-		rbs := resp.bodyStream
-		bodyStream := &clientStreamBody{
-			reader:     rbs,
-			forceClose: closeConn,
-			interrupt: func() {
-				_ = conn.Close()
-			},
-			release: func(closeConnection bool) {
-				hc.ReleaseReader(br)
-				if r, ok := rbs.(*requestStream); ok {
-					releaseRequestStream(r)
-				}
-				if closeConnection {
-					hc.CloseConn(cc)
-				} else {
-					hc.ReleaseConn(cc)
-				}
-			},
+	if customStreamBody {
+		if rbs, ok := resp.bodyStream.(*requestStream); ok {
+			resp.bodyStream = &clientStreamBody{
+				reader: rbs,
+				interrupt: func() {
+					_ = conn.Close()
+				},
+				release: func(discard bool) {
+					hc.ReleaseReader(br)
+					releaseRequestStream(rbs)
+					if closeConn || discard {
+						hc.CloseConn(cc)
+					} else {
+						hc.ReleaseConn(cc)
+					}
+				},
+			}
+			return false, nil
 		}
-		if _, ok := rbs.(*requestStream); !ok {
-			// The network body is already buffered, so closing this in-memory stream
-			// does not prevent the connection from being reused.
-			bodyStream.fullyRead.Store(true)
-		}
-		resp.bodyStream = bodyStream
-		return false, nil
 	}
 	hc.ReleaseReader(br)
 

--- a/client.go
+++ b/client.go
@@ -3373,25 +3373,47 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	}
 
 	closeConn := resetConnection || req.ConnectionClose() || resp.ConnectionClose()
-	if customStreamBody {
-		if rbs, ok := resp.bodyStream.(*requestStream); ok {
+	if customStreamBody && resp.bodyStream != nil {
+		// releaseConn runs when the caller closes the body stream, so it has to
+		// re-check resp.ConnectionClose(): a caller may only decide that the
+		// connection is unusable while consuming the streamed body.
+		releaseConn := func(discard bool) {
+			if closeConn || discard || resp.ConnectionClose() {
+				hc.CloseConn(cc)
+			} else {
+				hc.ReleaseConn(cc)
+			}
+		}
+		if rs, ok := resp.bodyStream.(*requestStream); ok {
+			// Network backed: a Read may still be in flight when the caller
+			// closes, so interrupt it and wait before pooling anything.
 			resp.bodyStream = &clientStreamBody{
-				reader: rbs,
+				reader: rs,
 				interrupt: func() {
 					_ = conn.Close()
 				},
 				release: func(discard bool) {
 					hc.ReleaseReader(br)
-					releaseRequestStream(rbs)
-					if closeConn || discard {
-						hc.CloseConn(cc)
-					} else {
-						hc.ReleaseConn(cc)
-					}
+					releaseRequestStream(rs)
+					releaseConn(discard)
 				},
 			}
-			return false, nil
+		} else {
+			// Fully buffered: the body already lives in resp.body and nothing
+			// reads the connection any more, so br can be released right away.
+			// The connection still waits for the caller to close the stream.
+			hc.ReleaseReader(br)
+			rbs := resp.bodyStream
+			var closed atomic.Bool
+			resp.bodyStream = newCloseReaderWithError(rbs, func(wErr error) error {
+				if !closed.CompareAndSwap(false, true) {
+					return nil
+				}
+				releaseConn(wErr != nil)
+				return nil
+			})
 		}
+		return false, nil
 	}
 	hc.ReleaseReader(br)
 

--- a/client.go
+++ b/client.go
@@ -3243,9 +3243,8 @@ type clientStreamBody struct {
 	forceClose  bool
 	closed      atomic.Bool
 	fullyRead   atomic.Bool
-	activeReads atomic.Int32
 	readersLock sync.RWMutex
-	closeDone   chan struct{}
+	closeOnce   sync.Once
 }
 
 func (s *clientStreamBody) Read(p []byte) (int, error) {
@@ -3254,11 +3253,7 @@ func (s *clientStreamBody) Read(p []byte) (int, error) {
 	}
 
 	s.readersLock.RLock()
-	s.activeReads.Add(1)
-	defer func() {
-		s.activeReads.Add(-1)
-		s.readersLock.RUnlock()
-	}()
+	defer s.readersLock.RUnlock()
 	if s.closed.Load() {
 		return 0, io.ErrClosedPipe
 	}
@@ -3271,21 +3266,23 @@ func (s *clientStreamBody) Read(p []byte) (int, error) {
 }
 
 func (s *clientStreamBody) CloseWithError(err error) error {
-	if !s.closed.CompareAndSwap(false, true) {
-		<-s.closeDone
-		return nil
-	}
-	defer close(s.closeDone)
-
-	closeConnection := s.forceClose || err != nil || !s.fullyRead.Load() || s.activeReads.Load() > 0
-	if closeConnection {
-		// Interrupt before waiting on readersLock so a blocked network Read can exit.
-		s.interrupt()
-	}
-
-	s.readersLock.Lock()
-	defer s.readersLock.Unlock()
-	s.release(closeConnection)
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		closeConnection := s.forceClose || err != nil || !s.fullyRead.Load()
+		locked := s.readersLock.TryLock()
+		if !locked {
+			closeConnection = true
+		}
+		if closeConnection {
+			s.interrupt()
+		}
+		if !locked {
+			// The interrupt lets a blocked network Read release readersLock.
+			s.readersLock.Lock()
+		}
+		defer s.readersLock.Unlock()
+		s.release(closeConnection)
+	})
 	return nil
 }
 
@@ -3383,7 +3380,6 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 		bodyStream := &clientStreamBody{
 			reader:     rbs,
 			forceClose: closeConn,
-			closeDone:  make(chan struct{}),
 			interrupt: func() {
 				_ = conn.Close()
 			},

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"regexp"
@@ -118,6 +119,253 @@ func TestClientConnectionCounts(t *testing.T) {
 	if n := c.IdleConnsCount(); n != 0 {
 		t.Errorf("unexpected idle connection count %d. Expecting %d", n, 0)
 	}
+}
+
+func TestClientStreamCloseWaitsForRead(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	delayedConn := &delayedReadReturnConn{
+		Conn:               clientConn,
+		readStarted:        make(chan struct{}),
+		underlyingReturned: make(chan struct{}),
+		allowReadReturn:    make(chan struct{}),
+	}
+	serverDone := make(chan struct{})
+	go func() {
+		defer serverConn.Close()
+		reader := bufio.NewReader(serverConn)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		if _, err := io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n"); err != nil {
+			return
+		}
+		<-serverDone
+	}()
+
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(func() {
+			close(delayedConn.allowReadReturn)
+			close(serverDone)
+			clientConn.Close()
+		})
+	}
+	t.Cleanup(cleanup)
+
+	client := HostClient{
+		Addr:               "example.com:80",
+		Dial:               func(string) (net.Conn, error) { return delayedConn, nil },
+		StreamResponseBody: true,
+	}
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	resp := AcquireResponse()
+	defer ReleaseResponse(resp)
+	if err := client.Do(&req, resp); err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+
+	stream, ok := resp.BodyStream().(ReadCloserWithError)
+	if !ok {
+		t.Fatalf("unexpected body stream type %T", resp.BodyStream())
+	}
+	buf := make([]byte, 1)
+	if n, err := stream.Read(buf); n != 1 || err != nil || buf[0] != 'a' {
+		t.Fatalf("unexpected first stream read: n=%d err=%v body=%q", n, err, buf[:n])
+	}
+
+	delayedConn.delayRead.Store(true)
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := stream.Read(buf)
+		readDone <- err
+	}()
+	select {
+	case <-delayedConn.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stream read to block")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- stream.CloseWithError(errors.New("cancel stream"))
+	}()
+	select {
+	case <-delayedConn.underlyingReturned:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for connection close to unblock the stream read")
+	}
+
+	if got := client.ConnsCount(); got != 1 {
+		t.Errorf("connection was released while the in-flight read was still running: got %d active connections", got)
+	}
+
+	cleanup()
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stream read to finish")
+	}
+	var closeErr error
+	select {
+	case closeErr = <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stream close to finish")
+	}
+	if closeErr != nil {
+		t.Fatalf("unexpected stream close error: %v", closeErr)
+	}
+	if got := client.ConnsCount(); got != 0 {
+		t.Fatalf("connection was not released after the stream read finished: got %d active connections", got)
+	}
+}
+
+func TestClientStreamCloseReusesBufferedResponseConnection(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "hello world")
+	}))
+	t.Cleanup(server.Close)
+
+	var dialCount atomic.Int32
+	client := HostClient{
+		Addr: strings.TrimPrefix(server.URL, "http://"),
+		Dial: func(addr string) (net.Conn, error) {
+			dialCount.Add(1)
+			return net.Dial("tcp", addr)
+		},
+		StreamResponseBody: true,
+	}
+	t.Cleanup(client.CloseIdleConnections)
+
+	for range 2 {
+		var req Request
+		req.SetRequestURI(server.URL)
+		resp := AcquireResponse()
+		if err := client.Do(&req, resp); err != nil {
+			ReleaseResponse(resp)
+			t.Fatalf("unexpected request error: %v", err)
+		}
+		if err := resp.CloseBodyStream(); err != nil {
+			ReleaseResponse(resp)
+			t.Fatalf("unexpected stream close error: %v", err)
+		}
+		ReleaseResponse(resp)
+	}
+
+	if got := dialCount.Load(); got != 1 {
+		t.Fatalf("buffered response connection was not reused: got %d dials", got)
+	}
+}
+
+func TestClientStreamCloseInterruptsActiveReadAfterEOF(t *testing.T) {
+	t.Parallel()
+
+	reader := &blockingStreamReader{
+		started: make(chan struct{}),
+		unblock: make(chan struct{}),
+	}
+	var unblockOnce sync.Once
+	unblock := func() {
+		unblockOnce.Do(func() {
+			close(reader.unblock)
+		})
+	}
+	t.Cleanup(unblock)
+
+	released := make(chan bool, 1)
+	stream := &clientStreamBody{
+		reader:    reader,
+		closeDone: make(chan struct{}),
+		interrupt: unblock,
+		release: func(closeConnection bool) {
+			released <- closeConnection
+		},
+	}
+	stream.fullyRead.Store(true)
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := stream.Read(make([]byte, 1))
+		readDone <- err
+	}()
+	select {
+	case <-reader.started:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stream read to block")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- stream.CloseWithError(nil)
+	}()
+	select {
+	case closeConnection := <-released:
+		if !closeConnection {
+			t.Fatal("active stream read did not force the connection closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream close did not interrupt the active read")
+	}
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stream read to finish")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("unexpected stream close error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stream close to finish")
+	}
+}
+
+type blockingStreamReader struct {
+	started chan struct{}
+	unblock chan struct{}
+}
+
+func (r *blockingStreamReader) Read([]byte) (int, error) {
+	close(r.started)
+	<-r.unblock
+	return 0, io.EOF
+}
+
+type delayedReadReturnConn struct {
+	net.Conn
+
+	delayRead          atomic.Bool
+	readStarted        chan struct{}
+	underlyingReturned chan struct{}
+	allowReadReturn    chan struct{}
+	readStartOnce      sync.Once
+	readReturnOnce     sync.Once
+}
+
+func (c *delayedReadReturnConn) Read(p []byte) (int, error) {
+	if !c.delayRead.Load() {
+		return c.Conn.Read(p)
+	}
+	c.readStartOnce.Do(func() {
+		close(c.readStarted)
+	})
+	n, err := c.Conn.Read(p)
+	c.readReturnOnce.Do(func() {
+		close(c.underlyingReturned)
+	})
+	<-c.allowReadReturn
+	return n, err
 }
 
 func TestPipelineClientSetUserAgent(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -267,6 +267,70 @@ func TestClientStreamCloseReusesBufferedResponseConnection(t *testing.T) {
 	}
 }
 
+func TestClientStreamCloseHonorsLateSetConnectionClose(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		// A body larger than maxResponseBodySize is served through a
+		// *requestStream; leaving it at zero buffers the body instead.
+		maxResponseBodySize int
+	}{
+		{name: "requestStream", maxResponseBodySize: 1},
+		{name: "buffered", maxResponseBodySize: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set(HeaderContentLength, "11")
+				_, _ = io.WriteString(w, "hello world")
+			}))
+			t.Cleanup(server.Close)
+
+			var dialCount atomic.Int32
+			client := HostClient{
+				Addr: strings.TrimPrefix(server.URL, "http://"),
+				Dial: func(addr string) (net.Conn, error) {
+					dialCount.Add(1)
+					return net.Dial("tcp", addr)
+				},
+				MaxResponseBodySize: tc.maxResponseBodySize,
+				StreamResponseBody:  true,
+			}
+			t.Cleanup(client.CloseIdleConnections)
+
+			for i := range 2 {
+				var req Request
+				req.SetRequestURI(server.URL)
+				resp := AcquireResponse()
+				if err := client.Do(&req, resp); err != nil {
+					ReleaseResponse(resp)
+					t.Fatalf("unexpected request error: %v", err)
+				}
+				if _, err := io.ReadAll(resp.BodyStream()); err != nil {
+					ReleaseResponse(resp)
+					t.Fatalf("unexpected stream read error: %v", err)
+				}
+				// The caller only decides the connection is unusable after it
+				// consumed the streamed body.
+				if i == 0 {
+					resp.SetConnectionClose()
+				}
+				if err := resp.CloseBodyStream(); err != nil {
+					ReleaseResponse(resp)
+					t.Fatalf("unexpected stream close error: %v", err)
+				}
+				ReleaseResponse(resp)
+			}
+
+			if got := dialCount.Load(); got != 2 {
+				t.Fatalf("connection was reused after a late SetConnectionClose: got %d dials", got)
+			}
+		})
+	}
+}
+
 func TestClientStreamCloseInterruptsActiveReadAfterEOF(t *testing.T) {
 	t.Parallel()
 

--- a/client_test.go
+++ b/client_test.go
@@ -285,7 +285,6 @@ func TestClientStreamCloseInterruptsActiveReadAfterEOF(t *testing.T) {
 	released := make(chan bool, 1)
 	stream := &clientStreamBody{
 		reader:    reader,
-		closeDone: make(chan struct{}),
 		interrupt: unblock,
 		release: func(closeConnection bool) {
 			released <- closeConnection

--- a/client_test.go
+++ b/client_test.go
@@ -286,11 +286,11 @@ func TestClientStreamCloseInterruptsActiveReadAfterEOF(t *testing.T) {
 	stream := &clientStreamBody{
 		reader:    reader,
 		interrupt: unblock,
-		release: func(closeConnection bool) {
-			released <- closeConnection
+		release: func(discard bool) {
+			released <- discard
 		},
 	}
-	stream.fullyRead.Store(true)
+	stream.fullyRead = true
 
 	readDone := make(chan error, 1)
 	go func() {
@@ -308,8 +308,8 @@ func TestClientStreamCloseInterruptsActiveReadAfterEOF(t *testing.T) {
 		closeDone <- stream.CloseWithError(nil)
 	}()
 	select {
-	case closeConnection := <-released:
-		if !closeConnection {
+	case discard := <-released:
+		if !discard {
 			t.Fatal("active stream read did not force the connection closed")
 		}
 	case <-time.After(time.Second):


### PR DESCRIPTION
## Problem

When `StreamResponseBody` is enabled, `CloseWithError` currently releases the pooled `bufio.Reader` and `requestStream` before closing the underlying connection. If another goroutine is blocked in `requestStream.Read`, the release path clears and pools the same object while it is still being read.

This produces a real data race during stream cancellation and timeout handling:

```text
Write: fasthttp.releaseRequestStream
Previous read: fasthttp.(*requestStream).Read
```

PR #2211 prevents a second close from releasing the stream twice, but the first close can still race with an in-flight read.

## Fix

- close the underlying connection first when a streamed body must be interrupted
- wait for all in-flight reads to return before releasing reader, stream, and connection pool objects
- make concurrent closes wait for the first cleanup to finish
- preserve connection reuse for response bodies that were already fully buffered

## Tests

Added deterministic regressions for:

- cancellation while a network read is in flight
- an active read after EOF
- connection reuse for an unread, fully buffered response

Local non-race validation:

- `go test . -count=1`
- `go vet ./...`

Race and multi-platform validation are left to this repository CI.

Fixes: https://github.com/valyala/fasthttp/issues/2359