### PR TITLE
Do not start the idle-conn cleaner after a failed dial

### DIFF
--- a/client.go
+++ b/client.go
@@ -1912,14 +1912,27 @@ func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool)
 		}
 	}
 
-	if startCleaner {
-		go c.connsCleaner()
-	}
-
 	conn, err := c.dialHostHard(reqTimeout)
 	if err != nil {
 		c.decConnsCount()
+		if startCleaner {
+			c.connsLock.Lock()
+			if c.connsCount == 0 {
+				c.connsCleanerRun = false
+				startCleaner = false
+			}
+			c.connsLock.Unlock()
+		}
+		if !startCleaner {
+			return nil, err
+		}
+		// Other in-use connections still need the cleaner.
+		go c.connsCleaner()
 		return nil, err
+	}
+
+	if startCleaner {
+		go c.connsCleaner()
 	}
 	cc = acquireClientConn(conn)
 

--- a/client_test.go
+++ b/client_test.go
@@ -26,6 +26,37 @@ import (
 	"github.com/valyala/fasthttp/fasthttputil"
 )
 
+func TestHostClientDialErrorDoesNotStartCleaner(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	c := &HostClient{
+		Addr:                addr,
+		MaxIdleConnDuration: time.Hour,
+	}
+	_, err = c.AcquireConn(time.Second, false)
+	if err == nil {
+		t.Fatal("expected dial error")
+	}
+
+	c.connsLock.Lock()
+	run := c.connsCleanerRun
+	count := c.connsCount
+	c.connsLock.Unlock()
+	if run {
+		t.Fatal("connsCleaner should not run after a failed dial with no connections")
+	}
+	if count != 0 {
+		t.Fatalf("connsCount = %d, want 0", count)
+	}
+}
+
 func TestCloseIdleConnections(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #2171

`AcquireConn` started `connsCleaner` before `dialHostHard`. When dial failed and no connections remained, the cleaner still slept for `MaxIdleConnDuration`, leaking a goroutine per failed host (worse with a large idle timeout).

Dial first. Start the cleaner after a successful connection, or if other in-use connections still need it. Reset `connsCleanerRun` when the failed dial leaves the pool empty.