### PR TITLE
docs: clarify RequestURI host behavior

### DIFF
--- a/http.go
+++ b/http.go
@@ -159,6 +159,11 @@ func (req *Request) SetRequestURIBytes(requestURI []byte) {
 }
 
 // RequestURI returns request's URI.
+//
+// If the request URI is absolute and contains a host, calling RequestURI after
+// Host or URI may reset the parsed URI state and make a subsequent Host call
+// return an empty value. Use req.URI().RequestURI() when the parsed URI and its
+// host must remain available.
 func (req *Request) RequestURI() []byte {
 	if req.parsedURI {
 		requestURI := req.uri.RequestURI()


### PR DESCRIPTION
## What does this PR do?

Documents a surprising side effect of `Request.RequestURI()` when an absolute request URI contains the host.

After the parsed URI is synchronized back into the request header, a subsequent `Host()` call may no longer recover a host that existed only in the absolute URI. The updated documentation recommends `req.URI().RequestURI()` when callers need to preserve the parsed host.

Closes #895.

## Tests

- `gofmt`
- `go test ./...`
- `git diff --check`

AI assistance was used to investigate the behavior and prepare the initial documentation change. I reviewed the final diff and ran the complete Go test suite.