### PR TITLE
discard unread streamed request body before the next request

### DIFF
--- a/http.go
+++ b/http.go
@@ -2387,9 +2387,11 @@ func (req *Request) closeBodyStream() error {
 	if bsc, ok := req.bodyStream.(io.Closer); ok {
 		err = bsc.Close()
 	}
-	if rs, ok := req.bodyStream.(*requestStream); ok {
-		releaseRequestStream(rs)
-	}
+	// A *requestStream reads directly from the connection, so the server loop
+	// owns it: it drains any unread body and returns the stream to the pool
+	// once the connection can be reused, or drops it when closing. Releasing it
+	// here would let a handler abandon an unread body and desync the next
+	// request, so leave that to the server.
 	req.bodyStream = nil
 	return err
 }

--- a/server.go
+++ b/server.go
@@ -2637,6 +2637,12 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		ctx.connRequestNum = connRequestNum
 		ctx.time = time.Now()
 
+		// Capture the streamed request body reader, if any, before running the
+		// handler. The handler may return without reading all of it, or abandon
+		// it via CloseBodyStream; either way it is the server, not the handler,
+		// that owns draining it and returning it to the pool afterwards.
+		reqStream, _ := ctx.Request.bodyStream.(*requestStream)
+
 		// If a client denies a request the handler should not be called
 		if continueReadingRequest {
 			s.Handler(ctx)
@@ -2644,13 +2650,16 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 
 		timeoutResponse = ctx.timeoutResponse
 		if timeoutResponse != nil {
-			// The timed out handler may still be reading the streamed body,
-			// so the rest of it cannot be discarded here: close the connection
-			// instead of parsing the unread body as the next request.
-			if ctx.Request.bodyStream != nil {
+			// The timed out handler runs in its own goroutine and may still be
+			// reading the streamed body from br, so it cannot be drained here.
+			// Close the connection, and keep br out of the reader pool while
+			// that goroutine still owns it by dropping our reference to it.
+			if reqStream != nil {
 				connectionClose = true
+				br = nil
 			}
-			// Acquire a new ctx because the old one will still be in use by the timeout out handler.
+			reqStream = nil
+			// Acquire a new ctx because the old one will still be in use by the timed out handler.
 			ctx = s.acquireCtx(c)
 			timeoutResponse.CopyTo(&ctx.Response)
 		}
@@ -2664,12 +2673,21 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		hijackNoResponse = ctx.hijackNoResponse && hijackHandler != nil
 		ctx.hijackNoResponse = false
 
+		// Decide whether the connection is closing before touching the body
+		// stream, so a handler that asked to close it (or a per-connection
+		// limit) skips the drain below instead of blocking on unread bytes.
+		connectionClose = connectionClose ||
+			(s.MaxRequestsPerConn > 0 && connRequestNum >= uint64(s.MaxRequestsPerConn)) || // #nosec G115
+			ctx.Response.Header.ConnectionClose() ||
+			(s.CloseOnShutdown && s.stop.Load() == 1)
+
 		// The handler may have returned without reading the whole streamed
 		// body. What is left of it would be parsed as the next request on
 		// this connection, so discard it, or close the connection when there
-		// is too much left to read.
-		if !connectionClose && hijackHandler == nil {
-			if rs, ok := ctx.Request.bodyStream.(*requestStream); ok && !rs.discard(maxUnreadStreamBodySize) {
+		// is too much left to read. Skip this when the connection is closing
+		// anyway or was hijacked.
+		if reqStream != nil && !connectionClose && hijackHandler == nil {
+			if !reqStream.discard(maxUnreadStreamBodySize) {
 				connectionClose = true
 			}
 		}
@@ -2687,10 +2705,6 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 			previousWriteTimeout = 0
 		}
 
-		connectionClose = connectionClose ||
-			(s.MaxRequestsPerConn > 0 && connRequestNum >= uint64(s.MaxRequestsPerConn)) || // #nosec G115
-			ctx.Response.Header.ConnectionClose() ||
-			(s.CloseOnShutdown && s.stop.Load() == 1)
 		if connectionClose {
 			ctx.Response.Header.SetConnectionClose()
 		} else if !ctx.Request.Header.IsHTTP11() {
@@ -2755,12 +2769,10 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 			break
 		}
 
-		if ctx.Request.bodyStream != nil {
-			if rs, ok := ctx.Request.bodyStream.(*requestStream); ok {
-				releaseRequestStream(rs)
-			}
-			ctx.Request.bodyStream = nil
+		if reqStream != nil {
+			releaseRequestStream(reqStream)
 		}
+		ctx.Request.bodyStream = nil
 
 		idleConnTime.Store(ctx.time.Unix())
 		s.setState(c, StateIdle)

--- a/server.go
+++ b/server.go
@@ -2306,6 +2306,12 @@ func nextConnID() uint64 {
 // See Server.MaxRequestBodySize for details.
 const DefaultMaxRequestBodySize = 4 * 1024 * 1024
 
+// maxUnreadStreamBodySize is how much of a streamed request body the server
+// discards after the handler returns without reading it, in order to keep the
+// connection alive. When more is left the connection is closed instead, as
+// net/http does once a handler returns.
+const maxUnreadStreamBodySize = 256 * 1024
+
 func (s *Server) idleTimeout() time.Duration {
 	if s.IdleTimeout != 0 {
 		return s.IdleTimeout
@@ -2638,6 +2644,12 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 
 		timeoutResponse = ctx.timeoutResponse
 		if timeoutResponse != nil {
+			// The timed out handler may still be reading the streamed body,
+			// so the rest of it cannot be discarded here: close the connection
+			// instead of parsing the unread body as the next request.
+			if ctx.Request.bodyStream != nil {
+				connectionClose = true
+			}
 			// Acquire a new ctx because the old one will still be in use by the timeout out handler.
 			ctx = s.acquireCtx(c)
 			timeoutResponse.CopyTo(&ctx.Response)
@@ -2651,6 +2663,16 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		ctx.hijackHandler = nil
 		hijackNoResponse = ctx.hijackNoResponse && hijackHandler != nil
 		ctx.hijackNoResponse = false
+
+		// The handler may have returned without reading the whole streamed
+		// body. What is left of it would be parsed as the next request on
+		// this connection, so discard it, or close the connection when there
+		// is too much left to read.
+		if !connectionClose && hijackHandler == nil {
+			if rs, ok := ctx.Request.bodyStream.(*requestStream); ok && !rs.discard(maxUnreadStreamBodySize) {
+				connectionClose = true
+			}
+		}
 
 		if writeTimeout > 0 {
 			if err = c.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -5326,6 +5326,110 @@ func TestServerClosesConnOnLargeUnreadStreamedBody(t *testing.T) {
 	}
 }
 
+func TestServerDiscardsStreamedBodyClosedByHandler(t *testing.T) {
+	t.Parallel()
+
+	// A handler that abandons the stream with CloseBodyStream instead of
+	// reading it must not leave the unread body on the connection either.
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := strings.Repeat("a", 8*1024) + smuggled
+
+	rw := &readWriter{}
+	fmt.Fprintf(&rw.r, "POST /first HTTP/1.1\r\nHost: x\r\nContent-Length: %d\r\n\r\n%s", len(body), body)
+	rw.r.WriteString("GET /next HTTP/1.1\r\nHost: x\r\n\r\n")
+
+	var paths []string
+	s := Server{
+		StreamRequestBody: true,
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+			ctx.Request.CloseBodyStream() //nolint:errcheck
+		},
+	}
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(paths) != 2 || paths[0] != "/first" || paths[1] != "/next" {
+		t.Fatalf("handler paths = %q; want [/first /next]", paths)
+	}
+}
+
+func TestServerSkipsDiscardOnHandlerConnectionClose(t *testing.T) {
+	t.Parallel()
+
+	// A handler that closes the connection must respond right away instead of
+	// blocking on the rest of an unfinished chunked upload that never arrives.
+	ln := fasthttputil.NewInmemoryListener()
+
+	var mu sync.Mutex
+	var paths []string
+	s := &Server{
+		StreamRequestBody: true,
+		Handler: func(ctx *RequestCtx) {
+			mu.Lock()
+			paths = append(paths, string(ctx.Path()))
+			mu.Unlock()
+			ctx.Response.Header.SetConnectionClose()
+		},
+	}
+	serverCh := make(chan struct{})
+	go func() {
+		if err := s.Serve(ln); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(serverCh)
+	}()
+
+	conn, err := ln.Dial()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only the chunked header is sent, the body chunks never follow.
+	if _, err = conn.Write([]byte("POST /first HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	respCh := make(chan error, 1)
+	go func() {
+		var resp Response
+		if rerr := resp.Read(bufio.NewReader(conn)); rerr != nil {
+			respCh <- rerr
+			return
+		}
+		if !resp.ConnectionClose() {
+			respCh <- errors.New("expecting 'Connection: close' response header")
+			return
+		}
+		respCh <- nil
+	}()
+
+	select {
+	case err = <-respCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(testTimeout(time.Second)):
+		t.Fatal("no response: the server blocked on the unfinished body")
+	}
+
+	mu.Lock()
+	if len(paths) != 1 || paths[0] != "/first" {
+		mu.Unlock()
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+	mu.Unlock()
+
+	if err := ln.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	select {
+	case <-serverCh:
+	case <-time.After(testTimeout(time.Second)):
+		t.Fatal("timeout")
+	}
+}
+
 func TestServerClosesConnOnTimedOutStreamedBody(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -5229,6 +5229,173 @@ func TestRequestBodyStreamReadIssue1816(t *testing.T) {
 	}
 }
 
+func TestServerDiscardsUnreadStreamedBody(t *testing.T) {
+	t.Parallel()
+
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	next := "GET /next HTTP/1.1\r\nHost: x\r\n\r\n"
+
+	// The first 8KiB of a fixed-length body are prefetched, so the rest of
+	// the body is what the next request would be parsed from.
+	body := strings.Repeat("a", 8*1024) + smuggled
+
+	for _, tc := range []struct {
+		name string
+		req  string
+	}{
+		{
+			name: "content-length",
+			req: fmt.Sprintf("POST /first HTTP/1.1\r\nHost: x\r\nContent-Length: %d\r\n\r\n%s",
+				len(body), body),
+		},
+		{
+			name: "chunked",
+			req: fmt.Sprintf("POST /first HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n%x\r\n%s\r\n0\r\n\r\n",
+				len(body), body),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rw := &readWriter{}
+			rw.r.WriteString(tc.req)
+			rw.r.WriteString(next)
+
+			var paths []string
+			s := Server{
+				StreamRequestBody: true,
+				Handler: func(ctx *RequestCtx) {
+					paths = append(paths, string(ctx.Path()))
+				},
+			}
+			if err := s.ServeConn(rw); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(paths) != 2 || paths[0] != "/first" || paths[1] != "/next" {
+				t.Fatalf("handler paths = %q; want [/first /next]", paths)
+			}
+
+			br := bufio.NewReader(&rw.w)
+			var resp Response
+			for range 2 {
+				if err := resp.Read(br); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if resp.ConnectionClose() {
+					t.Fatal("unexpected 'Connection: close' response header")
+				}
+			}
+		})
+	}
+}
+
+func TestServerClosesConnOnLargeUnreadStreamedBody(t *testing.T) {
+	t.Parallel()
+
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := strings.Repeat("a", maxUnreadStreamBodySize) + smuggled
+
+	rw := &readWriter{}
+	fmt.Fprintf(&rw.r, "POST /first HTTP/1.1\r\nHost: x\r\nContent-Length: %d\r\n\r\n%s", len(body), body)
+	rw.r.WriteString("GET /next HTTP/1.1\r\nHost: x\r\n\r\n")
+
+	var paths []string
+	s := Server{
+		StreamRequestBody: true,
+		Handler: func(ctx *RequestCtx) {
+			paths = append(paths, string(ctx.Path()))
+		},
+	}
+	if err := s.ServeConn(rw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(paths) != 1 || paths[0] != "/first" {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+
+	br := bufio.NewReader(&rw.w)
+	var resp Response
+	if err := resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.ConnectionClose() {
+		t.Fatal("expecting 'Connection: close' response header")
+	}
+	if br.Buffered() != 0 {
+		t.Fatalf("unexpected data after the first response: %q", rw.w.String())
+	}
+}
+
+func TestServerClosesConnOnTimedOutStreamedBody(t *testing.T) {
+	t.Parallel()
+
+	ln := fasthttputil.NewInmemoryListener()
+
+	var mu sync.Mutex
+	var paths []string
+	handlerDone := make(chan struct{})
+	h := func(ctx *RequestCtx) {
+		mu.Lock()
+		paths = append(paths, string(ctx.Path()))
+		mu.Unlock()
+		if string(ctx.Path()) == "/first" {
+			<-handlerDone
+		}
+	}
+	s := &Server{
+		StreamRequestBody: true,
+		Handler:           TimeoutHandler(h, testTimeout(20*time.Millisecond), "timeout"),
+	}
+	serverCh := make(chan struct{})
+	go func() {
+		if err := s.Serve(ln); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(serverCh)
+	}()
+
+	conn, err := ln.Dial()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	smuggled := "GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"
+	body := strings.Repeat("a", 8*1024) + smuggled
+	if _, err = fmt.Fprintf(conn, "POST /first HTTP/1.1\r\nHost: x\r\nContent-Length: %d\r\n\r\n%s", len(body), body); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	br := bufio.NewReader(conn)
+	var resp Response
+	if err = resp.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode() != StatusRequestTimeout {
+		t.Fatalf("unexpected status code: %d. Expecting %d", resp.StatusCode(), StatusRequestTimeout)
+	}
+	if !resp.ConnectionClose() {
+		t.Fatal("expecting 'Connection: close' response header")
+	}
+	if _, err = br.ReadByte(); err != io.EOF {
+		t.Fatalf("expecting the connection to be closed, got %v", err)
+	}
+	close(handlerDone)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) != 1 || paths[0] != "/first" {
+		t.Fatalf("handler paths = %q; want only [/first]", paths)
+	}
+
+	if err := ln.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	select {
+	case <-serverCh:
+	case <-time.After(testTimeout(time.Second)):
+		t.Fatal("timeout")
+	}
+}
+
 func TestRequestCtxInitShouldNotBeCanceledIssue1879(t *testing.T) {
 	var r Request
 	var requestCtx RequestCtx

--- a/streaming.go
+++ b/streaming.go
@@ -20,6 +20,10 @@ type requestStream struct {
 	reader          *bufio.Reader
 	totalBytesRead  int
 	chunkLeft       int
+	// chunkedEOF is set once the last chunk and the trailer of a chunked
+	// body have been read, so that further reads don't consume the next
+	// request from the reader.
+	chunkedEOF bool
 }
 
 func (rs *requestStream) Read(p []byte) (int, error) {
@@ -28,6 +32,9 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 		err error
 	)
 	if rs.header.ContentLength() == -1 {
+		if rs.chunkedEOF {
+			return 0, io.EOF
+		}
 		if rs.chunkLeft == 0 {
 			chunkSize, err := parseChunkSize(rs.reader)
 			if err != nil {
@@ -38,6 +45,7 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 				if err != nil && err != io.EOF {
 					return 0, err
 				}
+				rs.chunkedEOF = true
 				return 0, io.EOF
 			}
 			rs.chunkLeft = chunkSize
@@ -86,6 +94,17 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// discard reads and drops what is left of the body, so that the reader ends
+// where the next request starts. It gives up after limit bytes and reports
+// whether the end of the body was reached.
+func (rs *requestStream) discard(limit int) bool {
+	if cl := rs.header.ContentLength(); cl >= 0 && cl-rs.totalBytesRead > limit {
+		return false
+	}
+	_, err := io.CopyN(io.Discard, rs, int64(limit)+1)
+	return err == io.EOF
+}
+
 func acquireRequestStream(b *bytebufferpool.ByteBuffer, r *bufio.Reader, h bodyStreamHeader) *requestStream {
 	rs := requestStreamPool.Get().(*requestStream) //nolint:forcetypeassert
 	rs.prefetchedBytes = bytes.NewReader(b.B)
@@ -98,6 +117,7 @@ func releaseRequestStream(rs *requestStream) {
 	rs.prefetchedBytes = nil
 	rs.totalBytesRead = 0
 	rs.chunkLeft = 0
+	rs.chunkedEOF = false
 	rs.reader = nil
 	rs.header = nil
 	requestStreamPool.Put(rs)


### PR DESCRIPTION
Repro: run a `StreamRequestBody: true` server whose handler returns without reading the body, then send `POST /first` with a body of 8 KiB padding followed by `GET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n`. Expected: the handler runs once. Actual: it runs a second time for `/smuggled`, and with a chunked body the next real request on the connection gets a 400 instead.

Cause: `serveConn` released the `requestStream` after the handler returned without consuming what was left of it, so the unread body bytes stayed in `br` and were parsed as the next request (only the first 8 KiB of a fixed-length body is prefetched, and none of a chunked one). `net/http` discards up to 256 KiB here and otherwise closes the connection. #2336 only covers the multipart reader; this is the general case for any handler that does not drain the stream.

Fix: after the handler returns, discard what is left of the stream up to 256 KiB, otherwise answer with `Connection: close`. Same for a request that timed out through `TimeoutHandler`, since its goroutine still owns the stream. `requestStream.Read` now also stays at `io.EOF` after the last chunk instead of reading the next request as a chunk size. Hijacked requests are left alone. The added tests fail on master and pass with this change.
