### PR TITLE
perf: try to avoid reallocations while reading zstd compressed requests

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -196,7 +196,9 @@ func estimateUnzstdSize(p []byte) int {
 		// Let's have some limit just in case the input is malicious
 		// and wants us to allocate bazillion bytes.
 		// In a non-malicious case it's still better to start growing from 4 MB than from 0.
-		sizeHint = int(min(header.FrameContentSize, 4_000_000))
+
+		// Static analysis complains about integer overflow but the uint64 argument to int() is not larger than 4_000_000, so we silence it.
+		sizeHint = int(min(header.FrameContentSize, 4_000_000)) // #nosec G115
 	}
 	return sizeHint
 }

--- a/zstd.go
+++ b/zstd.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"slices"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
@@ -143,6 +144,20 @@ func WriteUnzstd(w io.Writer, p []byte) (int, error) {
 }
 
 func writeUnzstd(w io.Writer, p []byte, maxBodySize int) (int, error) {
+	estimatedDecompressedSize := estimateUnzstdSize(p)
+	if maxBodySize > 0 {
+		estimatedDecompressedSize = min(estimatedDecompressedSize, maxBodySize)
+	}
+
+	switch dst := w.(type) {
+	case *byteSliceWriter:
+		dst.b = slices.Grow(dst.b, estimatedDecompressedSize)
+	case *bytebufferpool.ByteBuffer:
+		dst.B = slices.Grow(dst.B, estimatedDecompressedSize)
+	case *bytes.Buffer:
+		dst.Grow(estimatedDecompressedSize)
+	}
+
 	r := &byteSliceReader{b: p}
 	zr, err := acquireZstdReader(r)
 	if err != nil {
@@ -155,6 +170,35 @@ func writeUnzstd(w io.Writer, p []byte, maxBodySize int) (int, error) {
 		return 0, fmt.Errorf("too much data unzstd: %d", n)
 	}
 	return nn, err
+}
+
+func estimateUnzstdSize(p []byte) int {
+	// Somewhat reasonable and conservative expectation of compression factor of 2
+	sizeHint := 2 * len(p)
+
+	// We look for the first non-skippable header
+	var header zstd.Header
+	for {
+		if err := header.Decode(p); err != nil {
+			break
+		}
+		if !header.Skippable {
+			break
+		}
+		skippedBytes := header.HeaderSize + int(header.SkippableSize)
+		if skippedBytes <= 0 || skippedBytes > len(p) {
+			break
+		}
+		p = p[skippedBytes:]
+	}
+
+	if header.HasFCS {
+		// Let's have some limit just in case the input is malicious
+		// and wants us to allocate bazillion bytes.
+		// In a non-malicious case it's still better to start growing from 4 MB than from 0.
+		sizeHint = int(min(header.FrameContentSize, 4_000_000))
+	}
+	return sizeHint
 }
 
 // AppendUnzstdBytes appends unzstd src to dst and returns the resulting dst.

--- a/zstd.go
+++ b/zstd.go
@@ -197,7 +197,7 @@ func estimateUnzstdSize(p []byte) int {
 		// and wants us to allocate bazillion bytes.
 		// In a non-malicious case it's still better to start growing from 4 MB than from 0.
 
-		// Static analysis complains about integer overflow but the uint64 argument to int() is not larger than 4_000_000, so we silence it.
+		// gosec complains about integer overflow but the uint64 argument to int() is not larger than 4_000_000, so we silence it.
 		sizeHint = int(min(header.FrameContentSize, 4_000_000)) // #nosec G115
 	}
 	return sizeHint

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -114,47 +114,66 @@ func TestEstimateUnzstdSize(t *testing.T) {
 	}
 }
 
-func TestWriteUnzstdPresizesDestination(t *testing.T) {
+func TestWriteUnzstdOptimizedDestinations(t *testing.T) {
 	t.Parallel()
 
-	body := moderatelyCompressibleBody(110000)
+	body := bytes.Repeat([]byte("payload"), 1000)
 	compressedBody := zstdEncodeWithFCS(t, body)
+	prefix := []byte("prefix")
 
-	for _, maxBodySize := range []int{0, len(body), 2 * len(body)} {
-		var bb bytebufferpool.ByteBuffer
-		n, err := writeUnzstd(&bb, compressedBody, maxBodySize)
-		if err != nil {
-			t.Fatalf("unexpected error with maxBodySize=%d: %v", maxBodySize, err)
-		}
-		if n != len(body) {
-			t.Fatalf("unexpected decompressed size %d with maxBodySize=%d. Expecting %d", n, maxBodySize, len(body))
-		}
-		if !bytes.Equal(bb.B, body) {
-			t.Fatalf("unexpected decompressed body with maxBodySize=%d", maxBodySize)
-		}
-		// The destination has been pre-sized from the frame header, so
-		// decompression must not have grown it beyond the initial reservation.
-		if cap(bb.B) > 2*len(body) {
-			t.Fatalf("destination buffer was reallocated with maxBodySize=%d: cap=%d, decompressed size=%d",
-				maxBodySize, cap(bb.B), len(body))
-		}
+	testCases := []struct {
+		name      string
+		newWriter func() (io.Writer, func() []byte)
+	}{
+		{name: "byte slice writer", newWriter: func() (io.Writer, func() []byte) {
+			w := &byteSliceWriter{b: append([]byte(nil), prefix...)}
+			return w, func() []byte { return w.b }
+		}},
+		{name: "byte buffer pool", newWriter: func() (io.Writer, func() []byte) {
+			w := &bytebufferpool.ByteBuffer{B: append([]byte(nil), prefix...)}
+			return w, func() []byte { return w.B }
+		}},
+		{name: "bytes buffer", newWriter: func() (io.Writer, func() []byte) {
+			w := bytes.NewBuffer(append([]byte(nil), prefix...))
+			return w, w.Bytes
+		}},
+	}
+
+	want := append(append([]byte(nil), prefix...), body...)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			w, result := testCase.newWriter()
+			n, err := writeUnzstd(w, compressedBody, 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if n != len(body) {
+				t.Fatalf("unexpected decompressed size %d. Expecting %d", n, len(body))
+			}
+			if got := result(); !bytes.Equal(got, want) {
+				t.Fatalf("unexpected destination %q. Expecting %q", got, want)
+			}
+		})
 	}
 }
 
-func TestWriteUnzstdSmallMaxBodySize(t *testing.T) {
-	t.Parallel()
-
-	body := moderatelyCompressibleBody(110000)
-	compressedBody := zstdEncodeWithFCS(t, body)
-
-	// The pre-allocation must not exceed maxBodySize, and the body must still
-	// be rejected as too large.
-	var bb bytebufferpool.ByteBuffer
-	if _, err := writeUnzstd(&bb, compressedBody, 100); err != ErrBodyTooLarge {
-		t.Fatalf("unexpected error %v. Expecting %v", err, ErrBodyTooLarge)
+func BenchmarkWriteUnzstdPresized(b *testing.B) {
+	body := bytes.Repeat([]byte("payload"), 16*1024)
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		b.Fatal(err)
 	}
-	if cap(bb.B) > 2*len(body) {
-		t.Fatalf("unexpected destination buffer capacity %d", cap(bb.B))
+	compressedBody := encoder.EncodeAll(body, nil)
+	encoder.Close()
+
+	b.SetBytes(int64(len(body)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		var dst bytebufferpool.ByteBuffer
+		if _, err := WriteUnzstd(&dst, compressedBody); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -68,80 +68,50 @@ func zstdEncodeWithFCS(t *testing.T, body []byte) []byte {
 	return compressedBody
 }
 
-// moderatelyCompressibleBody returns n bytes of text which zstd compresses with
-// a ratio well below the one estimateUnzstdSize is willing to trust, so that the
-// uncompressed size from the frame header is used as-is.
-func moderatelyCompressibleBody(n int) []byte {
-	words := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"}
-	pseudoRandomState := uint64(42)
-
-	body := make([]byte, 0, n+8)
-	for len(body) < n {
-		pseudoRandomState = pseudoRandomState*6364136223846793005 + 1442695040888963407
-		body = append(body, words[pseudoRandomState>>60&7]...)
-		body = append(body, byte('0'+pseudoRandomState%10), ' ')
-	}
-	return body[:n]
-}
-
 func TestEstimateUnzstdSize(t *testing.T) {
 	t.Parallel()
 
-	body := moderatelyCompressibleBody(11000)
-	compressedBody := zstdEncodeWithFCS(t, body)
-	if size := estimateUnzstdSize(compressedBody); size != len(body) {
-		t.Fatalf("unexpected estimate %d. Expecting %d", size, len(body))
+	body := bytes.Repeat([]byte("a"), 11_000)
+	withFCS := zstdEncodeWithFCS(t, body)
+	withoutFCS := []byte{
+		0x28, 0xb5, 0x2f, 0xfd, // zstd magic
+		0x00,       // no frame content size and not a single segment
+		0x00,       // 1 KiB window
+		0x09, 0, 0, // last raw block containing one byte
+		'x',
 	}
-
-	// An uncompressed size implying a suspiciously high compression ratio is
-	// clamped, even though such a ratio is legitimately reachable.
-	highlyCompressibleBody := bytes.Repeat([]byte("foobar baz "), 1000000)
-	compressedBody = zstdEncodeWithFCS(t, highlyCompressibleBody)
-	expectedSize := 4_000_000
-	if size := estimateUnzstdSize(compressedBody); size != expectedSize {
-		t.Fatalf("unexpected estimate %d for a highly compressible body. Expecting %d", size, expectedSize)
+	skippablePrefix := []byte{
+		0x50, 0x2a, 0x4d, 0x18, // skippable frame magic
+		0x03, 0, 0, 0, // payload size
+		'f', 'o', 'o',
 	}
-
-	// Streaming encoders don't know the body size upfront, so a compression
-	// factor of 2 is assumed for the frames they produce. Bodies small enough to
-	// be buffered whole are an exception, as the encoder does learn their size
-	// before writing the frame header.
-	streamedCompressedBody := AppendZstdBytes(nil, moderatelyCompressibleBody(4*1024*1024))
-	if zstdFrameHasContentSize(streamedCompressedBody) {
-		t.Fatalf("expecting no uncompressed size in a frame produced by the streaming encoder")
-	}
-	expectedSize = 2 * len(streamedCompressedBody)
-	if size := estimateUnzstdSize(streamedCompressedBody); size != expectedSize {
-		t.Fatalf("unexpected estimate %d for a streamed frame. Expecting %d", size, expectedSize)
-	}
-
-	if size := estimateUnzstdSize(nil); size != 0 {
-		t.Fatalf("unexpected estimate %d for empty data. Expecting 0", size)
-	}
-
-	nonZstdData := []byte("this is not zstd at all")
-	expectedSize = 2 * len(nonZstdData)
-	if size := estimateUnzstdSize(nonZstdData); size != expectedSize {
-		t.Fatalf("unexpected estimate %d for non-zstd data. Expecting %d", size, expectedSize)
-	}
-
-	// A forged huge uncompressed size must not be trusted as-is:
-	// magic number, then a frame header descriptor with single segment set and
-	// an 8 byte frame content size field, then the maximum content size.
-	forgedHeader := []byte{
+	forgedFCS := []byte{
 		0x28, 0xb5, 0x2f, 0xfd,
 		0xe0,
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 	}
-	expectedSize = 4_000_000
-	if size := estimateUnzstdSize(forgedHeader); size != expectedSize {
-		t.Fatalf("unexpected estimate %d for a forged header. Expecting %d", size, expectedSize)
-	}
-}
+	invalid := []byte("not zstd")
 
-func zstdFrameHasContentSize(p []byte) bool {
-	var header zstd.Header
-	return header.Decode(p) == nil && header.HasFCS
+	testCases := []struct {
+		name string
+		src  []byte
+		want int
+	}{
+		{name: "frame content size", src: withFCS, want: len(body)},
+		{name: "leading skippable frame", src: append(skippablePrefix, withFCS...), want: len(body)},
+		{name: "without frame content size", src: withoutFCS, want: 2 * len(withoutFCS)},
+		{name: "forged frame content size is clamped", src: forgedFCS, want: 4_000_000},
+		{name: "invalid input", src: invalid, want: 2 * len(invalid)},
+		{name: "empty input", src: nil, want: 0},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := estimateUnzstdSize(testCase.src); got != testCase.want {
+				t.Fatalf("unexpected estimate %d. Expecting %d", got, testCase.want)
+			}
+		})
+	}
 }
 
 func TestWriteUnzstdPresizesDestination(t *testing.T) {

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/valyala/bytebufferpool"
 )
 
 func TestZstdBytesSerial(t *testing.T) {
@@ -51,6 +54,138 @@ func testZstdBytesSingleCase(s string) error {
 		return fmt.Errorf("unexpected uncompressed string %q. Expecting %q", unZstdedS, s)
 	}
 	return nil
+}
+
+func zstdEncodeWithFCS(t *testing.T, body []byte) []byte {
+	t.Helper()
+
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	compressedBody := encoder.EncodeAll(body, nil)
+	encoder.Close()
+	return compressedBody
+}
+
+// moderatelyCompressibleBody returns n bytes of text which zstd compresses with
+// a ratio well below the one estimateUnzstdSize is willing to trust, so that the
+// uncompressed size from the frame header is used as-is.
+func moderatelyCompressibleBody(n int) []byte {
+	words := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"}
+	pseudoRandomState := uint64(42)
+
+	body := make([]byte, 0, n+8)
+	for len(body) < n {
+		pseudoRandomState = pseudoRandomState*6364136223846793005 + 1442695040888963407
+		body = append(body, words[pseudoRandomState>>60&7]...)
+		body = append(body, byte('0'+pseudoRandomState%10), ' ')
+	}
+	return body[:n]
+}
+
+func TestEstimateUnzstdSize(t *testing.T) {
+	t.Parallel()
+
+	body := moderatelyCompressibleBody(11000)
+	compressedBody := zstdEncodeWithFCS(t, body)
+	if size := estimateUnzstdSize(compressedBody); size != len(body) {
+		t.Fatalf("unexpected estimate %d. Expecting %d", size, len(body))
+	}
+
+	// An uncompressed size implying a suspiciously high compression ratio is
+	// clamped, even though such a ratio is legitimately reachable.
+	highlyCompressibleBody := bytes.Repeat([]byte("foobar baz "), 1000000)
+	compressedBody = zstdEncodeWithFCS(t, highlyCompressibleBody)
+	expectedSize := 4_000_000
+	if size := estimateUnzstdSize(compressedBody); size != expectedSize {
+		t.Fatalf("unexpected estimate %d for a highly compressible body. Expecting %d", size, expectedSize)
+	}
+
+	// Streaming encoders don't know the body size upfront, so a compression
+	// factor of 2 is assumed for the frames they produce. Bodies small enough to
+	// be buffered whole are an exception, as the encoder does learn their size
+	// before writing the frame header.
+	streamedCompressedBody := AppendZstdBytes(nil, moderatelyCompressibleBody(4*1024*1024))
+	if zstdFrameHasContentSize(streamedCompressedBody) {
+		t.Fatalf("expecting no uncompressed size in a frame produced by the streaming encoder")
+	}
+	expectedSize = 2 * len(streamedCompressedBody)
+	if size := estimateUnzstdSize(streamedCompressedBody); size != expectedSize {
+		t.Fatalf("unexpected estimate %d for a streamed frame. Expecting %d", size, expectedSize)
+	}
+
+	if size := estimateUnzstdSize(nil); size != 0 {
+		t.Fatalf("unexpected estimate %d for empty data. Expecting 0", size)
+	}
+
+	nonZstdData := []byte("this is not zstd at all")
+	expectedSize = 2 * len(nonZstdData)
+	if size := estimateUnzstdSize(nonZstdData); size != expectedSize {
+		t.Fatalf("unexpected estimate %d for non-zstd data. Expecting %d", size, expectedSize)
+	}
+
+	// A forged huge uncompressed size must not be trusted as-is:
+	// magic number, then a frame header descriptor with single segment set and
+	// an 8 byte frame content size field, then the maximum content size.
+	forgedHeader := []byte{
+		0x28, 0xb5, 0x2f, 0xfd,
+		0xe0,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	}
+	expectedSize = 4_000_000
+	if size := estimateUnzstdSize(forgedHeader); size != expectedSize {
+		t.Fatalf("unexpected estimate %d for a forged header. Expecting %d", size, expectedSize)
+	}
+}
+
+func zstdFrameHasContentSize(p []byte) bool {
+	var header zstd.Header
+	return header.Decode(p) == nil && header.HasFCS
+}
+
+func TestWriteUnzstdPresizesDestination(t *testing.T) {
+	t.Parallel()
+
+	body := moderatelyCompressibleBody(110000)
+	compressedBody := zstdEncodeWithFCS(t, body)
+
+	for _, maxBodySize := range []int{0, len(body), 2 * len(body)} {
+		var bb bytebufferpool.ByteBuffer
+		n, err := writeUnzstd(&bb, compressedBody, maxBodySize)
+		if err != nil {
+			t.Fatalf("unexpected error with maxBodySize=%d: %v", maxBodySize, err)
+		}
+		if n != len(body) {
+			t.Fatalf("unexpected decompressed size %d with maxBodySize=%d. Expecting %d", n, maxBodySize, len(body))
+		}
+		if !bytes.Equal(bb.B, body) {
+			t.Fatalf("unexpected decompressed body with maxBodySize=%d", maxBodySize)
+		}
+		// The destination has been pre-sized from the frame header, so
+		// decompression must not have grown it beyond the initial reservation.
+		if cap(bb.B) > 2*len(body) {
+			t.Fatalf("destination buffer was reallocated with maxBodySize=%d: cap=%d, decompressed size=%d",
+				maxBodySize, cap(bb.B), len(body))
+		}
+	}
+}
+
+func TestWriteUnzstdSmallMaxBodySize(t *testing.T) {
+	t.Parallel()
+
+	body := moderatelyCompressibleBody(110000)
+	compressedBody := zstdEncodeWithFCS(t, body)
+
+	// The pre-allocation must not exceed maxBodySize, and the body must still
+	// be rejected as too large.
+	var bb bytebufferpool.ByteBuffer
+	if _, err := writeUnzstd(&bb, compressedBody, 100); err != ErrBodyTooLarge {
+		t.Fatalf("unexpected error %v. Expecting %v", err, ErrBodyTooLarge)
+	}
+	if cap(bb.B) > 2*len(body) {
+		t.Fatalf("unexpected destination buffer capacity %d", cap(bb.B))
+	}
 }
 
 func TestZstdCompressSerial(t *testing.T) {


### PR DESCRIPTION
One of my applications is spending noticeable amount of CPU in `runtime.growslice` under zstd decompression, so I've tried to reduce the amount of reallocations there a bit.

The added tests are entirely vibe coded, but the main changes are not.

<img width="1400" height="601" alt="Screenshot 2026-08-13 at 14 48 21" src="https://github.com/user-attachments/assets/a1d08792-a945-4379-a320-dbf4600bc3bf" />
