### PR TITLE
docs: show how to read a bounded response prefix

### DIFF
--- a/client.go
+++ b/client.go
@@ -370,9 +370,13 @@ type Client struct {
 
 	// StreamResponseBody enables response body streaming for Do methods.
 	// Response bodies aren't fully buffered before Do returns. The caller must
-	// read and close Response.BodyStream. Body read errors occur after Do returns
-	// and aren't handled by retry callbacks. ReadTimeout and request deadlines
-	// remain active while reading the stream.
+	// read [Response.BodyStream] and close it with [Response.CloseBodyStream] or
+	// [ReadCloserWithError.CloseWithError]. Body read errors occur after Do
+	// returns and aren't handled by retry callbacks. ReadTimeout and request
+	// deadlines remain active while reading the stream.
+	//
+	// See the [Response.BodyStream] example for retaining only a bounded prefix
+	// of a response body.
 	//
 	// Get and Post methods still read the full response body before returning.
 	// If Do is called with a nil Response, the client drains only small,
@@ -1014,9 +1018,13 @@ type HostClient struct {
 
 	// StreamResponseBody enables response body streaming for Do methods.
 	// Response bodies aren't fully buffered before Do returns. The caller must
-	// read and close Response.BodyStream. Body read errors occur after Do returns
-	// and aren't handled by retry callbacks. ReadTimeout and request deadlines
-	// remain active while reading the stream.
+	// read [Response.BodyStream] and close it with [Response.CloseBodyStream] or
+	// [ReadCloserWithError.CloseWithError]. Body read errors occur after Do
+	// returns and aren't handled by retry callbacks. ReadTimeout and request
+	// deadlines remain active while reading the stream.
+	//
+	// See the [Response.BodyStream] example for retaining only a bounded prefix
+	// of a response body.
 	//
 	// Get and Post methods still read the full response body before returning.
 	// If Do is called with a nil Response, the client drains only small,

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -1,9 +1,14 @@
 package fasthttp_test
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"log"
+	"net"
 
 	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
 )
 
 func ExampleHostClient() {
@@ -37,4 +42,69 @@ func ExampleHostClient() {
 
 func useResponseBody(body []byte) {
 	// Do something with body :)
+}
+
+func ExampleResponse_BodyStream() {
+	listener := fasthttputil.NewInmemoryListener()
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			ctx.SetBodyString("hello world")
+		},
+	}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	defer func() {
+		_ = server.Shutdown()
+	}()
+
+	readBodyPrefix := func(resp *fasthttp.Response, limit int) ([]byte, error) {
+		stream := resp.BodyStream()
+		closer, ok := stream.(fasthttp.ReadCloserWithError)
+		if !ok {
+			_ = resp.CloseBodyStream()
+			return nil, fmt.Errorf("unexpected body stream type %T", stream)
+		}
+
+		// Read one extra byte so an exact-size body can be distinguished from
+		// a truncated body.
+		body, err := io.ReadAll(io.LimitReader(stream, int64(limit)+1))
+		if err != nil {
+			_ = closer.CloseWithError(err)
+			return body, err
+		}
+		if len(body) > limit {
+			body = body[:limit]
+			_ = closer.CloseWithError(fasthttp.ErrBodyTooLarge)
+			return body, fasthttp.ErrBodyTooLarge
+		}
+
+		return body, resp.CloseBodyStream()
+	}
+
+	client := &fasthttp.Client{
+		Dial: func(string) (net.Conn, error) {
+			return listener.Dial()
+		},
+	}
+	defer client.CloseIdleConnections()
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.SetRequestURI("http://example.com/")
+
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	resp.StreamBody = true
+
+	if err := client.Do(req, resp); err != nil {
+		fmt.Printf("request error: %v\n", err)
+		return
+	}
+	body, err := readBodyPrefix(resp, 5)
+	fmt.Printf("%s\n%t\n", body, errors.Is(err, fasthttp.ErrBodyTooLarge))
+
+	// Output:
+	// hello
+	// true
 }

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -60,6 +60,11 @@ func ExampleResponse_BodyStream() {
 
 	readBodyPrefix := func(resp *fasthttp.Response, limit int) ([]byte, error) {
 		stream := resp.BodyStream()
+		// BodyStream is nil for responses without a body, such as HEAD, 204,
+		// and 304 responses.
+		if stream == nil {
+			return nil, nil
+		}
 		closer, ok := stream.(fasthttp.ReadCloserWithError)
 		if !ok {
 			_ = resp.CloseBodyStream()

--- a/http.go
+++ b/http.go
@@ -370,8 +370,8 @@ func (resp *Response) CloseBodyStream() error {
 }
 
 // ReadCloserWithError is a body stream that can be closed with the error that
-// caused the caller to stop reading. Streamed client response bodies implement
-// this interface.
+// caused the caller to stop reading. Streamed response bodies returned by
+// [Client.Do] and [HostClient.Do] implement this interface.
 type ReadCloserWithError interface {
 	io.Reader
 	CloseWithError(err error) error

--- a/http.go
+++ b/http.go
@@ -355,9 +355,12 @@ func (req *Request) CloseBodyStream() error {
 	return req.closeBodyStream()
 }
 
-// BodyStream returns io.Reader.
+// BodyStream returns the response body stream.
 //
-// You must CloseBodyStream or ReleaseResponse after you use it.
+// When response streaming is enabled, the caller must close the stream with
+// [Response.CloseBodyStream] after reading it. To report why a read stopped
+// before EOF, assert the returned reader to [ReadCloserWithError] and call
+// CloseWithError. See the example for retaining only a bounded body prefix.
 func (resp *Response) BodyStream() io.Reader {
 	return resp.bodyStream
 }
@@ -366,6 +369,9 @@ func (resp *Response) CloseBodyStream() error {
 	return resp.closeBodyStream(nil)
 }
 
+// ReadCloserWithError is a body stream that can be closed with the error that
+// caused the caller to stop reading. Streamed client response bodies implement
+// this interface.
 type ReadCloserWithError interface {
 	io.Reader
 	CloseWithError(err error) error


### PR DESCRIPTION
## What does this PR do?

Documents the existing response-streaming pattern for retaining a bounded body prefix without adding another client option or precedence rule.

- Adds an executable `Response.BodyStream` example that reads `limit + 1` bytes, returns `ErrBodyTooLarge` when truncated, and closes the stream with the error so the partially consumed connection is discarded.
- Expands the `Client.StreamResponseBody` and `HostClient.StreamResponseBody` documentation with the required stream-closing semantics.
- Documents `ReadCloserWithError` and how it is used when a caller stops before EOF.

The pattern can be enabled per response with `resp.StreamBody = true`, or for every response from a client with `StreamResponseBody = true`.

Fixes #1724.

## Tests

- `go test ./...`
- `go test -race .`
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/master`
