### PR TITLE
fix: send / as the path when the request-target is query-only

### DIFF
--- a/header.go
+++ b/header.go
@@ -786,6 +786,12 @@ func (h *RequestHeader) RequestURI() []byte {
 	requestURI := h.requestURI
 	if len(requestURI) == 0 {
 		requestURI = strSlash
+	} else if requestURI[0] == '?' {
+		// Origin-form requires a path. An empty path is "/".
+		h.requestURI = append(h.requestURI, 0)
+		copy(h.requestURI[1:], h.requestURI[:len(h.requestURI)-1])
+		h.requestURI[0] = '/'
+		requestURI = h.requestURI
 	}
 	return requestURI
 }

--- a/header_test.go
+++ b/header_test.go
@@ -4116,3 +4116,22 @@ func TestRequestHeaderValidWhitespace(t *testing.T) {
 		}
 	}
 }
+
+func TestRequestHeaderEmptyPathWithQuery(t *testing.T) {
+	t.Parallel()
+
+	var h RequestHeader
+	h.SetMethod(MethodGet)
+	h.SetHost("example.com")
+	h.SetRequestURI("?foo=bar")
+
+	got := string(h.RequestURI())
+	if got != "/?foo=bar" {
+		t.Fatalf("unexpected RequestURI %q. Expecting %q", got, "/?foo=bar")
+	}
+
+	firstLine := strings.Split(string(h.Header()), "\r\n")[0]
+	if firstLine != "GET /?foo=bar HTTP/1.1" {
+		t.Fatalf("unexpected request line %q. Expecting %q", firstLine, "GET /?foo=bar HTTP/1.1")
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -1961,6 +1961,43 @@ func TestRequestWriteRequestURINoHost(t *testing.T) {
 	}
 }
 
+func TestRequestWriteEmptyPathWithQuery(t *testing.T) {
+	t.Parallel()
+
+	var req Request
+	req.SetRequestURI("http://example.com?foo=bar")
+	var w bytes.Buffer
+	bw := bufio.NewWriter(&w)
+	if err := req.Write(bw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	firstLine := strings.Split(w.String(), "\r\n")[0]
+	if firstLine != "GET /?foo=bar HTTP/1.1" {
+		t.Fatalf("unexpected request line %q. Expecting %q", firstLine, "GET /?foo=bar HTTP/1.1")
+	}
+
+	req.Reset()
+	req.SetRequestURI("http://example.com?foo=bar")
+	req.URI().DisablePathNormalizing = true
+	w.Reset()
+	bw.Reset(&w)
+	if err := req.Write(bw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	firstLine = strings.Split(w.String(), "\r\n")[0]
+	if firstLine != "GET /?foo=bar HTTP/1.1" {
+		t.Fatalf("unexpected request line with DisablePathNormalizing %q. Expecting %q", firstLine, "GET /?foo=bar HTTP/1.1")
+	}
+}
+
 func TestSetRequestBodyStreamFixedSize(t *testing.T) {
 	t.Parallel()
 
@@ -3461,7 +3498,7 @@ func TestResponseBodyStream(t *testing.T) {
 			client := Client{StreamResponseBody: true, DisablePathNormalizing: true}
 			resp := AcquireResponse()
 			request := AcquireRequest()
-			request.SetRequestURI(server.URL + "?400BadRequest")
+			request.SetRequestURI(server.URL + "?foo=bar")
 			if err := client.Do(request, resp); err != nil {
 				t.Fatal(err)
 			}
@@ -3475,8 +3512,8 @@ func TestResponseBodyStream(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if string(content) != "400 Bad Request" {
-				t.Fatalf("unexpected body content, got: %#v, want: %#v", string(content), "400 Bad Request")
+			if string(content) != "hello world" {
+				t.Fatalf("unexpected body content, got: %#v, want: %#v", string(content), "hello world")
 			}
 		})
 	})

--- a/uri.go
+++ b/uri.go
@@ -754,7 +754,11 @@ func (u *URI) RequestURI() []byte {
 	var dst []byte
 	if u.DisablePathNormalizing {
 		dst = u.requestURI[:0]
-		dst = append(dst, u.PathOriginal()...)
+		path := u.PathOriginal()
+		if len(path) == 0 {
+			path = strSlash
+		}
+		dst = append(dst, path...)
 	} else {
 		dst = appendQuotedPath(u.requestURI[:0], u.Path())
 	}

--- a/uri_test.go
+++ b/uri_test.go
@@ -620,3 +620,21 @@ func TestFragmentInHost(t *testing.T) {
 		t.Fatalf("Unexpected host %q. Expected %q", got, "google.com")
 	}
 }
+
+func TestURIRequestURIEmptyPathWithQuery(t *testing.T) {
+	t.Parallel()
+
+	var u URI
+	if err := u.Parse(nil, []byte("http://example.com?foo=bar")); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := string(u.RequestURI()); got != "/?foo=bar" {
+		t.Fatalf("unexpected RequestURI %q. Expecting %q", got, "/?foo=bar")
+	}
+
+	u.DisablePathNormalizing = true
+	if got := string(u.RequestURI()); got != "/?foo=bar" {
+		t.Fatalf("unexpected RequestURI with DisablePathNormalizing %q. Expecting %q", got, "/?foo=bar")
+	}
+}


### PR DESCRIPTION
Fixes #1659

RFC 7230 5.3.1: if the path is empty, the client must send `/` as the origin-form path.

`http://example.com?foo=bar` was serialized as `GET ?foo=bar` when path normalizing was off, and `RequestHeader.SetRequestURI("?foo=bar")` did the same. `net/http` and many servers reject that request-target.

Empty `RequestURI` already became `/`. Do the same when it starts with `?`.