### PR TITLE
Add canonical header lookup

### DIFF
--- a/header.go
+++ b/header.go
@@ -1907,6 +1907,16 @@ func (h *ResponseHeader) PeekBytes(key []byte) []byte {
 	return h.peek(h.bufK)
 }
 
+// PeekCanonical returns header value for the given key without normalizing it.
+// The key must match the canonical form used with SetCanonical.
+//
+// The returned value is valid until the response is released,
+// either though ReleaseResponse or your request handler returning.
+// Do not store references to the returned value. Make copies instead.
+func (h *ResponseHeader) PeekCanonical(key []byte) []byte {
+	return h.peek(key)
+}
+
 // Peek returns header value for the given key.
 //
 // The returned value is valid until the request is released,
@@ -1926,6 +1936,16 @@ func (h *RequestHeader) PeekBytes(key []byte) []byte {
 	h.bufK = append(h.bufK[:0], key...)
 	normalizeHeaderKey(h.bufK, h.disableNormalizing)
 	return h.peek(h.bufK)
+}
+
+// PeekCanonical returns header value for the given key without normalizing it.
+// The key must match the canonical form used with SetCanonical.
+//
+// The returned value is valid until the request is released,
+// either though ReleaseRequest or your request handler returning.
+// Do not store references to the returned value. Make copies instead.
+func (h *RequestHeader) PeekCanonical(key []byte) []byte {
+	return h.peek(key)
 }
 
 func (h *ResponseHeader) peek(key []byte) []byte {

--- a/header_test.go
+++ b/header_test.go
@@ -3844,6 +3844,22 @@ func TestRequestHeaderPeekAll(t *testing.T) {
 	expectRequestHeaderAll(t, h, "aaa", [][]byte{})
 }
 
+func TestRequestHeaderPeekCanonical(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("ETag")
+	value := []byte("13-1831710635")
+	var h RequestHeader
+	h.SetCanonical(key, value)
+
+	if got := h.PeekCanonical(key); !bytes.Equal(got, value) {
+		t.Fatalf("unexpected value for key %q: %q; want %q", key, got, value)
+	}
+	if string(key) != "ETag" {
+		t.Fatalf("PeekCanonical modified key: %q", key)
+	}
+}
+
 func expectRequestHeaderAll(t *testing.T, h *RequestHeader, key string, expectedValue [][]byte) {
 	if len(h.PeekAll(key)) != len(expectedValue) {
 		t.Fatalf("Unexpected size for key %q: %d. Expected %d", key, len(h.PeekAll(key)), len(expectedValue))
@@ -3878,6 +3894,22 @@ func TestResponseHeaderPeekAll(t *testing.T) {
 	h.Del(HeaderContentEncoding)
 	expectResponseHeaderAll(t, h, HeaderContentType, [][]byte{defaultContentType})
 	expectResponseHeaderAll(t, h, HeaderContentEncoding, [][]byte{})
+}
+
+func TestResponseHeaderPeekCanonical(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("ETag")
+	value := []byte("13-1831710635")
+	var h ResponseHeader
+	h.SetCanonical(key, value)
+
+	if got := h.PeekCanonical(key); !bytes.Equal(got, value) {
+		t.Fatalf("unexpected value for key %q: %q; want %q", key, got, value)
+	}
+	if string(key) != "ETag" {
+		t.Fatalf("PeekCanonical modified key: %q", key)
+	}
 }
 
 func expectResponseHeaderAll(t *testing.T, h *ResponseHeader, key string, expectedValue [][]byte) {


### PR DESCRIPTION
## Summary

- add `PeekCanonical` to request and response headers for keys stored with `SetCanonical`
- bypass key normalization without mutating the caller-provided key
- cover exact `ETag` lookups for both header types

## Validation

- `go test ./... -count=1` (Go 1.25)
- `go test -race -shuffle=on ./...` (Go 1.25)
- `golangci-lint run --verbose` (v2.10.1, 0 issues)
- `gofmt` on changed files
- `git diff --check`

Fixes #872
