### PR TITLE
Always stream response bodies when requested

### DIFF
--- a/client.go
+++ b/client.go
@@ -288,6 +288,8 @@ type Client struct {
 	WriteBufferSize int
 
 	// Maximum duration for full response reading (including body).
+	// When response streaming is enabled, the deadline remains active while
+	// the caller reads Response.BodyStream.
 	//
 	// By default response read timeout is unlimited.
 	ReadTimeout time.Duration
@@ -309,8 +311,10 @@ type Client struct {
 	// sends a very large Content-Length or chunk size. Set a positive limit
 	// when requesting untrusted servers.
 	//
-	// If StreamResponseBody is true, MaxResponseBodySize is ignored. The caller
-	// must limit reads from BodyStream itself.
+	// If response streaming is enabled for Do methods through StreamResponseBody
+	// or Response.StreamBody, MaxResponseBodySize is ignored and the response
+	// body isn't fully buffered before Do returns. The caller must limit reads
+	// from BodyStream itself. Get and Post methods always enforce this limit.
 	MaxResponseBodySize int
 
 	// Maximum duration for waiting for a free connection.
@@ -364,7 +368,15 @@ type Client struct {
 	// extra slashes are removed, special characters are encoded.
 	DisablePathNormalizing bool
 
-	// StreamResponseBody enables response body streaming.
+	// StreamResponseBody enables response body streaming for Do methods.
+	// Response bodies aren't fully buffered before Do returns. The caller must
+	// read and close Response.BodyStream. Body read errors occur after Do returns
+	// and aren't handled by retry callbacks. ReadTimeout and request deadlines
+	// remain active while reading the stream.
+	//
+	// Get and Post methods still read the full response body before returning.
+	// If Do is called with a nil Response, the client drains only small,
+	// known-length bodies for connection reuse and closes other body streams.
 	StreamResponseBody bool
 }
 
@@ -895,6 +907,8 @@ type HostClient struct {
 	WriteBufferSize int
 
 	// Maximum duration for full response reading (including body).
+	// When response streaming is enabled, the deadline remains active while
+	// the caller reads Response.BodyStream.
 	//
 	// By default response read timeout is unlimited.
 	ReadTimeout time.Duration
@@ -916,8 +930,10 @@ type HostClient struct {
 	// sends a very large Content-Length or chunk size. Set a positive limit
 	// when requesting untrusted servers.
 	//
-	// If StreamResponseBody is true, MaxResponseBodySize is ignored. The caller
-	// must limit reads from BodyStream itself.
+	// If response streaming is enabled for Do methods through StreamResponseBody
+	// or Response.StreamBody, MaxResponseBodySize is ignored and the response
+	// body isn't fully buffered before Do returns. The caller must limit reads
+	// from BodyStream itself. Get and Post methods always enforce this limit.
 	MaxResponseBodySize int
 
 	// Maximum duration for waiting for a free connection.
@@ -996,7 +1012,15 @@ type HostClient struct {
 	// Client logs full errors by default.
 	SecureErrorLogMessage bool
 
-	// StreamResponseBody enables response body streaming.
+	// StreamResponseBody enables response body streaming for Do methods.
+	// Response bodies aren't fully buffered before Do returns. The caller must
+	// read and close Response.BodyStream. Body read errors occur after Do returns
+	// and aren't handled by retry callbacks. ReadTimeout and request deadlines
+	// remain active while reading the stream.
+	//
+	// Get and Post methods still read the full response body before returning.
+	// If Do is called with a nil Response, the client drains only small,
+	// known-length bodies for connection reuse and closes other body streams.
 	StreamResponseBody bool
 
 	connsCleanerRun bool
@@ -1212,17 +1236,46 @@ var (
 
 const defaultMaxRedirectsCount = 16
 
+// Only drain response streams that are known to be small. Reading an unknown
+// length stream can block forever (for example, on an event stream), while
+// closing a large stream avoids transferring a body the caller discarded.
+const maxResponseBodyDrainSize = 8 * 1024
+
+func closeOrDrainResponseBody(resp *Response, maxDrainSize int) error {
+	if !resp.IsBodyStream() {
+		return nil
+	}
+
+	contentLength := resp.Header.ContentLength()
+	if contentLength < 0 || contentLength > maxDrainSize {
+		return resp.CloseBodyStream()
+	}
+	return resp.BodyWriteTo(io.Discard)
+}
+
+func responseBodyDrainSize(maxBodySize int) int {
+	if maxBodySize > 0 && maxBodySize < maxResponseBodyDrainSize {
+		return maxBodySize
+	}
+	return maxResponseBodyDrainSize
+}
+
 func doRequestFollowRedirectsBuffer(req *Request, dst []byte, url string, c clientDoer) (statusCode int, body []byte, err error) {
 	resp := AcquireResponse()
 	bodyBuf := resp.bodyBuffer()
 	resp.keepBodyBuffer = true
+	resp.preserveBodyBuffer = true
 	oldBody := bodyBuf.B
 	bodyBuf.B = dst
+	forceResponseBodyBuffering := req.forceResponseBodyBuffering
+	req.forceResponseBodyBuffering = true
 
 	statusCode, _, err = doRequestFollowRedirects(req, resp, url, defaultMaxRedirectsCount, c)
+	req.forceResponseBodyBuffering = forceResponseBodyBuffering
 
 	body = bodyBuf.B
 	bodyBuf.B = oldBody
+	resp.preserveBodyBuffer = false
 	resp.keepBodyBuffer = false
 	ReleaseResponse(resp)
 
@@ -1232,6 +1285,11 @@ func doRequestFollowRedirectsBuffer(req *Request, dst []byte, url string, c clie
 func doRequestFollowRedirects(
 	req *Request, resp *Response, url string, maxRedirectsCount int, c clientDoer,
 ) (statusCode int, body []byte, err error) {
+	if resp == nil {
+		resp = AcquireResponse()
+		defer ReleaseResponse(resp)
+	}
+
 	redirectsCount := 0
 	initialHost := hostnameFromURLString(url)
 	// Writing the request consumes a body stream, so remember it here: by the
@@ -1302,6 +1360,10 @@ func doRequestFollowRedirects(
 			// user agent MAY change the request method from POST to GET for a
 			// 301 (Moved Permanently) or 302 (Found) response.
 			req.Header.SetMethod(MethodGet)
+		}
+
+		if err = closeOrDrainResponseBody(resp, maxResponseBodyDrainSize); err != nil {
+			break
 		}
 	}
 
@@ -1603,7 +1665,7 @@ func (c *HostClient) Do(req *Request, resp *Response) error {
 		switch {
 		case c.RetryIfErrUpstream != nil:
 			upstream := ""
-			if resp.RemoteAddr() != nil {
+			if resp != nil && resp.RemoteAddr() != nil {
 				upstream = resp.RemoteAddr().String()
 			}
 			resetTimeout, retry = c.RetryIfErrUpstream(req, attempts, err, upstream)
@@ -1647,6 +1709,15 @@ func (c *HostClient) do(req *Request, resp *Response) (bool, error) {
 	if resp == nil {
 		resp = AcquireResponse()
 		defer ReleaseResponse(resp)
+
+		retry, err := c.doNonNilReqResp(req, resp)
+		if err != nil {
+			return retry, err
+		}
+		if err = closeOrDrainResponseBody(resp, responseBodyDrainSize(c.MaxResponseBodySize)); err != nil {
+			return true, err
+		}
+		return retry, nil
 	}
 
 	return c.doNonNilReqResp(req, resp)
@@ -1679,7 +1750,7 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 
 	// backing up SkipBody in case it was set explicitly
 	customSkipBody := resp.SkipBody
-	customStreamBody := resp.StreamBody || c.StreamResponseBody
+	customStreamBody := !req.forceResponseBodyBuffering && (resp.StreamBody || c.StreamResponseBody)
 	resp.Reset()
 	resp.SkipBody = customSkipBody
 	resp.StreamBody = customStreamBody
@@ -2467,9 +2538,10 @@ func (q *wantConnQueue) clearFront() (cleaned bool) {
 // It is safe calling PipelineClient methods from concurrently running
 // goroutines.
 //
-// PipelineClient buffers complete response bodies without a size limit. Use
-// Client or HostClient with a positive MaxResponseBodySize when requesting
-// untrusted servers.
+// PipelineClient buffers complete response bodies without a size limit. If
+// Response.StreamBody is set, BodyStream reads from that buffered body; it
+// doesn't stream from the network. Use Client or HostClient with a positive
+// MaxResponseBodySize when requesting untrusted servers.
 type PipelineClient struct {
 	noCopy noCopy
 
@@ -2702,6 +2774,8 @@ func (c *pipelineConnClient) DoDeadline(req *Request, resp *Response, deadline t
 
 	w := c.acquirePipelineWork(timeout)
 	w.respCopy.Header.disableNormalizing = c.DisableHeaderNamesNormalizing
+	streamBody := resp != nil && resp.StreamBody
+	w.respCopy.StreamBody = streamBody
 	w.req = &w.reqCopy
 	w.resp = &w.respCopy
 
@@ -2730,6 +2804,7 @@ func (c *pipelineConnClient) DoDeadline(req *Request, resp *Response, deadline t
 		if resp != nil {
 			w.respCopy.copyToSkipBody(resp)
 			swapResponseBody(resp, &w.respCopy)
+			resp.StreamBody = streamBody
 		}
 		err = w.err
 		c.releasePipelineWork(w)
@@ -3199,10 +3274,20 @@ func (c *pipelineConnClient) reader(conn net.Conn, stopCh <-chan struct{}, chs *
 				return err
 			}
 		}
-		if err = w.resp.Read(br); err != nil {
+		// PipelineClient must consume each response body before reading the
+		// next response from the shared connection. Preserve StreamBody's
+		// reader API with a buffered stream instead of leaving bytes in br.
+		streamBody := w.resp.StreamBody
+		w.resp.StreamBody = false
+		err = w.resp.Read(br)
+		w.resp.StreamBody = streamBody
+		if err != nil {
 			w.err = err
 			w.done <- struct{}{}
 			return err
+		}
+		if streamBody && !w.resp.mustSkipBody() {
+			w.resp.bodyStream = bytes.NewReader(w.resp.bodyBytes())
 		}
 
 		w.done <- struct{}{}
@@ -3402,34 +3487,21 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 				hc.ReleaseConn(cc)
 			}
 		}
-		if rs, ok := resp.bodyStream.(*requestStream); ok {
-			// Network backed: a Read may still be in flight when the caller
-			// closes, so interrupt it and wait before pooling anything.
-			resp.bodyStream = &clientStreamBody{
-				reader: rs,
-				interrupt: func() {
-					_ = conn.Close()
-				},
-				release: func(discard bool) {
-					hc.ReleaseReader(br)
-					releaseRequestStream(rs)
-					releaseConn(discard)
-				},
-			}
-		} else {
-			// Fully buffered: the body already lives in resp.body and nothing
-			// reads the connection any more, so br can be released right away.
-			// The connection still waits for the caller to close the stream.
-			hc.ReleaseReader(br)
-			rbs := resp.bodyStream
-			var closed atomic.Bool
-			resp.bodyStream = newCloseReaderWithError(rbs, func(wErr error) error {
-				if !closed.CompareAndSwap(false, true) {
-					return nil
-				}
-				releaseConn(wErr != nil)
-				return nil
-			})
+		// ReadLimitBody always creates a network-backed requestStream when
+		// StreamBody is enabled. A Read may still be in flight when the caller
+		// closes, so interrupt it and wait before pooling anything.
+		rs := resp.bodyStream.(*requestStream) //nolint:forcetypeassert
+		resp.bodyStream = &clientStreamBody{
+			reader:    rs,
+			fullyRead: rs.contentLength == 0,
+			interrupt: func() {
+				_ = conn.Close()
+			},
+			release: func(discard bool) {
+				hc.ReleaseReader(br)
+				releaseRequestStream(rs)
+				releaseConn(discard)
+			},
 		}
 		return false, nil
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -320,7 +320,7 @@ func TestClientByteReturningHelpersWithStreamingEnabled(t *testing.T) {
 		if r.Method == http.MethodPost {
 			body, _ = io.ReadAll(r.Body)
 		}
-		w.Header().Set(HeaderContentLength, fmt.Sprintf("%d", len(body)))
+		w.Header().Set(HeaderContentLength, strconv.Itoa(len(body)))
 		_, _ = w.Write(body)
 	}))
 	t.Cleanup(server.Close)
@@ -1222,7 +1222,6 @@ func TestPipelineClientBuffersStreamBody(t *testing.T) {
 	if err := client.Do(&req1, &resp1); err != nil {
 		t.Fatalf("first request failed: %v", err)
 	}
-	defer resp1.CloseBodyStream()
 	if got := string(resp1.bodyBytes()); got != "FIRST" {
 		t.Fatalf("first response was not buffered: got %q", got)
 	}
@@ -1243,6 +1242,9 @@ func TestPipelineClientBuffersStreamBody(t *testing.T) {
 	}
 	if got := string(firstBody); got != "FIRST" {
 		t.Fatalf("unexpected first response body %q", got)
+	}
+	if err := resp1.CloseBodyStream(); err != nil {
+		t.Fatalf("close first buffered body stream: %v", err)
 	}
 	if err := <-serverDone; err != nil {
 		t.Fatalf("server failed: %v", err)

--- a/client_test.go
+++ b/client_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -228,11 +229,55 @@ func TestClientStreamCloseWaitsForRead(t *testing.T) {
 	}
 }
 
-func TestClientStreamCloseReusesBufferedResponseConnection(t *testing.T) {
+func TestClientStreamCloseReusesFullyReadResponseConnection(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, "hello world")
+	}))
+	t.Cleanup(server.Close)
+
+	var dialCount atomic.Int32
+	client := HostClient{
+		Addr: strings.TrimPrefix(server.URL, "http://"),
+		Dial: func(addr string) (net.Conn, error) {
+			dialCount.Add(1)
+			return net.Dial("tcp", addr)
+		},
+		StreamResponseBody: true,
+	}
+	t.Cleanup(client.CloseIdleConnections)
+
+	for range 2 {
+		var req Request
+		req.SetRequestURI(server.URL)
+		resp := AcquireResponse()
+		if err := client.Do(&req, resp); err != nil {
+			ReleaseResponse(resp)
+			t.Fatalf("unexpected request error: %v", err)
+		}
+		if _, err := io.Copy(io.Discard, resp.BodyStream()); err != nil {
+			ReleaseResponse(resp)
+			t.Fatalf("unexpected stream read error: %v", err)
+		}
+		if err := resp.CloseBodyStream(); err != nil {
+			ReleaseResponse(resp)
+			t.Fatalf("unexpected stream close error: %v", err)
+		}
+		ReleaseResponse(resp)
+	}
+
+	if got := dialCount.Load(); got != 1 {
+		t.Fatalf("fully read response connection was not reused: got %d dials", got)
+	}
+}
+
+func TestClientStreamCloseReusesZeroLengthResponseConnection(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(HeaderContentLength, "0")
+		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(server.Close)
 
@@ -263,7 +308,331 @@ func TestClientStreamCloseReusesBufferedResponseConnection(t *testing.T) {
 	}
 
 	if got := dialCount.Load(); got != 1 {
-		t.Fatalf("buffered response connection was not reused: got %d dials", got)
+		t.Fatalf("zero-length response connection was not reused: got %d dials", got)
+	}
+}
+
+func TestClientByteReturningHelpersWithStreamingEnabled(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := []byte("get response")
+		if r.Method == http.MethodPost {
+			body, _ = io.ReadAll(r.Body)
+		}
+		w.Header().Set(HeaderContentLength, fmt.Sprintf("%d", len(body)))
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{StreamResponseBody: true}
+	hostClient := &HostClient{
+		Addr:               strings.TrimPrefix(server.URL, "http://"),
+		StreamResponseBody: true,
+	}
+	t.Cleanup(client.CloseIdleConnections)
+	t.Cleanup(hostClient.CloseIdleConnections)
+
+	clients := []struct {
+		name   string
+		client interface {
+			Get([]byte, string) (int, []byte, error)
+			Post([]byte, string, *Args) (int, []byte, error)
+		}
+	}{
+		{name: "Client", client: client},
+		{name: "HostClient", client: hostClient},
+	}
+
+	for _, tc := range clients {
+		t.Run(tc.name, func(t *testing.T) {
+			statusCode, body, err := tc.client.Get(nil, server.URL)
+			if err != nil {
+				t.Fatalf("unexpected GET error: %v", err)
+			}
+			if statusCode != StatusOK {
+				t.Fatalf("unexpected GET status code %d", statusCode)
+			}
+			if string(body) != "get response" {
+				t.Fatalf("unexpected GET body %q", body)
+			}
+
+			var args Args
+			args.Set("foo", "bar")
+			statusCode, body, err = tc.client.Post(body[:0], server.URL, &args)
+			if err != nil {
+				t.Fatalf("unexpected POST error: %v", err)
+			}
+			if statusCode != StatusOK {
+				t.Fatalf("unexpected POST status code %d", statusCode)
+			}
+			if string(body) != args.String() {
+				t.Fatalf("unexpected POST body %q", body)
+			}
+		})
+	}
+}
+
+func TestClientByteReturningHelpersHonorMaxResponseBodySizeWithStreamingEnabled(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "response exceeds limit")
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{
+		StreamResponseBody:  true,
+		MaxResponseBodySize: 8,
+	}
+	hostClient := &HostClient{
+		Addr:                strings.TrimPrefix(server.URL, "http://"),
+		StreamResponseBody:  true,
+		MaxResponseBodySize: 8,
+	}
+	t.Cleanup(client.CloseIdleConnections)
+	t.Cleanup(hostClient.CloseIdleConnections)
+
+	clients := []struct {
+		name   string
+		client interface {
+			Get([]byte, string) (int, []byte, error)
+			Post([]byte, string, *Args) (int, []byte, error)
+		}
+	}{
+		{name: "Client", client: client},
+		{name: "HostClient", client: hostClient},
+	}
+
+	for _, tc := range clients {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := tc.client.Get(nil, server.URL); !errors.Is(err, ErrBodyTooLarge) {
+				t.Fatalf("unexpected GET error %v; want %v", err, ErrBodyTooLarge)
+			}
+			if _, _, err := tc.client.Post(nil, server.URL, nil); !errors.Is(err, ErrBodyTooLarge) {
+				t.Fatalf("unexpected POST error %v; want %v", err, ErrBodyTooLarge)
+			}
+		})
+	}
+}
+
+func TestClientByteReturningHelperPreservesBodyWithPoolLimit(t *testing.T) {
+	oldRequestLimit := atomic.LoadInt64(&requestBodyPoolSizeLimit)
+	oldResponseLimit := atomic.LoadInt64(&responseBodyPoolSizeLimit)
+	SetBodySizePoolLimit(int(oldRequestLimit), 1)
+	t.Cleanup(func() {
+		SetBodySizePoolLimit(int(oldRequestLimit), int(oldResponseLimit))
+	})
+
+	client := Client{
+		Transport: &TransportMock{wrapperFunc: func(_ *HostClient, _ *Request, resp *Response) (bool, error) {
+			resp.Header.SetStatusCode(StatusOK)
+			resp.SetBodyString("fresh response")
+			return false, nil
+		}},
+	}
+	tests := []struct {
+		name string
+		do   func([]byte) (int, []byte, error)
+	}{
+		{name: "GET", do: func(dst []byte) (int, []byte, error) {
+			return client.Get(dst, "http://example.com/")
+		}},
+		{name: "POST", do: func(dst []byte) (int, []byte, error) {
+			return client.Post(dst, "http://example.com/", nil)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := make([]byte, len("stale response"), 64)
+			copy(dst, "stale response")
+
+			statusCode, body, err := tc.do(dst)
+			if err != nil {
+				t.Fatalf("unexpected request error: %v", err)
+			}
+			if statusCode != StatusOK {
+				t.Fatalf("unexpected status code %d", statusCode)
+			}
+			if string(body) != "fresh response" {
+				t.Fatalf("unexpected response body %q", body)
+			}
+		})
+	}
+}
+
+func TestClientByteReturningHelperRetriesBodyReadError(t *testing.T) {
+	t.Parallel()
+
+	var dialCount atomic.Int32
+	serverDone := make(chan error, 2)
+	client := HostClient{
+		Addr:                      "example.com:80",
+		StreamResponseBody:        true,
+		MaxIdemponentCallAttempts: 2,
+		RetryIfErr: func(_ *Request, attempts int, err error) (bool, bool) {
+			if attempts != 1 {
+				t.Errorf("unexpected retry attempt %d", attempts)
+			}
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Errorf("unexpected retry error %v; want %v", err, io.ErrUnexpectedEOF)
+			}
+			return false, true
+		},
+		Dial: func(string) (net.Conn, error) {
+			attempt := dialCount.Add(1)
+			if attempt > 2 {
+				return nil, fmt.Errorf("unexpected dial attempt %d", attempt)
+			}
+			clientConn, serverConn := net.Pipe()
+			go func() {
+				defer serverConn.Close()
+				reader := bufio.NewReader(serverConn)
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						serverDone <- err
+						return
+					}
+					if line == "\r\n" {
+						break
+					}
+				}
+				body := "short"
+				if attempt == 2 {
+					body = "hello world"
+				}
+				_, err := io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\n"+body)
+				serverDone <- err
+			}()
+			return clientConn, nil
+		},
+	}
+	t.Cleanup(client.CloseIdleConnections)
+
+	statusCode, body, err := client.Get(nil, "http://example.com/")
+	if err != nil {
+		t.Fatalf("unexpected GET error: %v", err)
+	}
+	if statusCode != StatusOK {
+		t.Fatalf("unexpected GET status code %d", statusCode)
+	}
+	if string(body) != "hello world" {
+		t.Fatalf("unexpected GET body %q", body)
+	}
+	if got := dialCount.Load(); got != 2 {
+		t.Fatalf("unexpected dial count %d; want 2", got)
+	}
+	for range 2 {
+		if err := <-serverDone; err != nil {
+			t.Fatalf("unexpected server error: %v", err)
+		}
+	}
+}
+
+func TestClientStreamingDoesNotPreReadFixedLengthBody(t *testing.T) {
+	tests := []struct {
+		name               string
+		streamResponseBody bool
+	}{
+		{name: "client option", streamResponseBody: true},
+		{name: "response option"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientConn, serverConn := net.Pipe()
+			allowBody := make(chan struct{})
+			var allowBodyOnce sync.Once
+			releaseBody := func() {
+				allowBodyOnce.Do(func() {
+					close(allowBody)
+				})
+			}
+			serverDone := make(chan error, 1)
+			go func() {
+				defer serverConn.Close()
+				reader := bufio.NewReader(serverConn)
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						serverDone <- err
+						return
+					}
+					if line == "\r\n" {
+						break
+					}
+				}
+				if _, err := io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\n"); err != nil {
+					serverDone <- err
+					return
+				}
+				<-allowBody
+				_, err := io.WriteString(serverConn, "hello world")
+				serverDone <- err
+			}()
+			t.Cleanup(func() {
+				releaseBody()
+				_ = clientConn.Close()
+				_ = serverConn.Close()
+			})
+
+			client := HostClient{
+				Addr:               "example.com:80",
+				Dial:               func(string) (net.Conn, error) { return clientConn, nil },
+				StreamResponseBody: tc.streamResponseBody,
+			}
+			t.Cleanup(client.CloseIdleConnections)
+
+			var req Request
+			req.SetRequestURI("http://example.com/")
+			var resp Response
+			resp.StreamBody = !tc.streamResponseBody
+
+			doDone := make(chan error, 1)
+			go func() {
+				doDone <- client.Do(&req, &resp)
+			}()
+
+			select {
+			case err := <-doDone:
+				if err != nil {
+					t.Fatalf("unexpected request error: %v", err)
+				}
+			case <-time.After(time.Second):
+				releaseBody()
+				select {
+				case <-doDone:
+				case <-time.After(time.Second):
+					_ = clientConn.Close()
+					select {
+					case <-doDone:
+					case <-time.After(time.Second):
+						t.Fatal("client did not stop after its connection was closed")
+					}
+				}
+				_ = resp.CloseBodyStream()
+				t.Fatal("client waited for the fixed-length response body")
+			}
+
+			if _, ok := resp.BodyStream().(*clientStreamBody); !ok {
+				t.Fatalf("unexpected body stream type %T", resp.BodyStream())
+			}
+			releaseBody()
+			body, err := io.ReadAll(resp.BodyStream())
+			if err != nil {
+				t.Fatalf("unexpected body stream error: %v", err)
+			}
+			if string(body) != "hello world" {
+				t.Fatalf("unexpected body %q", body)
+			}
+			if err := resp.CloseBodyStream(); err != nil {
+				t.Fatalf("unexpected close error: %v", err)
+			}
+			if err := <-serverDone; err != nil {
+				t.Fatalf("unexpected server error: %v", err)
+			}
+		})
 	}
 }
 
@@ -271,13 +640,11 @@ func TestClientStreamCloseHonorsLateSetConnectionClose(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name string
-		// A body larger than maxResponseBodySize is served through a
-		// *requestStream; leaving it at zero buffers the body instead.
+		name                string
 		maxResponseBodySize int
 	}{
-		{name: "requestStream", maxResponseBodySize: 1},
-		{name: "buffered", maxResponseBodySize: 0},
+		{name: "zero limit", maxResponseBodySize: 0},
+		{name: "positive limit", maxResponseBodySize: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -307,6 +674,10 @@ func TestClientStreamCloseHonorsLateSetConnectionClose(t *testing.T) {
 				if err := client.Do(&req, resp); err != nil {
 					ReleaseResponse(resp)
 					t.Fatalf("unexpected request error: %v", err)
+				}
+				if _, ok := resp.BodyStream().(*clientStreamBody); !ok {
+					ReleaseResponse(resp)
+					t.Fatalf("unexpected body stream type %T", resp.BodyStream())
 				}
 				if _, err := io.ReadAll(resp.BodyStream()); err != nil {
 					ReleaseResponse(resp)
@@ -805,6 +1176,154 @@ func TestPipelineClientSkipsEarlyHints(t *testing.T) {
 	}
 }
 
+func TestPipelineClientBuffersStreamBody(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+
+	serverDone := make(chan error, 1)
+	go func() {
+		defer serverConn.Close()
+		br := bufio.NewReader(serverConn)
+		for _, body := range []string{"FIRST", "SECOND"} {
+			var req Request
+			if err := req.Read(br); err != nil {
+				serverDone <- err
+				return
+			}
+			if _, err := fmt.Fprintf(serverConn, "HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s", len(body), body); err != nil {
+				serverDone <- err
+				return
+			}
+		}
+		serverDone <- nil
+	}()
+
+	var dialed atomic.Bool
+	client := PipelineClient{
+		Dial: func(string) (net.Conn, error) {
+			if !dialed.CompareAndSwap(false, true) {
+				return nil, errors.New("unexpected second dial")
+			}
+			return clientConn, nil
+		},
+		MaxIdleConnDuration: time.Second,
+		Logger:              &testLogger{},
+	}
+
+	var req1 Request
+	req1.SetRequestURI("http://example.test/first")
+	var resp1 Response
+	resp1.StreamBody = true
+	if err := client.Do(&req1, &resp1); err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	defer resp1.CloseBodyStream()
+	if got := string(resp1.bodyBytes()); got != "FIRST" {
+		t.Fatalf("first response was not buffered: got %q", got)
+	}
+
+	var req2 Request
+	req2.SetRequestURI("http://example.test/second")
+	var resp2 Response
+	if err := client.Do(&req2, &resp2); err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+	if got := string(resp2.Body()); got != "SECOND" {
+		t.Fatalf("unexpected second response body %q", got)
+	}
+
+	firstBody, err := io.ReadAll(resp1.BodyStream())
+	if err != nil {
+		t.Fatalf("read first buffered body stream: %v", err)
+	}
+	if got := string(firstBody); got != "FIRST" {
+		t.Fatalf("unexpected first response body %q", got)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatalf("server failed: %v", err)
+	}
+}
+
+func TestPipelineClientDeadlineMethodsPreserveStreamBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		do   func(*PipelineClient, *Request, *Response) error
+	}{
+		{
+			name: "DoTimeout",
+			do: func(c *PipelineClient, req *Request, resp *Response) error {
+				return c.DoTimeout(req, resp, time.Second)
+			},
+		},
+		{
+			name: "DoDeadline",
+			do: func(c *PipelineClient, req *Request, resp *Response) error {
+				return c.DoDeadline(req, resp, time.Now().Add(time.Second))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientConn, serverConn := net.Pipe()
+			t.Cleanup(func() {
+				_ = clientConn.Close()
+				_ = serverConn.Close()
+			})
+
+			serverDone := make(chan error, 1)
+			go func() {
+				defer serverConn.Close()
+				var req Request
+				if err := req.Read(bufio.NewReader(serverConn)); err != nil {
+					serverDone <- err
+					return
+				}
+				_, err := io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nBODY")
+				serverDone <- err
+			}()
+
+			client := PipelineClient{
+				Addr:                "example.com:80",
+				Dial:                func(string) (net.Conn, error) { return clientConn, nil },
+				MaxIdleConnDuration: time.Second,
+				Logger:              &testLogger{},
+			}
+			var req Request
+			req.SetRequestURI("http://example.com/")
+			var resp Response
+			resp.StreamBody = true
+
+			if err := tc.do(&client, &req, &resp); err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			if !resp.StreamBody || !resp.IsBodyStream() {
+				t.Fatalf("stream body setting was lost: enabled=%v, stream=%T", resp.StreamBody, resp.BodyStream())
+			}
+			body, err := io.ReadAll(resp.BodyStream())
+			if err != nil {
+				t.Fatalf("read buffered body stream: %v", err)
+			}
+			if string(body) != "BODY" {
+				t.Fatalf("unexpected response body %q", body)
+			}
+			if err := resp.CloseBodyStream(); err != nil {
+				t.Fatalf("close body stream: %v", err)
+			}
+			if err := <-serverDone; err != nil {
+				t.Fatalf("server failed: %v", err)
+			}
+		})
+	}
+}
+
 func TestPipelineClientTLSMalformedAddrFailsBeforeDial(t *testing.T) {
 	t.Parallel()
 
@@ -1044,6 +1563,118 @@ func TestClientNilResp(t *testing.T) {
 		t.Fatal(err)
 	}
 	ln.Close()
+}
+
+func TestClientNilRespWithStreamingEnabledReusesConnection(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "hello world")
+	}))
+	t.Cleanup(server.Close)
+
+	var dialCount atomic.Int32
+	client := HostClient{
+		Addr: strings.TrimPrefix(server.URL, "http://"),
+		Dial: func(addr string) (net.Conn, error) {
+			dialCount.Add(1)
+			return net.Dial("tcp", addr)
+		},
+		StreamResponseBody: true,
+	}
+	t.Cleanup(client.CloseIdleConnections)
+
+	for range 2 {
+		var req Request
+		req.SetRequestURI(server.URL)
+		if err := client.Do(&req, nil); err != nil {
+			t.Fatalf("unexpected request error: %v", err)
+		}
+	}
+
+	if got := dialCount.Load(); got != 1 {
+		t.Fatalf("ignored response body prevented connection reuse: got %d dials", got)
+	}
+}
+
+func TestClientNilRespWithStreamingEnabledDoesNotDrainDiscardedBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		responseHeader      string
+		maxResponseBodySize int
+	}{
+		{
+			name:           "unknown length",
+			responseHeader: "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+		},
+		{
+			name:                "over configured limit",
+			responseHeader:      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n",
+			maxResponseBodySize: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientConn, serverConn := net.Pipe()
+			t.Cleanup(func() {
+				_ = clientConn.Close()
+				_ = serverConn.Close()
+			})
+
+			serverDone := make(chan error, 1)
+			go func() {
+				defer serverConn.Close()
+				var req Request
+				if err := req.Read(bufio.NewReader(serverConn)); err != nil {
+					serverDone <- err
+					return
+				}
+				if _, err := io.WriteString(serverConn, tc.responseHeader); err != nil {
+					serverDone <- err
+					return
+				}
+
+				var b [1]byte
+				if _, err := serverConn.Read(b[:]); err == nil {
+					serverDone <- errors.New("client kept the discarded response stream open")
+					return
+				}
+				serverDone <- nil
+			}()
+
+			client := HostClient{
+				Addr:                "example.com:80",
+				Dial:                func(string) (net.Conn, error) { return clientConn, nil },
+				StreamResponseBody:  true,
+				MaxResponseBodySize: tc.maxResponseBodySize,
+			}
+			t.Cleanup(client.CloseIdleConnections)
+
+			var req Request
+			req.SetRequestURI("http://example.com/")
+			doDone := make(chan error, 1)
+			go func() {
+				doDone <- client.Do(&req, nil)
+			}()
+
+			select {
+			case err := <-doDone:
+				if err != nil {
+					t.Fatalf("unexpected request error: %v", err)
+				}
+			case <-time.After(time.Second):
+				_ = clientConn.Close()
+				t.Fatal("client tried to drain a discarded response")
+			}
+
+			if err := <-serverDone; err != nil {
+				t.Fatalf("server failed: %v", err)
+			}
+		})
+	}
 }
 
 func TestClientNegativeTimeout(t *testing.T) {
@@ -2423,6 +3054,94 @@ func TestClientFollowRedirects(t *testing.T) {
 
 	ReleaseRequest(req)
 	ReleaseResponse(resp)
+}
+
+func TestClientStreamingRedirectsReuseConnection(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body string
+		switch r.URL.Path {
+		case "/first":
+			body = "first redirect"
+			w.Header().Set(HeaderLocation, "/second")
+			w.Header().Set(HeaderContentLength, strconv.Itoa(len(body)))
+			w.WriteHeader(StatusFound)
+		case "/second":
+			body = "second redirect"
+			w.Header().Set(HeaderLocation, "/final")
+			w.Header().Set(HeaderContentLength, strconv.Itoa(len(body)))
+			w.WriteHeader(StatusFound)
+		case "/final":
+			body = "final response"
+			w.Header().Set(HeaderContentLength, strconv.Itoa(len(body)))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(StatusNotFound)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	var dialCount atomic.Int32
+	client := HostClient{
+		Addr: strings.TrimPrefix(server.URL, "http://"),
+		Dial: func(addr string) (net.Conn, error) {
+			dialCount.Add(1)
+			return net.Dial("tcp", addr)
+		},
+		StreamResponseBody: true,
+	}
+	t.Cleanup(client.CloseIdleConnections)
+
+	var req Request
+	req.SetRequestURI(server.URL + "/first")
+	var resp Response
+	if err := client.DoRedirects(&req, &resp, 2); err != nil {
+		t.Fatalf("follow redirects: %v", err)
+	}
+	body, err := io.ReadAll(resp.BodyStream())
+	if err != nil {
+		t.Fatalf("read final response: %v", err)
+	}
+	if string(body) != "final response" {
+		t.Fatalf("unexpected final response %q", body)
+	}
+	if err := resp.CloseBodyStream(); err != nil {
+		t.Fatalf("close final response: %v", err)
+	}
+	if got := dialCount.Load(); got != 1 {
+		t.Fatalf("redirect responses prevented connection reuse: got %d dials", got)
+	}
+}
+
+func TestClientDoRedirectsAllowsNilResponse(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	client := HostClient{
+		Addr: "example.com:80",
+		Transport: &TransportMock{wrapperFunc: func(_ *HostClient, _ *Request, resp *Response) (bool, error) {
+			requests++
+			if requests == 1 {
+				resp.Header.SetStatusCode(StatusFound)
+				resp.Header.Set(HeaderLocation, "/final")
+			} else {
+				resp.Header.SetStatusCode(StatusOK)
+			}
+			return false, nil
+		}},
+	}
+
+	var req Request
+	req.SetRequestURI("http://example.com/start")
+	if err := client.DoRedirects(&req, nil, 1); err != nil {
+		t.Fatalf("follow redirects with nil response: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("unexpected request count %d; want 2", requests)
+	}
 }
 
 func TestClientRedirectMethodSwitch(t *testing.T) {
@@ -4840,6 +5559,33 @@ func TestClientRetryIfErrUpstream(t *testing.T) {
 		err := c.Do(req, res)
 		if !errors.Is(err, upstreamErr) {
 			t.Fatal(err)
+		}
+		if !retryIfErrCalled {
+			t.Fatal("RetryIfErrUpstream should be called")
+		}
+	})
+
+	t.Run("nil response", func(t *testing.T) {
+		retryIfErrCalled := false
+		c := &Client{
+			Transport: &TransportMock{
+				wrapperFunc: func(_ *HostClient, _ *Request, _ *Response) (bool, error) {
+					return true, upstreamErr
+				},
+			},
+			RetryIfErrUpstream: func(_ *Request, _ int, _ error, upstream string) (bool, bool) {
+				retryIfErrCalled = true
+				if upstream != "" {
+					t.Errorf("expected upstream to be empty, got %s", upstream)
+				}
+				return false, false
+			},
+		}
+		var req Request
+		req.SetRequestURI("http://example.com")
+
+		if err := c.Do(&req, nil); !errors.Is(err, upstreamErr) {
+			t.Fatalf("unexpected error: %v", err)
 		}
 		if !retryIfErrCalled {
 			t.Fatal("RetryIfErrUpstream should be called")

--- a/http.go
+++ b/http.go
@@ -71,6 +71,11 @@ type Request struct {
 
 	keepBodyBuffer bool
 
+	// Used by byte-returning client helpers so body limits and retries remain
+	// inside the normal buffered request path. This is deliberately not copied
+	// by Request.CopyTo; it is scoped to the helper's synchronous Do call.
+	forceResponseBodyBuffering bool
+
 	// Used by Server to indicate the request was received on a HTTPS endpoint.
 	// Client/HostClient shouldn't use this field but should depend on the uri.scheme instead.
 	isTLS bool
@@ -114,8 +119,11 @@ type Response struct {
 	// Relevant for bodyStream only.
 	ImmediateHeaderFlush bool
 
-	// StreamBody enables response body streaming.
-	// Use SetBodyStream to set the body stream.
+	// StreamBody enables response body streaming while reading a response.
+	// Body read errors are returned by BodyStream reads or BodyWriteTo after
+	// Read or a client Do method has returned. Errors that occur after a client
+	// Do method returns aren't handled by that client's retry callbacks.
+	// Use SetBodyStream to set the body stream when writing a response.
 	StreamBody bool
 
 	// Response.Read() skips reading body if set to true.
@@ -126,6 +134,7 @@ type Response struct {
 	SkipBody bool
 
 	keepBodyBuffer        bool
+	preserveBodyBuffer    bool
 	secureErrorLogMessage bool
 }
 
@@ -441,6 +450,8 @@ func (resp *Response) LocalAddr() net.Addr {
 //
 // If the body is backed by a stream, Body reads the entire stream into memory.
 // Use BodyStream to read it incrementally.
+// If reading the stream fails, Body returns the error message as the body.
+// Use BodyStream or BodyWriteTo when the read error must be handled separately.
 func (resp *Response) Body() []byte {
 	if resp.bodyStream != nil {
 		bodyBuf := resp.bodyBuffer()
@@ -1010,6 +1021,7 @@ func (req *Request) copyToSkipBody(dst *Request) {
 }
 
 // CopyTo copies resp contents to dst except of body stream.
+// If the body is streamed, call Body before CopyTo to read and copy it.
 func (resp *Response) CopyTo(dst *Response) {
 	resp.copyToSkipBody(dst)
 	switch {
@@ -1281,6 +1293,7 @@ func (req *Request) Reset() {
 	req.Header.Reset()
 	req.resetSkipHeader()
 	req.timeout = 0
+	req.forceResponseBodyBuffering = false
 	req.UseHostHeader = false
 	req.DisableRedirectPathNormalizing = false
 }
@@ -1309,8 +1322,10 @@ func (req *Request) RemoveMultipartFormFiles() {
 
 // Reset clears response contents.
 func (resp *Response) Reset() {
-	if bodyPoolSizeLimit := int(atomic.LoadInt64(&responseBodyPoolSizeLimit)); bodyPoolSizeLimit >= 0 && resp.body != nil {
-		resp.ReleaseBody(bodyPoolSizeLimit)
+	if !resp.preserveBodyBuffer {
+		if bodyPoolSizeLimit := int(atomic.LoadInt64(&responseBodyPoolSizeLimit)); bodyPoolSizeLimit >= 0 && resp.body != nil {
+			resp.ReleaseBody(bodyPoolSizeLimit)
+		}
 	}
 	resp.resetSkipHeader()
 	resp.Header.Reset()
@@ -1586,6 +1601,8 @@ func (req *Request) ContinueReadBodyStream(r *bufio.Reader, maxBodySize int, pre
 //
 // Read does not limit the response body size. Use ReadLimitBody with a positive
 // maxBodySize when reading responses from untrusted sources.
+// If StreamBody is true, the caller must not read from or reuse r until
+// BodyStream is fully read or CloseBodyStream is called.
 //
 // io.EOF is returned if r is closed before reading the first header byte.
 func (resp *Response) Read(r *bufio.Reader) error {
@@ -1610,6 +1627,10 @@ var errTooManyInterimResponses = errors.New("fasthttp: too many 1xx informationa
 // then ErrBodyTooLarge is returned.
 // If maxBodySize <= 0, no limit is applied and the response may consume
 // unbounded memory.
+// If StreamBody is true, maxBodySize is ignored and the response body is
+// exposed through BodyStream without being fully buffered.
+// The caller must not read from or reuse r until BodyStream is fully read or
+// CloseBodyStream is called.
 //
 // io.EOF is returned if r is closed before reading the first header byte.
 func (resp *Response) ReadLimitBody(r *bufio.Reader, maxBodySize int) error {
@@ -1657,34 +1678,29 @@ func (resp *Response) ReadLimitBody(r *bufio.Reader, maxBodySize int) error {
 //
 // If maxBodySize > 0 and the body size exceeds maxBodySize,
 // then ErrBodyTooLarge is returned.
+//
+// If StreamBody is true, maxBodySize is ignored and the response body is
+// exposed through BodyStream without being fully buffered.
+// The caller must not read from or reuse r until BodyStream is fully read or
+// CloseBodyStream is called.
 func (resp *Response) ReadBody(r *bufio.Reader, maxBodySize int) (err error) {
 	bodyBuf := resp.bodyBuffer()
 	bodyBuf.Reset()
 
 	contentLength := resp.Header.ContentLength()
+	if resp.StreamBody {
+		resp.bodyStream = acquireResponseStream(bodyBuf, r, &resp.Header)
+		return nil
+	}
+
 	switch {
 	case contentLength >= 0:
 		bodyBuf.B, err = readBody(r, contentLength, maxBodySize, bodyBuf.B)
-		if err == ErrBodyTooLarge && resp.StreamBody {
-			resp.bodyStream = acquireRequestStream(bodyBuf, r, &resp.Header)
-			err = nil
-		}
 	case contentLength == -1:
-		if resp.StreamBody {
-			resp.bodyStream = acquireRequestStream(bodyBuf, r, &resp.Header)
-		} else {
-			bodyBuf.B, err = readBodyChunked(r, maxBodySize, bodyBuf.B)
-		}
+		bodyBuf.B, err = readBodyChunked(r, maxBodySize, bodyBuf.B)
 	default:
-		if resp.StreamBody {
-			resp.bodyStream = acquireRequestStream(bodyBuf, r, &resp.Header)
-		} else {
-			bodyBuf.B, err = readBodyIdentity(r, maxBodySize, bodyBuf.B)
-			resp.Header.SetContentLength(len(bodyBuf.B))
-		}
-	}
-	if err == nil && resp.StreamBody && resp.bodyStream == nil {
-		resp.bodyStream = bytes.NewReader(bodyBuf.B)
+		bodyBuf.B, err = readBodyIdentity(r, maxBodySize, bodyBuf.B)
+		resp.Header.SetContentLength(len(bodyBuf.B))
 	}
 	return err
 }

--- a/http_test.go
+++ b/http_test.go
@@ -3323,25 +3323,81 @@ func TestResponseBodyStream(t *testing.T) {
 			t.Fatalf("unexpected body content, got: %#v, want: %#v", string(body), "1234561234567")
 		}
 	})
-	t.Run("read simple response", func(t *testing.T) {
+	t.Run("read fixed-length response", func(t *testing.T) {
+		for _, maxBodySize := range []int{0, 8, 20} {
+			t.Run(fmt.Sprintf("maxBodySize=%d", maxBodySize), func(t *testing.T) {
+				resp := AcquireResponse()
+				defer ReleaseResponse(resp)
+				resp.StreamBody = true
+				if err := resp.ReadLimitBody(bufio.NewReader(bytes.NewBufferString(simpleResp)), maxBodySize); err != nil {
+					t.Fatalf("read limit body err: %v", err)
+				}
+				if _, ok := resp.BodyStream().(*requestStream); !ok {
+					t.Fatalf("unexpected body stream type %T", resp.BodyStream())
+				}
+				if body := resp.bodyBytes(); len(body) != 0 {
+					t.Fatalf("response body was buffered: %q", body)
+				}
+				content, err := io.ReadAll(resp.BodyStream())
+				if err != nil {
+					t.Fatalf("read body stream err: %v", err)
+				}
+				if string(content) != "123456789" {
+					t.Fatalf("unexpected body content, got: %#v, want: %#v", string(content), "123456789")
+				}
+				if err := resp.CloseBodyStream(); err != nil {
+					t.Fatalf("close body stream err: %v", err)
+				}
+			})
+		}
+	})
+	t.Run("truncated fixed-length response", func(t *testing.T) {
 		resp := AcquireResponse()
+		defer ReleaseResponse(resp)
 		resp.StreamBody = true
-		err := resp.ReadLimitBody(bufio.NewReader(bytes.NewBufferString(simpleResp)), 8)
-		if err != nil {
-			t.Fatalf("read limit body err: %v", err)
+		response := "HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\n1234"
+		if err := resp.Read(bufio.NewReader(bytes.NewBufferString(response))); err != nil {
+			t.Fatalf("read response headers err: %v", err)
 		}
-		body := resp.BodyStream()
-		defer func() {
-			if err := resp.CloseBodyStream(); err != nil {
-				t.Fatalf("close body stream err: %v", err)
-			}
-		}()
-		content, err := io.ReadAll(body)
-		if err != nil {
-			t.Fatalf("read limit body err: %v", err)
+		if _, err := io.ReadAll(resp.BodyStream()); err != io.ErrUnexpectedEOF {
+			t.Fatalf("unexpected body stream error: %v; want %v", err, io.ErrUnexpectedEOF)
 		}
-		if string(content) != "123456789" {
-			t.Fatalf("unexpected body content, got: %#v, want: %#v", string(content), "123456789")
+	})
+	t.Run("fixed-length stream keeps original framing", func(t *testing.T) {
+		resp := AcquireResponse()
+		defer ReleaseResponse(resp)
+		resp.StreamBody = true
+		if err := resp.Read(bufio.NewReader(bytes.NewBufferString(simpleResp))); err != nil {
+			t.Fatalf("read response headers err: %v", err)
+		}
+		resp.Header.SetContentLength(1)
+		body, err := io.ReadAll(resp.BodyStream())
+		if err != nil {
+			t.Fatalf("read body stream err: %v", err)
+		}
+		if string(body) != "123456789" {
+			t.Fatalf("unexpected body content, got: %#v, want: %#v", string(body), "123456789")
+		}
+	})
+	t.Run("copy streamed response after reading body", func(t *testing.T) {
+		var resp Response
+		resp.StreamBody = true
+		if err := resp.Read(bufio.NewReader(bytes.NewBufferString(simpleResp))); err != nil {
+			t.Fatalf("read response headers err: %v", err)
+		}
+
+		var dst Response
+		resp.CopyTo(&dst)
+		if body := dst.Body(); len(body) != 0 {
+			t.Fatalf("CopyTo copied an unread body stream: %q", body)
+		}
+
+		if body := resp.Body(); string(body) != "123456789" {
+			t.Fatalf("unexpected drained body %q", body)
+		}
+		resp.CopyTo(&dst)
+		if body := string(dst.Body()); body != "123456789" {
+			t.Fatalf("CopyTo did not copy the buffered body: %q", body)
 		}
 	})
 	t.Run("http client", func(t *testing.T) {
@@ -3601,8 +3657,10 @@ func TestResponseCompressedBodyStreamCloseDoesNotReleaseRequestStreamBeforeReadD
 	if err := resp.CloseBodyStream(); err != nil {
 		t.Fatalf("unexpected close error: %v", err)
 	}
-	if rs.reader == nil {
-		t.Fatalf("request stream was released while compression was still reading it")
+	select {
+	case <-compressedStream.done:
+		t.Fatal("compression finished before its body read was unblocked")
+	default:
 	}
 
 	close(reader.unblock)
@@ -3610,9 +3668,6 @@ func TestResponseCompressedBodyStreamCloseDoesNotReleaseRequestStreamBeforeReadD
 	case <-compressedStream.done:
 	case <-time.After(time.Second):
 		t.Fatalf("timeout waiting for compressed stream cleanup")
-	}
-	if rs.reader != nil {
-		t.Fatalf("request stream was not released after compression finished")
 	}
 }
 
@@ -3658,6 +3713,52 @@ func (h fixedRequestStreamHeader) ContentLength() int {
 
 func (fixedRequestStreamHeader) ReadTrailer(r *bufio.Reader) error {
 	return nil
+}
+
+func TestRequestBodyTruncatedStreamKeepsPartialBody(t *testing.T) {
+	t.Parallel()
+
+	var req Request
+	req.Header.SetContentLength(9)
+	req.bodyStream = acquireRequestStream(
+		req.bodyBuffer(),
+		bufio.NewReader(strings.NewReader("1234")),
+		&req.Header,
+	)
+
+	if body := string(req.Body()); body != "1234" {
+		t.Fatalf("unexpected request body %q; want partial body %q", body, "1234")
+	}
+}
+
+func TestAcquireRequestStreamAllocations(t *testing.T) {
+	var bodyBuf bytebufferpool.ByteBuffer
+	reader := bufio.NewReader(bytes.NewReader(nil))
+	header := fixedRequestStreamHeader{contentLength: 0}
+	allocs := testing.AllocsPerRun(1000, func() {
+		rs := acquireRequestStream(&bodyBuf, reader, header)
+		releaseRequestStream(rs)
+	})
+	if allocs != 0 {
+		t.Fatalf("unexpected allocations per request stream acquire: %v", allocs)
+	}
+}
+
+func TestReleasedRequestStreamReadPanics(t *testing.T) {
+	var bodyBuf bytebufferpool.ByteBuffer
+	rs := acquireRequestStream(
+		&bodyBuf,
+		bufio.NewReader(bytes.NewReader(nil)),
+		fixedRequestStreamHeader{contentLength: 0},
+	)
+	releaseRequestStream(rs)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("reading a released request stream did not panic")
+		}
+	}()
+	_, _ = rs.Read(make([]byte, 1))
 }
 
 type blockingOnceReader struct {

--- a/streaming.go
+++ b/streaming.go
@@ -16,18 +16,25 @@ type bodyStreamHeader interface {
 
 type requestStream struct {
 	header          bodyStreamHeader
-	prefetchedBytes *bytes.Reader
+	prefetchedBytes bytes.Reader
 	reader          *bufio.Reader
+	contentLength   int
 	totalBytesRead  int
 	chunkLeft       int
+	strictEOF       bool
 }
 
 func (rs *requestStream) Read(p []byte) (int, error) {
+	if rs.reader == nil {
+		panic("BUG: reading released body stream")
+	}
+
 	var (
 		n   int
 		err error
 	)
-	if rs.header.ContentLength() == -1 {
+	contentLength := rs.contentLength
+	if contentLength == -1 {
 		if rs.chunkLeft == 0 {
 			chunkSize, err := parseChunkSize(rs.reader)
 			if err != nil {
@@ -54,7 +61,7 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 		}
 		return n, err
 	}
-	if rs.totalBytesRead == rs.header.ContentLength() {
+	if rs.totalBytesRead == contentLength {
 		return 0, io.EOF
 	}
 	prefetchedSize := int(rs.prefetchedBytes.Size())
@@ -65,22 +72,25 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 		}
 		n, err := rs.prefetchedBytes.Read(p)
 		rs.totalBytesRead += n
-		if n == rs.header.ContentLength() {
+		if rs.totalBytesRead == contentLength {
 			return n, io.EOF
 		}
 		return n, err
 	}
-	left := rs.header.ContentLength() - rs.totalBytesRead
+	left := contentLength - rs.totalBytesRead
 	if left > 0 && len(p) > left {
 		p = p[:left]
 	}
 	n, err = rs.reader.Read(p)
 	rs.totalBytesRead += n
+	if err == io.EOF && rs.strictEOF && contentLength >= 0 && rs.totalBytesRead < contentLength {
+		err = io.ErrUnexpectedEOF
+	}
 	if err != nil {
 		return n, err
 	}
 
-	if rs.totalBytesRead == rs.header.ContentLength() {
+	if rs.totalBytesRead == contentLength {
 		err = io.EOF
 	}
 	return n, err
@@ -88,18 +98,27 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 
 func acquireRequestStream(b *bytebufferpool.ByteBuffer, r *bufio.Reader, h bodyStreamHeader) *requestStream {
 	rs := requestStreamPool.Get().(*requestStream) //nolint:forcetypeassert
-	rs.prefetchedBytes = bytes.NewReader(b.B)
+	rs.prefetchedBytes.Reset(b.B)
 	rs.reader = r
 	rs.header = h
+	rs.contentLength = h.ContentLength()
+	return rs
+}
+
+func acquireResponseStream(b *bytebufferpool.ByteBuffer, r *bufio.Reader, h bodyStreamHeader) *requestStream {
+	rs := acquireRequestStream(b, r, h)
+	rs.strictEOF = true
 	return rs
 }
 
 func releaseRequestStream(rs *requestStream) {
-	rs.prefetchedBytes = nil
+	rs.prefetchedBytes.Reset(nil)
 	rs.totalBytesRead = 0
 	rs.chunkLeft = 0
 	rs.reader = nil
 	rs.header = nil
+	rs.contentLength = 0
+	rs.strictEOF = false
 	requestStreamPool.Put(rs)
 }
 


### PR DESCRIPTION
StreamBody only exposed a network-backed stream for chunked, identity, or oversized fixed-length responses. Smaller fixed-length bodies were buffered before Do returned, making streaming depend on response framing and MaxResponseBodySize.

Return a stream immediately for every streamed response and retain its original framing metadata. Report truncated fixed-length responses as io.ErrUnexpectedEOF, keep deadlines active while the stream is being read, and only reuse pooled connections after the body has been fully consumed.

Keep Get and Post on the buffered path so they continue to enforce MaxResponseBodySize, surface body read failures to retry callbacks, and preserve caller-provided destination buffers. Drain small ignored and redirect responses for connection reuse while closing unknown-length or large discarded streams, and make the nil-response paths safe.

PipelineClient must consume responses in order, so preserve StreamBody there as a buffered BodyStream. Add coverage for fixed-length streaming, truncation, helper retries and limits, redirects, nil responses, connection reuse, pipeline deadlines, and stream lifecycle behavior.