### PR TITLE
fix: small read buffer error doesn't match the ignored string anymore

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -226,7 +226,7 @@ func (wp *workerPool) workerFunc(ch *workerChan) {
 			errStr := err.Error()
 			shouldIgnore := strings.Contains(errStr, "broken pipe") ||
 				strings.Contains(errStr, "reset by peer") ||
-				strings.Contains(errStr, "request headers: small read buffer") ||
+				strings.Contains(errStr, "request headers: "+ErrSmallReadBuffer.Error()) ||
 				strings.Contains(errStr, "unexpected EOF") ||
 				strings.Contains(errStr, "i/o timeout") ||
 				errors.Is(err, ErrBadTrailer)


### PR DESCRIPTION
After [this](https://github.com/valyala/fasthttp/commit/968cd3ce27d09a56d3ac9a3d4f231492b8be6e73), the sentinel errors contain a `fasthttp:` prefix.