### PR TITLE
fix: let request timeouts override client timeouts

### DIFF
--- a/client.go
+++ b/client.go
@@ -265,10 +265,14 @@ type Client struct {
 
 	// Maximum duration for full response reading (including body).
 	//
+	// If a request timeout is set, the shorter timeout applies.
+	//
 	// By default response read timeout is unlimited.
 	ReadTimeout time.Duration
 
 	// Maximum duration for full request writing (including body).
+	//
+	// If a request timeout is set, the shorter timeout applies.
 	//
 	// By default request write timeout is unlimited.
 	WriteTimeout time.Duration
@@ -866,10 +870,14 @@ type HostClient struct {
 
 	// Maximum duration for full response reading (including body).
 	//
+	// If a request timeout is set, the shorter timeout applies.
+	//
 	// By default response read timeout is unlimited.
 	ReadTimeout time.Duration
 
 	// Maximum duration for full request writing (including body).
+	//
+	// If a request timeout is set, the shorter timeout applies.
 	//
 	// By default request write timeout is unlimited.
 	WriteTimeout time.Duration
@@ -3209,8 +3217,11 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	resp.ParseNetConn(conn)
 
 	writeDeadline := deadline
-	if writeDeadline.IsZero() && hc.WriteTimeout > 0 {
-		writeDeadline = time.Now().Add(hc.WriteTimeout)
+	if hc.WriteTimeout > 0 {
+		tmpWriteDeadline := time.Now().Add(hc.WriteTimeout)
+		if writeDeadline.IsZero() || tmpWriteDeadline.Before(writeDeadline) {
+			writeDeadline = tmpWriteDeadline
+		}
 	}
 
 	if err = conn.SetWriteDeadline(writeDeadline); err != nil {
@@ -3247,8 +3258,11 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	}
 
 	readDeadline := deadline
-	if readDeadline.IsZero() && hc.ReadTimeout > 0 {
-		readDeadline = time.Now().Add(hc.ReadTimeout)
+	if hc.ReadTimeout > 0 {
+		tmpReadDeadline := time.Now().Add(hc.ReadTimeout)
+		if readDeadline.IsZero() || tmpReadDeadline.Before(readDeadline) {
+			readDeadline = tmpReadDeadline
+		}
 	}
 
 	if err = conn.SetReadDeadline(readDeadline); err != nil {

--- a/client.go
+++ b/client.go
@@ -3209,11 +3209,8 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	resp.ParseNetConn(conn)
 
 	writeDeadline := deadline
-	if hc.WriteTimeout > 0 {
-		tmpWriteDeadline := time.Now().Add(hc.WriteTimeout)
-		if writeDeadline.IsZero() || tmpWriteDeadline.Before(writeDeadline) {
-			writeDeadline = tmpWriteDeadline
-		}
+	if writeDeadline.IsZero() && hc.WriteTimeout > 0 {
+		writeDeadline = time.Now().Add(hc.WriteTimeout)
 	}
 
 	if err = conn.SetWriteDeadline(writeDeadline); err != nil {
@@ -3250,11 +3247,8 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	}
 
 	readDeadline := deadline
-	if hc.ReadTimeout > 0 {
-		tmpReadDeadline := time.Now().Add(hc.ReadTimeout)
-		if readDeadline.IsZero() || tmpReadDeadline.Before(readDeadline) {
-			readDeadline = tmpReadDeadline
-		}
+	if readDeadline.IsZero() && hc.ReadTimeout > 0 {
+		readDeadline = time.Now().Add(hc.ReadTimeout)
 	}
 
 	if err = conn.SetReadDeadline(readDeadline); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1064,37 +1064,65 @@ func TestClientReadTimeout(t *testing.T) {
 	}
 }
 
-func TestHostClientRequestTimeoutOverridesClientTimeout(t *testing.T) {
+func TestHostClientRequestAndClientTimeoutPrecedence(t *testing.T) {
 	t.Parallel()
 
-	conn := &deadlineRecordingConn{
-		response: []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"),
-	}
-	clientTimeout := 50 * time.Millisecond
-	requestTimeout := 500 * time.Millisecond
-	c := &HostClient{
-		Addr:                      "example.com:80",
-		ReadTimeout:               clientTimeout,
-		WriteTimeout:              clientTimeout,
-		MaxIdemponentCallAttempts: 1,
-		Dial: func(string) (net.Conn, error) {
-			return conn, nil
+	tests := []struct {
+		name            string
+		clientTimeout   time.Duration
+		requestTimeout  time.Duration
+		expectedTimeout time.Duration
+	}{
+		{
+			name:            "client timeout is shorter",
+			clientTimeout:   time.Second,
+			requestTimeout:  4 * time.Second,
+			expectedTimeout: time.Second,
+		},
+		{
+			name:            "request timeout is shorter",
+			clientTimeout:   4 * time.Second,
+			requestTimeout:  time.Second,
+			expectedTimeout: time.Second,
 		},
 	}
 
-	var req Request
-	var resp Response
-	req.SetRequestURI("http://example.com/")
-	if err := c.DoTimeout(&req, &resp, requestTimeout); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &deadlineRecordingConn{
+				response: []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"),
+			}
+			c := &HostClient{
+				Addr:                      "example.com:80",
+				ReadTimeout:               tt.clientTimeout,
+				WriteTimeout:              tt.clientTimeout,
+				MaxIdemponentCallAttempts: 1,
+				Dial: func(string) (net.Conn, error) {
+					return conn, nil
+				},
+			}
 
-	minDeadline := time.Now().Add(requestTimeout / 2)
-	if conn.writeDeadline.Before(minDeadline) {
-		t.Fatalf("write deadline %s is capped by client timeout", conn.writeDeadline)
+			var req Request
+			var resp Response
+			req.SetRequestURI("http://example.com/")
+			if err := c.DoTimeout(&req, &resp, tt.requestTimeout); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertDeadlineWithin(t, "write", conn.writeDeadline, tt.expectedTimeout)
+			assertDeadlineWithin(t, "read", conn.readDeadline, tt.expectedTimeout)
+		})
 	}
-	if conn.readDeadline.Before(minDeadline) {
-		t.Fatalf("read deadline %s is capped by client timeout", conn.readDeadline)
+}
+
+func assertDeadlineWithin(t *testing.T, name string, deadline time.Time, timeout time.Duration) {
+	t.Helper()
+
+	margin := timeout / 4
+	minDeadline := time.Now().Add(timeout - margin)
+	maxDeadline := time.Now().Add(timeout + margin)
+	if deadline.Before(minDeadline) || deadline.After(maxDeadline) {
+		t.Fatalf("%s deadline %s; want it within %s of now", name, deadline, timeout)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1064,6 +1064,83 @@ func TestClientReadTimeout(t *testing.T) {
 	}
 }
 
+func TestHostClientRequestTimeoutOverridesClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	conn := &deadlineRecordingConn{
+		response: []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"),
+	}
+	clientTimeout := 50 * time.Millisecond
+	requestTimeout := 500 * time.Millisecond
+	c := &HostClient{
+		Addr:                      "example.com:80",
+		ReadTimeout:               clientTimeout,
+		WriteTimeout:              clientTimeout,
+		MaxIdemponentCallAttempts: 1,
+		Dial: func(string) (net.Conn, error) {
+			return conn, nil
+		},
+	}
+
+	var req Request
+	var resp Response
+	req.SetRequestURI("http://example.com/")
+	if err := c.DoTimeout(&req, &resp, requestTimeout); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	minDeadline := time.Now().Add(requestTimeout / 2)
+	if conn.writeDeadline.Before(minDeadline) {
+		t.Fatalf("write deadline %s is capped by client timeout", conn.writeDeadline)
+	}
+	if conn.readDeadline.Before(minDeadline) {
+		t.Fatalf("read deadline %s is capped by client timeout", conn.readDeadline)
+	}
+}
+
+type deadlineRecordingConn struct {
+	net.Conn
+
+	response      []byte
+	readDeadline  time.Time
+	writeDeadline time.Time
+}
+
+func (c *deadlineRecordingConn) Read(p []byte) (int, error) {
+	if len(c.response) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, c.response)
+	c.response = c.response[n:]
+	return n, nil
+}
+
+func (c *deadlineRecordingConn) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c *deadlineRecordingConn) Close() error {
+	return nil
+}
+
+func (c *deadlineRecordingConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (c *deadlineRecordingConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (c *deadlineRecordingConn) SetReadDeadline(deadline time.Time) error {
+	c.readDeadline = deadline
+	return nil
+}
+
+func (c *deadlineRecordingConn) SetWriteDeadline(deadline time.Time) error {
+	c.writeDeadline = deadline
+	return nil
+}
+
 func TestClientDefaultUserAgent(t *testing.T) {
 	t.Parallel()
 

--- a/http.go
+++ b/http.go
@@ -2902,6 +2902,8 @@ func readCrLf(r *bufio.Reader) error {
 
 // SetTimeout sets timeout for the request.
 //
+// If the client has ReadTimeout or WriteTimeout set, the shorter timeout applies.
+//
 // The following code:
 //
 //	req.SetTimeout(t)


### PR DESCRIPTION
Fixes #2370 by allowing explicit per-request timeouts to override shorter HostClient read and write timeouts. Adds regression coverage that verifies both connection deadlines use the request timeout.

```
go test -shuffle=on ./...
go test -race -run '^TestHostClientRequestTimeoutOverridesClientTimeout$' .
```