### PR TITLE
feat: add the QUERY method (RFC 10008)

### DIFF
--- a/client.go
+++ b/client.go
@@ -1294,6 +1294,9 @@ func doRequestFollowRedirects(
 			req.ResetBody()
 			req.postArgs.Reset()
 			req.parsedPostArgs = false
+			// The body is gone for the rest of the chain, so later
+			// body-preserving redirects have nothing left to replay.
+			hasBodyStream = false
 		case req.Header.IsPost() && (statusCode == StatusMovedPermanently || statusCode == StatusFound):
 			// RFC 9110 sections 15.4.2/15.4.3 Note: for historical reasons a
 			// user agent MAY change the request method from POST to GET for a

--- a/client.go
+++ b/client.go
@@ -1622,7 +1622,7 @@ func (c *HostClient) PendingRequests() int {
 }
 
 func isIdempotent(req *Request) bool {
-	return req.Header.IsGet() || req.Header.IsHead() || req.Header.IsPut()
+	return req.Header.IsGet() || req.Header.IsHead() || req.Header.IsPut() || req.Header.IsQuery()
 }
 
 func (c *HostClient) do(req *Request, resp *Response) (bool, error) {

--- a/client.go
+++ b/client.go
@@ -1200,6 +1200,10 @@ var (
 	// ErrTooManyRedirects is returned by clients when the number of redirects followed
 	// exceed the max count.
 	ErrTooManyRedirects = errors.New("fasthttp: too many redirects detected when doing the request")
+	// ErrRedirectBodyStream is returned by clients when a redirect that keeps the request
+	// body is received for a request whose body is a stream. The hop that produced the
+	// redirect consumed the stream, so the body cannot be sent again.
+	ErrRedirectBodyStream = errors.New("fasthttp: cannot follow a body-preserving redirect for a request with a body stream")
 
 	// ErrHostClientRedirectToDifferentScheme is returned when a HostClient follows a redirect to a different protocol.
 	ErrHostClientRedirectToDifferentScheme = errors.New("fasthttp: hostclient can't follow redirects to a different protocol," +
@@ -1230,6 +1234,9 @@ func doRequestFollowRedirects(
 ) (statusCode int, body []byte, err error) {
 	redirectsCount := 0
 	initialHost := hostnameFromURLString(url)
+	// Writing the request consumes a body stream, so remember it here: by the
+	// time a redirect arrives req.IsBodyStream() is already false.
+	hasBodyStream := req.IsBodyStream()
 
 	for {
 		req.SetRequestURI(url)
@@ -1259,6 +1266,14 @@ func doRequestFollowRedirects(
 		url = getRedirectURL(url, location, req.DisableRedirectPathNormalizing, redirectURI)
 		stripSensitiveHeadersOnRedirect(req, initialHost, redirectURI)
 		ReleaseURI(redirectURI)
+
+		// Every redirect but 303 keeps the body, and a consumed stream cannot
+		// produce it again. Fail instead of following with an empty body, the
+		// same reason the retry path refuses to retry such a request.
+		if hasBodyStream && statusCode != StatusSeeOther {
+			err = ErrRedirectBodyStream
+			break
+		}
 
 		switch {
 		case statusCode == StatusSeeOther:

--- a/client_test.go
+++ b/client_test.go
@@ -2221,6 +2221,8 @@ func TestClientRedirectBodyStream(t *testing.T) {
 				ctx.Redirect("/landing", StatusTemporaryRedirect)
 			case "/redirect-308":
 				ctx.Redirect("/landing", StatusPermanentRedirect)
+			case "/redirect-303-then-307":
+				ctx.Redirect("/redirect-307", StatusSeeOther)
 			case "/landing":
 				ctx.SetBodyString(string(ctx.Method()) + "|" + string(ctx.PostBody()))
 			default:
@@ -2258,6 +2260,10 @@ func TestClientRedirectBodyStream(t *testing.T) {
 		// 303 drops the body, so a consumed stream is not in the way.
 		{nil, MethodPost, "/redirect-303", "GET|"},
 		{nil, MethodQuery, "/redirect-303", "GET|"},
+		// Once 303 has dropped the body there is nothing left to replay, so a
+		// body-preserving status later in the chain must still be followed.
+		{nil, MethodPost, "/redirect-303-then-307", "GET|"},
+		{nil, MethodQuery, "/redirect-303-then-307", "GET|"},
 	}
 
 	for _, tc := range tests {

--- a/client_test.go
+++ b/client_test.go
@@ -2164,6 +2164,13 @@ func TestClientRedirectMethodSwitch(t *testing.T) {
 		{MethodPost, "/redirect-302", "GET|hello"},
 		// 307 must preserve both the method and the body.
 		{MethodPost, "/redirect-307", "POST|hello"},
+		// RFC 10008 section 2.5: the POST exception for 301/302 does not
+		// apply to QUERY, so the method and body survive all three.
+		{MethodQuery, "/redirect-301", "QUERY|hello"},
+		{MethodQuery, "/redirect-302", "QUERY|hello"},
+		{MethodQuery, "/redirect-307", "QUERY|hello"},
+		// 303 switches QUERY to a body-less GET like any other method.
+		{MethodQuery, "/redirect-303", "GET|"},
 	}
 
 	for _, tc := range tests {
@@ -2661,6 +2668,27 @@ func TestClientIdempotentRequest(t *testing.T) {
 	if string(body) != "0123456" {
 		t.Fatalf("unexpected body: %q. Expecting %q", body, "0123456")
 	}
+
+	// QUERY is registered as idempotent by RFC 10008, so it must be retried
+	// like GET even though it carries a body.
+	dialsCount = 0
+	req := AcquireRequest()
+	resp := AcquireResponse()
+	req.SetRequestURI("http://foobar/a/b")
+	req.Header.SetMethod(MethodQuery)
+	req.Header.SetContentType("application/x-www-form-urlencoded")
+	req.SetBodyString("q=foobar")
+	if err = c.Do(req, resp); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := resp.StatusCode(); got != 345 {
+		t.Fatalf("unexpected status code: %d. Expecting 345", got)
+	}
+	if got := string(resp.Body()); got != "0123456" {
+		t.Fatalf("unexpected body: %q. Expecting %q", got, "0123456")
+	}
+	ReleaseRequest(req)
+	ReleaseResponse(resp)
 
 	var args Args
 

--- a/client_test.go
+++ b/client_test.go
@@ -2131,6 +2131,8 @@ func TestClientRedirectMethodSwitch(t *testing.T) {
 				ctx.Redirect("/landing", StatusSeeOther)
 			case "/redirect-307":
 				ctx.Redirect("/landing", StatusTemporaryRedirect)
+			case "/redirect-308":
+				ctx.Redirect("/landing", StatusPermanentRedirect)
 			case "/landing":
 				ctx.SetBodyString(string(ctx.Method()) + "|" + string(ctx.PostBody()))
 			default:
@@ -2162,13 +2164,15 @@ func TestClientRedirectMethodSwitch(t *testing.T) {
 		// 301/302 historically switch POST to GET (without forcing a body drop).
 		{MethodPost, "/redirect-301", "GET|hello"},
 		{MethodPost, "/redirect-302", "GET|hello"},
-		// 307 must preserve both the method and the body.
+		// 307 and 308 must preserve both the method and the body.
 		{MethodPost, "/redirect-307", "POST|hello"},
+		{MethodPost, "/redirect-308", "POST|hello"},
 		// RFC 10008 section 2.5: the POST exception for 301/302 does not
-		// apply to QUERY, so the method and body survive all three.
+		// apply to QUERY, so the method and body survive all four.
 		{MethodQuery, "/redirect-301", "QUERY|hello"},
 		{MethodQuery, "/redirect-302", "QUERY|hello"},
 		{MethodQuery, "/redirect-307", "QUERY|hello"},
+		{MethodQuery, "/redirect-308", "QUERY|hello"},
 		// 303 switches QUERY to a body-less GET like any other method.
 		{MethodQuery, "/redirect-303", "GET|"},
 	}
@@ -2189,6 +2193,91 @@ func TestClientRedirectMethodSwitch(t *testing.T) {
 			}
 			if got := resp.StatusCode(); got != StatusOK {
 				t.Fatalf("unexpected status code: %d", got)
+			}
+			if got := string(resp.Body()); got != tc.expectedBody {
+				t.Fatalf("unexpected landing echo %q. Expecting %q", got, tc.expectedBody)
+			}
+		})
+	}
+}
+
+func TestClientRedirectBodyStream(t *testing.T) {
+	t.Parallel()
+
+	// The hop that receives the redirect has already consumed the body stream,
+	// so a redirect that keeps the body cannot be replayed: 307 and 308 used to
+	// arrive with an empty body, and the POST switch to GET on 301/302 hung
+	// waiting for a body that never came.
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			switch string(ctx.Path()) {
+			case "/redirect-301":
+				ctx.Redirect("/landing", StatusMovedPermanently)
+			case "/redirect-302":
+				ctx.Redirect("/landing", StatusFound)
+			case "/redirect-303":
+				ctx.Redirect("/landing", StatusSeeOther)
+			case "/redirect-307":
+				ctx.Redirect("/landing", StatusTemporaryRedirect)
+			case "/redirect-308":
+				ctx.Redirect("/landing", StatusPermanentRedirect)
+			case "/landing":
+				ctx.SetBodyString(string(ctx.Method()) + "|" + string(ctx.PostBody()))
+			default:
+				ctx.Error("not found", StatusNotFound)
+			}
+		},
+	}
+	ln := fasthttputil.NewInmemoryListener()
+	go func() {
+		if err := s.Serve(ln); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	c := &HostClient{
+		Addr: "xxx",
+		Dial: func(addr string) (net.Conn, error) { return ln.Dial() },
+	}
+
+	tests := []struct {
+		expectedErr  error
+		method       string
+		path         string
+		expectedBody string
+	}{
+		// All four body-preserving statuses must report the unusable stream.
+		{ErrRedirectBodyStream, MethodPost, "/redirect-301", ""},
+		{ErrRedirectBodyStream, MethodPost, "/redirect-302", ""},
+		{ErrRedirectBodyStream, MethodPost, "/redirect-307", ""},
+		{ErrRedirectBodyStream, MethodPost, "/redirect-308", ""},
+		{ErrRedirectBodyStream, MethodQuery, "/redirect-301", ""},
+		{ErrRedirectBodyStream, MethodQuery, "/redirect-302", ""},
+		{ErrRedirectBodyStream, MethodQuery, "/redirect-307", ""},
+		{ErrRedirectBodyStream, MethodQuery, "/redirect-308", ""},
+		// 303 drops the body, so a consumed stream is not in the way.
+		{nil, MethodPost, "/redirect-303", "GET|"},
+		{nil, MethodQuery, "/redirect-303", "GET|"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := AcquireRequest()
+			resp := AcquireResponse()
+			defer ReleaseRequest(req)
+			defer ReleaseResponse(resp)
+
+			req.Header.SetMethod(tc.method)
+			req.SetRequestURI("http://xxx" + tc.path)
+			body := bytes.NewBufferString("hello")
+			req.SetBodyStream(body, body.Len())
+
+			err := c.DoRedirects(req, resp, 16)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Fatalf("unexpected error %v. Expecting %v", err, tc.expectedErr)
+			}
+			if tc.expectedErr != nil {
+				return
 			}
 			if got := string(resp.Body()); got != tc.expectedBody {
 				t.Fatalf("unexpected landing echo %q. Expecting %q", got, tc.expectedBody)

--- a/header.go
+++ b/header.go
@@ -849,6 +849,11 @@ func (h *RequestHeader) IsPatch() bool {
 	return string(h.Method()) == MethodPatch
 }
 
+// IsQuery returns true if request method is QUERY.
+func (h *RequestHeader) IsQuery() bool {
+	return string(h.Method()) == MethodQuery
+}
+
 // IsHTTP11 returns true if the header is HTTP/1.1.
 func (h *header) IsHTTP11() bool {
 	return !h.noHTTP11

--- a/headers.go
+++ b/headers.go
@@ -9,6 +9,7 @@ const (
 	HeaderAcceptLanguage                  = "Accept-Language"
 	HeaderAcceptPatch                     = "Accept-Patch"
 	HeaderAcceptPushPolicy                = "Accept-Push-Policy"
+	HeaderAcceptQuery                     = "Accept-Query"
 	HeaderAcceptRanges                    = "Accept-Ranges"
 	HeaderAcceptSignature                 = "Accept-Signature"
 	HeaderAccessControlAllowCredentials   = "Access-Control-Allow-Credentials"

--- a/methods.go
+++ b/methods.go
@@ -11,4 +11,5 @@ const (
 	MethodConnect = "CONNECT" // RFC 7231, 4.3.6
 	MethodOptions = "OPTIONS" // RFC 7231, 4.3.7
 	MethodTrace   = "TRACE"   // RFC 7231, 4.3.8
+	MethodQuery   = "QUERY"   // RFC 10008, 2
 )

--- a/server.go
+++ b/server.go
@@ -1336,6 +1336,11 @@ func (ctx *RequestCtx) IsPatch() bool {
 	return ctx.Request.Header.IsPatch()
 }
 
+// IsQuery returns true if request method is QUERY.
+func (ctx *RequestCtx) IsQuery() bool {
+	return ctx.Request.Header.IsQuery()
+}
+
 // Method return request method.
 //
 // Returned value is valid until your request handler returns.

--- a/server_test.go
+++ b/server_test.go
@@ -3938,6 +3938,34 @@ func TestServerEmptyResponse(t *testing.T) {
 	verifyResponse(t, br, 200, string(defaultContentType), "")
 }
 
+func TestServerQueryMethod(t *testing.T) {
+	t.Parallel()
+
+	// RFC 10008 QUERY carries the query in the request content, so the body
+	// must reach the handler the same way it does for POST.
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			if !ctx.IsQuery() {
+				t.Errorf("IsQuery() must be true for method %q", ctx.Method())
+			}
+			ctx.SetBodyString(string(ctx.Method()) + "|" +
+				string(ctx.PostBody()) + "|" + string(ctx.PostArgs().Peek("q")))
+		},
+	}
+
+	rw := &readWriter{}
+	rw.r.WriteString("QUERY /contacts HTTP/1.1\r\nHost: example.org\r\n" +
+		"Content-Type: application/x-www-form-urlencoded\r\n" +
+		"Content-Length: 14\r\n\r\nq=foo&limit=10")
+
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("Unexpected error from serveConn: %v", err)
+	}
+
+	br := bufio.NewReader(&rw.w)
+	verifyResponse(t, br, 200, string(defaultContentType), "QUERY|q=foo&limit=10|foo")
+}
+
 func TestServerLogger(t *testing.T) {
 	// This test can't run parallel as it modifies globalConnID.
 


### PR DESCRIPTION
[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html), published in June 2026, registers QUERY: a safe, idempotent method that carries its query in the request content instead of the URI.

Most of it already worked here. I probed the current behavior over both HTTP/1 and HTTP/2 before writing any code:

- method parsing is a character-table check rather than a whitelist, so `QUERY /contacts HTTP/1.1` already parses
- `ignoreBody()` only excludes GET and HEAD, so the request content is read and written normally
- `parsePostArgs` keys off Content-Type rather than the method, so `ctx.PostArgs()` works for a form-urlencoded QUERY

Redirects with a buffered body were already correct too, which section 2.5 is specific about, since the POST exception for 301/302 must not apply to QUERY:

|       | 301   | 302   | 303                | 307   | 308   |
| ----- | ----- | ----- | ------------------ | ----- | ----- |
| POST  | →GET  | →GET  | →GET, body dropped | POST  | POST  |
| QUERY | QUERY | QUERY | →GET, body dropped | QUERY | QUERY |

That falls out of the 301/302 downgrade being limited to `IsPost()` while the 303 branch is written for any method. The added cases lock it in.

## Behavior changes

### QUERY is retried like the other idempotent methods

`isIdempotent` did not know the method, so the client would not retry a QUERY after a connection failure:

```
isIdempotent(GET) = true    isIdempotent(POST)  = false
isIdempotent(PUT) = true    isIdempotent(QUERY) = false   <-
```

Section 5.1 registers QUERY with safe=yes and idempotent=yes, and repeating a request automatically is the point of the method over POST. `TestClientIdempotentRequest` covers it and was verified to fail without the change.

### A redirect no longer replays a consumed body stream

This one is a pre-existing bug that has nothing to do with QUERY; it came out of review here because QUERY keeps its body on four statuses instead of two. Verified on a separate worktree at an unmodified `upstream/master`, sending a streamed `hello` body:

| streamed body | 301       | 302       | 307      | 308      | 303          |
| ------------- | --------- | --------- | -------- | -------- | ------------ |
| POST          | **hangs** | **hangs** | `POST\|` | `POST\|` | `GET\|` (ok) |
| QUERY         | `QUERY\|` | `QUERY\|` | `QUERY\|`| `QUERY\|`| `GET\|` (ok) |

Writing the first hop consumes the stream, so a redirect that keeps the body was followed with an empty one. On 301/302 the POST switch to GET is worse than an empty body: the request still announces a `Content-Length` the drained stream can no longer fill, and the next hop blocks forever. PUT behaves like POST.

`HostClient.do` already captures `hasBodyStream` before the first write and refuses to retry for this exact reason. The redirect loop now captures the same flag up front (by the time a 3xx arrives, `req.IsBodyStream()` is already false, since `writeBodyStream` closes the stream) and fails with `ErrRedirectBodyStream` on any body-preserving status. The flag tracks the body it guards: a 303 drops the body and clears it, so once the request has become a body-less GET, later body-preserving statuses in the chain are followed normally — same as master. `TestClientRedirectBodyStream` covers all four statuses for both methods, the two 303 cases, and the 303-then-307 chain; with the guard removed it hangs and the test binary times out.

Happy to move this part into its own PR if it should be reviewed separately.

## The rest

`MethodQuery`, `RequestHeader.IsQuery`, `RequestCtx.IsQuery` and `HeaderAcceptQuery` are names with no behavior of their own.

Left to the application rather than the framework: rejecting a missing Content-Type (section 2), choosing between 415/422/406 (section 2.1), serializing `Accept-Query` as a Structured Field (section 3), the cache key (section 2.7, there is no cache layer here), and CORS preflight (section 4).

31 lines of source and 152 of tests. `go test -race`, `go vet` and golangci-lint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)