### PR TITLE
Give TestClientHeadWithBody a CI-proof read timeout

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -4554,7 +4554,7 @@ func TestClientHeadWithBody(t *testing.T) {
 		Dial: func(addr string) (net.Conn, error) {
 			return ln.Dial()
 		},
-		ReadTimeout:               time.Millisecond * 10,
+		ReadTimeout:               time.Millisecond * 200,
 		MaxIdemponentCallAttempts: 1,
 	}
 


### PR DESCRIPTION
`TestClientHeadWithBody` fails intermittently on the windows CI runners (seen twice on #2352's runs, both `1.25.x, windows-latest`): its 10ms `ReadTimeout` has to cover the whole first exchange, and a loaded runner misses that window, so the first request times out before the test reaches the sequence it means to check. The second request only needs the timeout to fire eventually, so a larger value keeps the test's intent while surviving slow runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
