### PR TITLE
client: add context-aware request execution

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package fasthttp
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -38,6 +39,15 @@ import (
 // positive MaxResponseBodySize when requesting untrusted servers.
 func Do(req *Request, resp *Response) error {
 	return defaultClient.Do(req, resp)
+}
+
+// DoContext performs the given request and fills the given response, honoring
+// cancellation and deadlines from ctx.
+//
+// The request's existing timeout is also honored. If both it and ctx have a
+// deadline, the earlier deadline is used.
+func DoContext(ctx context.Context, req *Request, resp *Response) error {
+	return defaultClient.DoContext(ctx, req, resp)
 }
 
 // DoTimeout performs the given request and waits for response during
@@ -207,6 +217,10 @@ type Client struct {
 
 	// Transport defines a transport-like mechanism that wraps every request/response.
 	Transport RoundTripper
+
+	// Callback for establishing new connections to hosts while honoring a
+	// request context. DialContext takes precedence over DialTimeout and Dial.
+	DialContext DialFuncWithContext
 
 	// Callback for establishing new connections to hosts.
 	//
@@ -492,6 +506,22 @@ func (c *Client) DoDeadline(req *Request, resp *Response, deadline time.Time) er
 	return c.Do(req, resp)
 }
 
+// DoContext performs the given request and fills the given response, honoring
+// cancellation and deadlines from ctx.
+//
+// The request's existing timeout is also honored. If both it and ctx have a
+// deadline, the earlier deadline is used. A nil context causes a panic.
+// If the request body stream implements io.Closer, cancellation calls Close;
+// the stream should use it to unblock an in-progress Read. A body reader that
+// cannot be interrupted must return on its own before cancellation can complete.
+// Custom dialers and transports must use DialContext and
+// RoundTripperWithContext respectively to be interrupted by cancellation.
+func (c *Client) DoContext(ctx context.Context, req *Request, resp *Response) error {
+	return doRequestContext(ctx, req, resp, func() error {
+		return c.do(ctx, req, resp, true)
+	})
+}
+
 // DoRedirects performs the given http request and fills the given http response,
 // following up to maxRedirectsCount redirects. When the redirect count exceeds
 // maxRedirectsCount, ErrTooManyRedirects is returned.
@@ -539,6 +569,10 @@ func (c *Client) DoRedirects(req *Request, resp *Response, maxRedirectsCount int
 // It is recommended obtaining req and resp via AcquireRequest
 // and AcquireResponse in performance-critical code.
 func (c *Client) Do(req *Request, resp *Response) error {
+	return c.do(context.Background(), req, resp, false)
+}
+
+func (c *Client) do(ctx context.Context, req *Request, resp *Response, contextAware bool) error {
 	uri := req.URI()
 	if uri == nil {
 		return ErrorInvalidURI
@@ -568,7 +602,7 @@ func (c *Client) Do(req *Request, resp *Response) error {
 
 	atomic.AddInt32(&hc.pendingClientRequests, 1)
 	defer atomic.AddInt32(&hc.pendingClientRequests, -1)
-	return hc.Do(req, resp)
+	return hc.doContext(ctx, req, resp, contextAware)
 }
 
 func (c *Client) hostClient(host []byte, isTLS bool) (*HostClient, error) {
@@ -594,6 +628,7 @@ func (c *Client) hostClient(host []byte, isTLS bool) (*HostClient, error) {
 		Transport:                     c.Transport,
 		Name:                          c.Name,
 		NoDefaultUserAgentHeader:      c.NoDefaultUserAgentHeader,
+		DialContext:                   c.DialContext,
 		Dial:                          c.Dial,
 		DialTimeout:                   c.DialTimeout,
 		DialDualStack:                 c.DialDualStack,
@@ -750,6 +785,17 @@ type DialFunc func(addr string) (net.Conn, error)
 //   - foobar.com:8080
 type DialFuncWithTimeout func(addr string, timeout time.Duration) (net.Conn, error)
 
+// DialFuncWithContext must establish a connection to addr while honoring ctx.
+// The context deadline is the earlier of the request timeout and the context
+// passed to DoContext when either is set.
+//
+// There is no need in establishing TLS (SSL) connection for https.
+// The client automatically converts connection to TLS if HostClient.IsTLS is
+// set.
+//
+// TCP address passed to DialFuncWithContext always contains host and port.
+type DialFuncWithContext func(ctx context.Context, addr string) (net.Conn, error)
+
 // RetryIfFunc defines the signature of the retry if function.
 // Request argument passed to RetryIfFunc, if there are any request errors.
 type RetryIfFunc func(request *Request) bool
@@ -783,6 +829,16 @@ type RoundTripper interface {
 	RoundTrip(hc *HostClient, req *Request, resp *Response) (retry bool, err error)
 }
 
+// RoundTripperWithContext is implemented by transports that can propagate
+// request cancellation, deadlines, and values. Client.DoContext and
+// HostClient.DoContext use this interface when available and fall back to
+// RoundTripper otherwise. Ordinary Do calls continue to use RoundTripper.
+type RoundTripperWithContext interface {
+	RoundTripContext(
+		ctx context.Context, hc *HostClient, req *Request, resp *Response,
+	) (retry bool, err error)
+}
+
 // ConnPoolStrategyType define strategy of connection pool enqueue/dequeue.
 type ConnPoolStrategyType int
 
@@ -809,6 +865,10 @@ type HostClient struct {
 
 	// Transport defines a transport-like mechanism that wraps every request/response.
 	Transport RoundTripper
+
+	// Callback for establishing new connections to hosts while honoring a
+	// request context. DialContext takes precedence over DialTimeout and Dial.
+	DialContext DialFuncWithContext
 
 	// Callback for establishing new connections to hosts.
 	//
@@ -1106,6 +1166,42 @@ func (c *HostClient) Post(dst []byte, url string, postArgs *Args) (statusCode in
 
 type clientDoer interface {
 	Do(req *Request, resp *Response) error
+}
+
+func doRequestContext(ctx context.Context, req *Request, resp *Response, do func() error) error {
+	if ctx == nil {
+		panic("fasthttp: nil Context")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	previousTimeout := req.timeout
+	defer func() {
+		req.timeout = previousTimeout
+	}()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		timeout := time.Until(deadline)
+		if timeout <= 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return context.DeadlineExceeded
+		}
+		if req.timeout <= 0 || timeout < req.timeout {
+			req.timeout = timeout
+		}
+	}
+
+	err := do()
+	if contextErr := ctx.Err(); contextErr != nil {
+		if err == nil && resp != nil {
+			_ = resp.closeBodyStream(contextErr)
+		}
+		return contextErr
+	}
+	return err
 }
 
 func clientGetURL(dst []byte, url string, c clientDoer) (statusCode int, body []byte, err error) {
@@ -1569,6 +1665,22 @@ func (c *HostClient) DoDeadline(req *Request, resp *Response, deadline time.Time
 	return c.Do(req, resp)
 }
 
+// DoContext performs the given request and fills the given response, honoring
+// cancellation and deadlines from ctx.
+//
+// The request's existing timeout is also honored. If both it and ctx have a
+// deadline, the earlier deadline is used. A nil context causes a panic.
+// If the request body stream implements io.Closer, cancellation calls Close;
+// the stream should use it to unblock an in-progress Read. A body reader that
+// cannot be interrupted must return on its own before cancellation can complete.
+// Custom dialers and transports must use DialContext and
+// RoundTripperWithContext respectively to be interrupted by cancellation.
+func (c *HostClient) DoContext(ctx context.Context, req *Request, resp *Response) error {
+	return doRequestContext(ctx, req, resp, func() error {
+		return c.doContext(ctx, req, resp, true)
+	})
+}
+
 // DoRedirects performs the given http request and fills the given http response,
 // following up to maxRedirectsCount redirects. When the redirect count exceeds
 // maxRedirectsCount, ErrTooManyRedirects is returned.
@@ -1611,6 +1723,12 @@ func (c *HostClient) DoRedirects(req *Request, resp *Response, maxRedirectsCount
 // It is recommended obtaining req and resp via AcquireRequest
 // and AcquireResponse in performance-critical code.
 func (c *HostClient) Do(req *Request, resp *Response) error {
+	return c.doContext(context.Background(), req, resp, false)
+}
+
+func (c *HostClient) doContext(
+	ctx context.Context, req *Request, resp *Response, contextAware bool,
+) error {
 	var (
 		err          error
 		retry        bool
@@ -1638,6 +1756,10 @@ func (c *HostClient) Do(req *Request, resp *Response) error {
 
 	atomic.AddInt32(&c.pendingRequests, 1)
 	for {
+		if err = ctx.Err(); err != nil {
+			break
+		}
+
 		// If the original timeout was set, we need to update
 		// the one set on the request to reflect the remaining time.
 		if timeout > 0 {
@@ -1648,7 +1770,14 @@ func (c *HostClient) Do(req *Request, resp *Response) error {
 			}
 		}
 
-		retry, err = c.do(req, resp)
+		retry, err = c.do(ctx, req, resp, contextAware)
+		if contextErr := ctx.Err(); contextErr != nil {
+			if err == nil && resp != nil {
+				_ = resp.closeBodyStream(contextErr)
+			}
+			err = contextErr
+			break
+		}
 		if err == nil || !retry {
 			break
 		}
@@ -1705,12 +1834,14 @@ func isIdempotent(req *Request) bool {
 	return req.Header.IsGet() || req.Header.IsHead() || req.Header.IsPut() || req.Header.IsQuery()
 }
 
-func (c *HostClient) do(req *Request, resp *Response) (bool, error) {
+func (c *HostClient) do(
+	ctx context.Context, req *Request, resp *Response, contextAware bool,
+) (bool, error) {
 	if resp == nil {
 		resp = AcquireResponse()
 		defer ReleaseResponse(resp)
 
-		retry, err := c.doNonNilReqResp(req, resp)
+		retry, err := c.doNonNilReqRespContext(ctx, req, resp, contextAware)
 		if err != nil {
 			return retry, err
 		}
@@ -1720,10 +1851,16 @@ func (c *HostClient) do(req *Request, resp *Response) (bool, error) {
 		return retry, nil
 	}
 
-	return c.doNonNilReqResp(req, resp)
+	return c.doNonNilReqRespContext(ctx, req, resp, contextAware)
 }
 
 func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error) {
+	return c.doNonNilReqRespContext(context.Background(), req, resp, false)
+}
+
+func (c *HostClient) doNonNilReqRespContext(
+	ctx context.Context, req *Request, resp *Response, contextAware bool,
+) (bool, error) {
 	if req == nil {
 		// for debugging purposes
 		panic("BUG: req cannot be nil")
@@ -1768,7 +1905,13 @@ func (c *HostClient) doNonNilReqResp(req *Request, resp *Response) (bool, error)
 		}
 	}
 
-	return c.transport().RoundTrip(c, req, resp)
+	transport := c.transport()
+	if contextAware {
+		if contextTransport, ok := transport.(RoundTripperWithContext); ok {
+			return contextTransport.RoundTripContext(ctx, c, req, resp)
+		}
+	}
+	return transport.RoundTrip(c, req, resp)
 }
 
 func (c *HostClient) transport() RoundTripper {
@@ -1826,6 +1969,21 @@ func (c *HostClient) SetMaxConns(newMaxConns int) {
 }
 
 func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool) (cc *clientConn, err error) {
+	return c.acquireConn(context.Background(), reqTimeout, connectionClose)
+}
+
+func (c *HostClient) acquireConn(
+	ctx context.Context, reqTimeout time.Duration, connectionClose bool,
+) (cc *clientConn, err error) {
+	if err = ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	requestDeadline := time.Time{}
+	if reqTimeout > 0 {
+		requestDeadline = time.Now().Add(reqTimeout)
+	}
+
 	createConn := false
 	startCleaner := false
 
@@ -1865,6 +2023,10 @@ func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool)
 	c.connsLock.Unlock()
 
 	if cc != nil {
+		if err = ctx.Err(); err != nil {
+			c.ReleaseConn(cc)
+			return nil, err
+		}
 		return cc, nil
 	}
 	if !createConn {
@@ -1891,7 +2053,9 @@ func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool)
 		defer ReleaseTimer(tc)
 
 		w := &wantConn{
-			ready: make(chan struct{}, 1),
+			ready:           make(chan struct{}, 1),
+			ctx:             ctx,
+			requestDeadline: requestDeadline,
 		}
 		defer func() {
 			if err != nil {
@@ -1903,7 +2067,12 @@ func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool)
 
 		select {
 		case <-w.ready:
+			if err = ctx.Err(); err != nil {
+				return nil, err
+			}
 			return w.conn, w.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		case <-tc.C:
 			if timeoutOverridden {
 				return nil, ErrTimeout
@@ -1916,7 +2085,15 @@ func (c *HostClient) AcquireConn(reqTimeout time.Duration, connectionClose bool)
 		go c.connsCleaner()
 	}
 
-	conn, err := c.dialHostHard(reqTimeout)
+	dialTimeout := reqTimeout
+	if !requestDeadline.IsZero() {
+		dialTimeout = time.Until(requestDeadline)
+		if dialTimeout <= 0 {
+			c.decConnsCount()
+			return nil, ErrTimeout
+		}
+	}
+	conn, err := c.dialHostHardContext(ctx, dialTimeout)
 	if err != nil {
 		c.decConnsCount()
 		return nil, err
@@ -1936,8 +2113,18 @@ func (c *HostClient) queueForIdle(w *wantConn) {
 	c.connsWait.pushBack(w)
 }
 
-func (c *HostClient) dialConnFor(w *wantConn) {
-	conn, err := c.dialHostHard(0)
+func (c *HostClient) dialConnFor(w *wantConn, state wantConnDialState) {
+	dialTimeout := time.Duration(0)
+	if !state.requestDeadline.IsZero() {
+		dialTimeout = time.Until(state.requestDeadline)
+		if dialTimeout <= 0 {
+			w.tryDeliver(nil, ErrTimeout)
+			c.decConnsCount()
+			return
+		}
+	}
+
+	conn, err := c.dialHostHardContext(state.ctx, dialTimeout)
 	if err != nil {
 		w.tryDeliver(nil, err)
 		c.decConnsCount()
@@ -1946,7 +2133,8 @@ func (c *HostClient) dialConnFor(w *wantConn) {
 
 	cc := acquireClientConn(conn)
 	if !w.tryDeliver(cc, nil) {
-		// not delivered, return idle connection
+		// The waiter no longer needs the result. Keep the valid connection idle
+		// so another request can reuse the reserved pool slot.
 		c.ReleaseConn(cc)
 	}
 }
@@ -2045,8 +2233,9 @@ func (c *HostClient) decConnsCount() {
 	if q := c.connsWait; q != nil {
 		for q.len() > 0 {
 			w := q.popFront()
-			if w.waiting() {
-				go c.dialConnFor(w)
+			state, ok := w.claimDial()
+			if ok {
+				go c.dialConnFor(w, state)
 				dialed = true
 				break
 			}
@@ -2231,6 +2420,12 @@ func (c *HostClient) nextAddr() string {
 }
 
 func (c *HostClient) dialHostHard(dialTimeout time.Duration) (conn net.Conn, err error) {
+	return c.dialHostHardContext(context.Background(), dialTimeout)
+}
+
+func (c *HostClient) dialHostHardContext(
+	ctx context.Context, dialTimeout time.Duration,
+) (conn net.Conn, err error) {
 	// use dialTimeout to control the timeout of each dial. It does not work if dialTimeout is 0 or if
 	// c.DialTimeout has not been set and c.Dial has been set.
 	// attempt to dial all the available hosts before giving up.
@@ -2249,7 +2444,14 @@ func (c *HostClient) dialHostHard(dialTimeout time.Duration) (conn net.Conn, err
 		timeout = DefaultDialTimeout
 	}
 	deadline := time.Now().Add(timeout)
+	requestDeadline := time.Time{}
+	if dialTimeout > 0 {
+		requestDeadline = time.Now().Add(dialTimeout)
+	}
 	for n > 0 {
+		if err = ctx.Err(); err != nil {
+			return nil, err
+		}
 		addr := c.nextAddr()
 		var tlsConfig *tls.Config
 		if c.IsTLS {
@@ -2259,9 +2461,22 @@ func (c *HostClient) dialHostHard(dialTimeout time.Duration) (conn net.Conn, err
 				continue
 			}
 		}
-		conn, err = dialAddr(addr, c.Dial, c.DialTimeout, c.DialDualStack, c.IsTLS, tlsConfig, dialTimeout, c.WriteTimeout)
+		attemptTimeout := dialTimeout
+		if !requestDeadline.IsZero() {
+			attemptTimeout = time.Until(requestDeadline)
+			if attemptTimeout <= 0 {
+				return nil, ErrTimeout
+			}
+		}
+		conn, err = dialAddrContext(
+			ctx, addr, c.DialContext, c.Dial, c.DialTimeout, c.DialDualStack,
+			c.IsTLS, tlsConfig, attemptTimeout, c.WriteTimeout,
+		)
 		if err == nil {
 			return conn, nil
+		}
+		if !requestDeadline.IsZero() && time.Until(requestDeadline) <= 0 {
+			return nil, ErrTimeout
 		}
 		if time.Since(deadline) >= 0 {
 			break
@@ -2294,7 +2509,9 @@ func (c *HostClient) cachedTLSConfig(addr string) (*tls.Config, error) {
 // ErrTLSHandshakeTimeout indicates there is a timeout from tls handshake.
 var ErrTLSHandshakeTimeout = errors.New("fasthttp: tls handshake timed out")
 
-func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.Time) (_ net.Conn, retErr error) {
+func tlsClientHandshakeContext(
+	ctx context.Context, rawConn net.Conn, tlsConfig *tls.Config, deadline time.Time,
+) (_ net.Conn, retErr error) {
 	defer func() {
 		if retErr != nil {
 			rawConn.Close()
@@ -2305,7 +2522,10 @@ func tlsClientHandshake(rawConn net.Conn, tlsConfig *tls.Config, deadline time.T
 	if err != nil {
 		return nil, err
 	}
-	err = conn.Handshake()
+	err = conn.HandshakeContext(ctx)
+	if contextErr := ctx.Err(); contextErr != nil {
+		return nil, contextErr
+	}
 	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 		return nil, ErrTLSHandshakeTimeout
 	}
@@ -2323,9 +2543,45 @@ func dialAddr(
 	addr string, dial DialFunc, dialWithTimeout DialFuncWithTimeout, dialDualStack, isTLS bool,
 	tlsConfig *tls.Config, dialTimeout, writeTimeout time.Duration,
 ) (net.Conn, error) {
-	deadline := time.Now().Add(writeTimeout)
-	conn, err := callDialFunc(addr, dial, dialWithTimeout, dialDualStack, isTLS, dialTimeout)
+	return dialAddrContext(
+		context.Background(), addr, nil, dial, dialWithTimeout, dialDualStack,
+		isTLS, tlsConfig, dialTimeout, writeTimeout,
+	)
+}
+
+func dialAddrContext(
+	ctx context.Context, addr string, dialContext DialFuncWithContext, dial DialFunc,
+	dialWithTimeout DialFuncWithTimeout, dialDualStack, isTLS bool,
+	tlsConfig *tls.Config, dialTimeout, writeTimeout time.Duration,
+) (net.Conn, error) {
+	now := time.Now()
+	deadline := now.Add(writeTimeout)
+	if dialTimeout > 0 {
+		requestDeadline := now.Add(dialTimeout)
+		if writeTimeout > 0 && requestDeadline.Before(deadline) {
+			deadline = requestDeadline
+		}
+	}
+
+	dialCtx := ctx
+	cancel := func() {}
+	requestContextDerived := false
+	if dialTimeout > 0 && (dialContext != nil || isTLS) {
+		requestDeadline := now.Add(dialTimeout)
+		if contextDeadline, ok := ctx.Deadline(); !ok || requestDeadline.Before(contextDeadline) {
+			dialCtx, cancel = context.WithDeadline(ctx, requestDeadline)
+			requestContextDerived = true
+		}
+	}
+	defer cancel()
+
+	conn, err := callDialFuncContext(
+		dialCtx, addr, dialContext, dial, dialWithTimeout, dialDualStack, isTLS, dialTimeout,
+	)
 	if err != nil {
+		if requestContextDerived && ctx.Err() == nil && errors.Is(dialCtx.Err(), context.DeadlineExceeded) {
+			return nil, ErrTimeout
+		}
 		return nil, err
 	}
 	if conn == nil {
@@ -2340,31 +2596,44 @@ func dialAddr(
 		if writeTimeout == 0 {
 			return tls.Client(conn, tlsConfig), nil
 		}
-		return tlsClientHandshake(conn, tlsConfig, deadline)
+		tlsConn, tlsErr := tlsClientHandshakeContext(dialCtx, conn, tlsConfig, deadline)
+		if tlsErr != nil && requestContextDerived && ctx.Err() == nil && errors.Is(dialCtx.Err(), context.DeadlineExceeded) {
+			return nil, ErrTimeout
+		}
+		return tlsConn, tlsErr
 	}
 	return conn, nil
 }
 
-func callDialFunc(
-	addr string, dial DialFunc, dialWithTimeout DialFuncWithTimeout, dialDualStack, isTLS bool, timeout time.Duration,
+func callDialFuncContext(
+	ctx context.Context, addr string, dialContext DialFuncWithContext, dial DialFunc,
+	dialWithTimeout DialFuncWithTimeout, dialDualStack, isTLS bool, timeout time.Duration,
 ) (net.Conn, error) {
-	if dialWithTimeout != nil {
-		return dialWithTimeout(addr, timeout)
-	}
-	if dial != nil {
-		return dial(addr)
-	}
-	addr = AddMissingPort(addr, isTLS)
-	if timeout > 0 {
-		if dialDualStack {
-			return DialDualStackTimeout(addr, timeout)
+	var (
+		conn net.Conn
+		err  error
+	)
+	switch {
+	case dialContext != nil:
+		conn, err = dialContext(ctx, addr)
+	case dialWithTimeout != nil:
+		conn, err = dialWithTimeout(addr, timeout)
+	case dial != nil:
+		conn, err = dial(addr)
+	default:
+		addr = AddMissingPort(addr, isTLS)
+		if timeout <= 0 {
+			timeout = DefaultDialTimeout
 		}
-		return DialTimeout(addr, timeout)
+		conn, err = defaultDialer.dialContext(ctx, addr, dialDualStack, timeout)
 	}
-	if dialDualStack {
-		return DialDualStack(addr)
+	if contextErr := ctx.Err(); contextErr != nil {
+		if conn != nil {
+			_ = conn.Close()
+		}
+		return nil, contextErr
 	}
-	return Dial(addr)
+	return conn, err
 }
 
 // AddMissingPort adds a port to a host if it is missing.
@@ -2405,10 +2674,18 @@ func AddMissingPort(addr string, isTLS bool) string {
 //
 // Inspired by net/http/transport.go.
 type wantConn struct {
-	err   error
-	ready chan struct{}
-	conn  *clientConn
-	mu    sync.Mutex // protects conn, err, close(ready)
+	err             error
+	ready           chan struct{}
+	conn            *clientConn
+	ctx             context.Context //nolint:containedctx // bound to this request-scoped waiter
+	requestDeadline time.Time
+	dialing         bool
+	mu              sync.Mutex // protects conn, err, close(ready)
+}
+
+type wantConnDialState struct {
+	ctx             context.Context //nolint:containedctx // transient state owned by one dial operation
+	requestDeadline time.Time
 }
 
 // waiting reports whether w is still waiting for an answer (connection or error).
@@ -2421,6 +2698,26 @@ func (w *wantConn) waiting() bool {
 	}
 }
 
+// claimDial atomically transfers the request state to a dial operation.
+// Clearing the stored context here prevents completed queue entries from
+// retaining request values while the dial is in progress.
+func (w *wantConn) claimDial() (wantConnDialState, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn != nil || w.err != nil || w.dialing {
+		return wantConnDialState{}, false
+	}
+	w.dialing = true
+	state := wantConnDialState{
+		ctx:             w.ctx,
+		requestDeadline: w.requestDeadline,
+	}
+	w.ctx = nil
+	w.requestDeadline = time.Time{}
+	return state, true
+}
+
 // tryDeliver attempts to deliver conn, err to w and reports whether it succeeded.
 func (w *wantConn) tryDeliver(conn *clientConn, err error) bool {
 	w.mu.Lock()
@@ -2431,6 +2728,8 @@ func (w *wantConn) tryDeliver(conn *clientConn, err error) bool {
 	}
 	w.conn = conn
 	w.err = err
+	w.ctx = nil
+	w.requestDeadline = time.Time{}
 	if w.conn == nil && w.err == nil {
 		panic("fasthttp: internal error: misuse of tryDeliver")
 	}
@@ -2449,6 +2748,8 @@ func (w *wantConn) cancel(c *HostClient, err error) {
 	conn := w.conn
 	w.conn = nil
 	w.err = err
+	w.ctx = nil
+	w.requestDeadline = time.Time{}
 	w.mu.Unlock()
 
 	if conn != nil {
@@ -3336,18 +3637,126 @@ var DefaultTransport RoundTripper = &transport{}
 
 type transport struct{}
 
+type contextConnWatcher struct {
+	cancelErr atomic.Pointer[contextConnError]
+	cancel    context.CancelFunc
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+}
+
+type contextRequestBodyCloser struct {
+	req        *Request
+	body       io.Reader
+	err        error
+	once       sync.Once
+	finishOnce sync.Once
+}
+
+type contextConnError struct {
+	err error
+}
+
+func newContextRequestBodyCloser(req *Request) *contextRequestBodyCloser {
+	if _, ok := req.bodyStream.(io.Closer); !ok {
+		return nil
+	}
+	return &contextRequestBodyCloser{
+		req:  req,
+		body: req.bodyStream,
+	}
+}
+
+func (c *contextRequestBodyCloser) close() error {
+	c.once.Do(func() {
+		c.err = c.body.(io.Closer).Close() //nolint:forcetypeassert // checked by constructor
+	})
+	return c.err
+}
+
+func (c *contextRequestBodyCloser) interrupt() {
+	_ = c.close()
+}
+
+func (c *contextRequestBodyCloser) finish() error {
+	err := c.close()
+	c.finishOnce.Do(func() {
+		c.req.bodyStream = nil
+		c.req = nil
+		c.body = nil
+	})
+	return err
+}
+
+func watchConnContext(
+	ctx context.Context,
+	parentCtx context.Context,
+	conn net.Conn,
+	requestBodyCloser *contextRequestBodyCloser,
+	requestTimeout bool,
+	cancel context.CancelFunc,
+) *contextConnWatcher {
+	if ctx.Done() == nil {
+		return nil
+	}
+	w := &contextConnWatcher{
+		cancel: cancel,
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
+	go func() {
+		defer close(w.doneCh)
+		select {
+		case <-ctx.Done():
+			cancelErr := ctx.Err()
+			if requestTimeout && errors.Is(cancelErr, context.DeadlineExceeded) && parentCtx.Err() == nil {
+				cancelErr = ErrTimeout
+			}
+			w.cancelErr.Store(&contextConnError{err: cancelErr})
+			_ = conn.Close()
+			if requestBodyCloser != nil {
+				requestBodyCloser.interrupt()
+			}
+		case <-w.stopCh:
+		}
+	}()
+	return w
+}
+
+func (w *contextConnWatcher) err() error {
+	if w == nil {
+		return nil
+	}
+	if contextErr := w.cancelErr.Load(); contextErr != nil {
+		return contextErr.err
+	}
+	return nil
+}
+
+func (w *contextConnWatcher) stop() error {
+	if w == nil {
+		return nil
+	}
+	close(w.stopCh)
+	<-w.doneCh
+	if w.cancel != nil {
+		w.cancel()
+	}
+	return w.err()
+}
+
 // clientStreamBody serializes reads and keeps pooled response resources alive
 // until an in-flight Read has returned. interrupt must unblock network reads
 // without releasing the connection wrapper or reader pools; release performs
 // that cleanup afterward.
 type clientStreamBody struct {
-	reader    io.Reader
-	interrupt func()
-	release   func(bool)
-	closed    atomic.Bool
-	fullyRead bool
-	readLock  sync.Mutex
-	closeOnce sync.Once
+	reader         io.Reader
+	contextWatcher *contextConnWatcher
+	interrupt      func()
+	release        func(bool)
+	closed         atomic.Bool
+	fullyRead      bool
+	readLock       sync.Mutex
+	closeOnce      sync.Once
 }
 
 func (s *clientStreamBody) Read(p []byte) (int, error) {
@@ -3362,6 +3771,11 @@ func (s *clientStreamBody) Read(p []byte) (int, error) {
 	}
 
 	n, err := s.reader.Read(p)
+	if err != nil && s.contextWatcher != nil {
+		if contextErr := s.contextWatcher.err(); contextErr != nil {
+			err = contextErr
+		}
+	}
 	if errors.Is(err, io.EOF) {
 		s.fullyRead = true
 	}
@@ -3388,6 +3802,12 @@ func (s *clientStreamBody) CloseWithError(err error) error {
 }
 
 func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (retry bool, err error) {
+	return t.RoundTripContext(context.Background(), hc, req, resp)
+}
+
+func (t *transport) RoundTripContext(
+	ctx context.Context, hc *HostClient, req *Request, resp *Response,
+) (retry bool, err error) {
 	customSkipBody := resp.SkipBody
 	customStreamBody := resp.StreamBody
 
@@ -3396,11 +3816,37 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 		deadline = time.Now().Add(req.timeout)
 	}
 
-	cc, err := hc.AcquireConn(req.timeout, req.ConnectionClose())
+	cc, err := hc.acquireConn(ctx, req.timeout, req.ConnectionClose())
 	if err != nil {
 		return false, err
 	}
 	conn := cc.c
+	watchContext := ctx
+	var watchCancel context.CancelFunc
+	requestTimeoutWatch := false
+	if _, bodyCanBeInterrupted := req.bodyStream.(io.Closer); !deadline.IsZero() && bodyCanBeInterrupted {
+		if contextDeadline, ok := ctx.Deadline(); !ok || deadline.Before(contextDeadline) {
+			watchContext, watchCancel = context.WithDeadline(ctx, deadline)
+			requestTimeoutWatch = true
+		}
+	}
+	var requestBodyCloser *contextRequestBodyCloser
+	if watchContext.Done() != nil {
+		requestBodyCloser = newContextRequestBodyCloser(req)
+	}
+	contextWatcher := watchConnContext(
+		watchContext, ctx, conn, requestBodyCloser, requestTimeoutWatch, watchCancel,
+	)
+	defer func() {
+		if contextWatcher != nil {
+			if contextErr := contextWatcher.stop(); contextErr != nil {
+				if requestBodyCloser != nil {
+					_ = requestBodyCloser.finish()
+				}
+				err = contextErr
+			}
+		}
+	}()
 
 	resp.ParseNetConn(conn)
 
@@ -3424,7 +3870,11 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 	}
 
 	bw := hc.AcquireWriter(conn)
-	err = req.Write(bw)
+	if requestBodyCloser == nil {
+		err = req.Write(bw)
+	} else {
+		err = req.write(bw, requestBodyCloser.finish)
+	}
 
 	if resetConnection {
 		req.Header.ResetConnectionClose()
@@ -3474,9 +3924,19 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 		needRetry := err != ErrBodyTooLarge
 		return needRetry, err
 	}
+	if contextErr := ctx.Err(); contextErr != nil {
+		if customStreamBody && resp.bodyStream != nil {
+			_ = resp.closeBodyStream(contextErr)
+		}
+		hc.ReleaseReader(br)
+		hc.CloseConn(cc)
+		return false, contextErr
+	}
 
 	closeConn := resetConnection || req.ConnectionClose() || resp.ConnectionClose()
 	if customStreamBody && resp.bodyStream != nil {
+		streamContextWatcher := contextWatcher
+		contextWatcher = nil
 		// releaseConn runs when the caller closes the body stream, so it has to
 		// re-check resp.ConnectionClose(): a caller may only decide that the
 		// connection is unusable while consuming the streamed body.
@@ -3492,12 +3952,18 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 		// closes, so interrupt it and wait before pooling anything.
 		rs := resp.bodyStream.(*requestStream) //nolint:forcetypeassert
 		resp.bodyStream = &clientStreamBody{
-			reader:    rs,
-			fullyRead: rs.contentLength == 0,
+			reader:         rs,
+			contextWatcher: streamContextWatcher,
+			fullyRead:      rs.contentLength == 0,
 			interrupt: func() {
 				_ = conn.Close()
 			},
 			release: func(discard bool) {
+				if streamContextWatcher != nil {
+					if contextErr := streamContextWatcher.stop(); contextErr != nil {
+						discard = true
+					}
+				}
 				hc.ReleaseReader(br)
 				releaseRequestStream(rs)
 				releaseConn(discard)
@@ -3506,6 +3972,14 @@ func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (ret
 		return false, nil
 	}
 	hc.ReleaseReader(br)
+	if contextWatcher != nil {
+		contextErr := contextWatcher.stop()
+		contextWatcher = nil
+		if contextErr != nil {
+			hc.CloseConn(cc)
+			return false, contextErr
+		}
+	}
 
 	if closeConn {
 		hc.CloseConn(cc)

--- a/client.go
+++ b/client.go
@@ -3802,11 +3802,17 @@ func (s *clientStreamBody) CloseWithError(err error) error {
 }
 
 func (t *transport) RoundTrip(hc *HostClient, req *Request, resp *Response) (retry bool, err error) {
-	return t.RoundTripContext(context.Background(), hc, req, resp)
+	return t.roundTrip(context.Background(), hc, req, resp, false)
 }
 
 func (t *transport) RoundTripContext(
 	ctx context.Context, hc *HostClient, req *Request, resp *Response,
+) (retry bool, err error) {
+	return t.roundTrip(ctx, hc, req, resp, true)
+}
+
+func (t *transport) roundTrip(
+	ctx context.Context, hc *HostClient, req *Request, resp *Response, contextAware bool,
 ) (retry bool, err error) {
 	customSkipBody := resp.SkipBody
 	customStreamBody := resp.StreamBody
@@ -3821,22 +3827,25 @@ func (t *transport) RoundTripContext(
 		return false, err
 	}
 	conn := cc.c
-	watchContext := ctx
-	var watchCancel context.CancelFunc
-	requestTimeoutWatch := false
-	if _, bodyCanBeInterrupted := req.bodyStream.(io.Closer); !deadline.IsZero() && bodyCanBeInterrupted {
-		if contextDeadline, ok := ctx.Deadline(); !ok || deadline.Before(contextDeadline) {
-			watchContext, watchCancel = context.WithDeadline(ctx, deadline)
-			requestTimeoutWatch = true
-		}
-	}
 	var requestBodyCloser *contextRequestBodyCloser
-	if watchContext.Done() != nil {
-		requestBodyCloser = newContextRequestBodyCloser(req)
+	var contextWatcher *contextConnWatcher
+	if contextAware {
+		watchContext := ctx
+		var watchCancel context.CancelFunc
+		requestTimeoutWatch := false
+		if _, bodyCanBeInterrupted := req.bodyStream.(io.Closer); !deadline.IsZero() && bodyCanBeInterrupted {
+			if contextDeadline, ok := ctx.Deadline(); !ok || deadline.Before(contextDeadline) {
+				watchContext, watchCancel = context.WithDeadline(ctx, deadline)
+				requestTimeoutWatch = true
+			}
+		}
+		if watchContext.Done() != nil {
+			requestBodyCloser = newContextRequestBodyCloser(req)
+		}
+		contextWatcher = watchConnContext(
+			watchContext, ctx, conn, requestBodyCloser, requestTimeoutWatch, watchCancel,
+		)
 	}
-	contextWatcher := watchConnContext(
-		watchContext, ctx, conn, requestBodyCloser, requestTimeoutWatch, watchCancel,
-	)
 	defer func() {
 		if contextWatcher != nil {
 			if contextErr := contextWatcher.stop(); contextErr != nil {

--- a/client_context_test.go
+++ b/client_context_test.go
@@ -1,0 +1,1102 @@
+package fasthttp
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type contextRoundTripperFunc func(context.Context, *HostClient, *Request, *Response) (bool, error)
+
+func (f contextRoundTripperFunc) RoundTrip(
+	hc *HostClient, req *Request, resp *Response,
+) (bool, error) {
+	return f(context.Background(), hc, req, resp)
+}
+
+func (f contextRoundTripperFunc) RoundTripContext(
+	ctx context.Context, hc *HostClient, req *Request, resp *Response,
+) (bool, error) {
+	return f(ctx, hc, req, resp)
+}
+
+type clientContextDoer interface {
+	DoContext(context.Context, *Request, *Response) error
+}
+
+type dualRoundTripper struct {
+	roundTripCalls        atomic.Int32
+	roundTripContextCalls atomic.Int32
+}
+
+func (rt *dualRoundTripper) RoundTrip(*HostClient, *Request, *Response) (bool, error) {
+	rt.roundTripCalls.Add(1)
+	return false, nil
+}
+
+func (rt *dualRoundTripper) RoundTripContext(
+	context.Context, *HostClient, *Request, *Response,
+) (bool, error) {
+	rt.roundTripContextCalls.Add(1)
+	return false, nil
+}
+
+func TestDoKeepsLegacyRoundTripperDispatch(t *testing.T) {
+	t.Parallel()
+
+	rt := &dualRoundTripper{}
+	hc := &HostClient{Addr: "example.com:80", Transport: rt}
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	var resp Response
+
+	if err := hc.Do(&req, &resp); err != nil {
+		t.Fatalf("unexpected Do error: %v", err)
+	}
+	if got := rt.roundTripCalls.Load(); got != 1 {
+		t.Fatalf("RoundTrip calls: got %d, want 1", got)
+	}
+	if got := rt.roundTripContextCalls.Load(); got != 0 {
+		t.Fatalf("ordinary Do unexpectedly called RoundTripContext %d times", got)
+	}
+
+	if err := hc.DoContext(context.Background(), &req, &resp); err != nil {
+		t.Fatalf("unexpected DoContext error: %v", err)
+	}
+	if got := rt.roundTripContextCalls.Load(); got != 1 {
+		t.Fatalf("DoContext calls: got %d, want 1", got)
+	}
+}
+
+func TestDoContextPropagatesContextAndRestoresRequest(t *testing.T) {
+	t.Parallel()
+
+	type contextKey string
+	const key contextKey = "key"
+
+	for _, tc := range []struct {
+		name string
+		new  func(RoundTripper) clientContextDoer
+	}{
+		{
+			name: "Client",
+			new: func(rt RoundTripper) clientContextDoer {
+				return &Client{Transport: rt}
+			},
+		},
+		{
+			name: "HostClient",
+			new: func(rt RoundTripper) clientContextDoer {
+				return &HostClient{Addr: "example.com:80", Transport: rt}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			capturedContext := make(chan context.Context, 1)
+			capturedTimeout := make(chan time.Duration, 1)
+			rt := contextRoundTripperFunc(func(
+				ctx context.Context, _ *HostClient, req *Request, _ *Response,
+			) (bool, error) {
+				capturedContext <- ctx
+				capturedTimeout <- req.timeout
+				return false, nil
+			})
+
+			ctx, cancel := context.WithTimeout(
+				context.WithValue(context.Background(), key, "current"),
+				testTimeout(5*time.Second),
+			)
+			defer cancel()
+
+			var req Request
+			req.SetRequestURI("http://example.com/")
+			req.SetTimeout(testTimeout(500 * time.Millisecond))
+			originalTimeout := req.timeout
+
+			var resp Response
+			if err := tc.new(rt).DoContext(ctx, &req, &resp); err != nil {
+				t.Fatalf("unexpected DoContext error: %v", err)
+			}
+
+			gotContext := <-capturedContext
+			if gotContext != ctx {
+				t.Fatal("RoundTripper did not receive the request context")
+			}
+			if value := gotContext.Value(key); value != "current" {
+				t.Fatalf("unexpected context value %v", value)
+			}
+			gotTimeout := <-capturedTimeout
+			if gotTimeout <= 0 || gotTimeout > originalTimeout {
+				t.Fatalf("request timeout was not preserved as the earlier limit: got %s, original %s", gotTimeout, originalTimeout)
+			}
+			if req.timeout != originalTimeout {
+				t.Fatalf("DoContext did not restore the request timeout: got %s, want %s", req.timeout, originalTimeout)
+			}
+		})
+	}
+}
+
+func TestDoContextUsesEarlierContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	var capturedTimeout time.Duration
+	hc := &HostClient{
+		Addr: "example.com:80",
+		Transport: contextRoundTripperFunc(func(
+			_ context.Context, _ *HostClient, req *Request, _ *Response,
+		) (bool, error) {
+			capturedTimeout = req.timeout
+			return false, nil
+		}),
+	}
+
+	ctxTimeout := testTimeout(500 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	defer cancel()
+
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	req.SetTimeout(testTimeout(5 * time.Second))
+	originalTimeout := req.timeout
+
+	var resp Response
+	if err := hc.DoContext(ctx, &req, &resp); err != nil {
+		t.Fatalf("unexpected DoContext error: %v", err)
+	}
+	if capturedTimeout <= 0 || capturedTimeout > ctxTimeout {
+		t.Fatalf("context deadline was not used as the earlier limit: got %s, context limit %s", capturedTimeout, ctxTimeout)
+	}
+	if req.timeout != originalTimeout {
+		t.Fatalf("DoContext did not restore the request timeout: got %s, want %s", req.timeout, originalTimeout)
+	}
+}
+
+func TestDoContextRejectsCanceledAndNilContexts(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+	hc := &HostClient{
+		Addr: "example.com:80",
+		Transport: contextRoundTripperFunc(func(
+			_ context.Context, _ *HostClient, _ *Request, _ *Response,
+		) (bool, error) {
+			called.Store(true)
+			return false, nil
+		}),
+	}
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	var resp Response
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := hc.DoContext(ctx, &req, &resp); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected canceled-context error: %v", err)
+	}
+	if called.Load() {
+		t.Fatal("transport was called for an already canceled context")
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("DoContext did not panic for a nil context")
+		}
+	}()
+	var nilContext context.Context
+	_ = hc.DoContext(nilContext, &req, &resp)
+}
+
+func TestDoContextCancelsConnectionWait(t *testing.T) {
+	t.Parallel()
+
+	hc := &HostClient{
+		Addr:               "example.com:80",
+		MaxConns:           1,
+		MaxConnWaitTimeout: testTimeout(5 * time.Second),
+	}
+	hc.connsCount = 1
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+
+	deadline := time.Now().Add(testTimeout(time.Second))
+	for {
+		hc.connsLock.Lock()
+		queued := hc.connsWait != nil && hc.connsWait.len() > 0
+		hc.connsLock.Unlock()
+		if queued {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("request did not enter the connection wait queue")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	cancel()
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected connection-wait cancellation error: %v", err)
+	}
+}
+
+func TestDoContextCanceledWaiterReleasesRequestState(t *testing.T) {
+	t.Parallel()
+
+	hc := &HostClient{
+		Addr:               "example.com:80",
+		MaxConns:           1,
+		MaxConnWaitTimeout: testTimeout(5 * time.Second),
+	}
+	hc.connsCount = 1
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+
+	waitForConnectionQueue(t, hc)
+	cancel()
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected connection-wait cancellation error: %v", err)
+	}
+
+	hc.connsLock.Lock()
+	w := hc.connsWait.peekFront()
+	if w == nil {
+		hc.connsLock.Unlock()
+		t.Fatal("canceled waiter was unexpectedly removed from the queue")
+	}
+	w.mu.Lock()
+	if w.ctx != nil || !w.requestDeadline.IsZero() {
+		w.mu.Unlock()
+		hc.connsLock.Unlock()
+		t.Fatal("canceled waiter retained request state")
+	}
+	w.mu.Unlock()
+	hc.connsLock.Unlock()
+}
+
+func TestDoContextCancelsWaiterDial(t *testing.T) {
+	t.Parallel()
+
+	dialStarted := make(chan struct{})
+	hc := &HostClient{
+		Addr:               "example.com:80",
+		MaxConns:           1,
+		MaxConnWaitTimeout: testTimeout(5 * time.Second),
+		DialContext: func(ctx context.Context, _ string) (net.Conn, error) {
+			close(dialStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	hc.connsCount = 1
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+
+	deadline := time.Now().Add(testTimeout(time.Second))
+	for {
+		hc.connsLock.Lock()
+		queued := hc.connsWait != nil && hc.connsWait.len() > 0
+		hc.connsLock.Unlock()
+		if queued {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("request did not enter the connection wait queue")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Simulate the active connection closing. The waiting request now owns the
+	// connection slot and must dial using its own context.
+	hc.decConnsCount()
+	<-dialStarted
+	cancel()
+
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected waiter-dial cancellation error: %v", err)
+	}
+	waitForConnectionCount(t, hc, 0)
+}
+
+func TestDoContextWaiterDialUsesRemainingRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	capturedTimeout := make(chan time.Duration, 1)
+	hc := &HostClient{
+		Addr:                      "example.com:80",
+		MaxConns:                  1,
+		MaxConnWaitTimeout:        testTimeout(5 * time.Second),
+		MaxIdemponentCallAttempts: 1,
+		DialContext: func(ctx context.Context, _ string) (net.Conn, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return nil, errors.New("dial context has no deadline")
+			}
+			capturedTimeout <- time.Until(deadline)
+			return nil, errors.New("stop dial")
+		},
+	}
+	hc.connsCount = 1
+
+	requestTimeout := testTimeout(500 * time.Millisecond)
+	waitDuration := testTimeout(50 * time.Millisecond)
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	req.SetTimeout(requestTimeout)
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.Do(&req, nil)
+	}()
+
+	waitForConnectionQueue(t, hc)
+	time.Sleep(waitDuration)
+	hc.decConnsCount()
+
+	if err := waitContextResult(t, result); err == nil {
+		t.Fatal("expected waiter dial error")
+	}
+	gotTimeout := <-capturedTimeout
+	if gotTimeout <= 0 || gotTimeout >= requestTimeout-waitDuration/2 {
+		t.Fatalf("waiter dial did not receive the remaining request timeout: got %s, original %s", gotTimeout, requestTimeout)
+	}
+}
+
+func TestRequestTimeoutStillInterruptsLegacyWaiterDial(t *testing.T) {
+	t.Parallel()
+
+	dialStarted := make(chan struct{})
+	releaseDial := make(chan struct{})
+	hc := &HostClient{
+		Addr:               "example.com:80",
+		MaxConns:           1,
+		MaxConnWaitTimeout: testTimeout(5 * time.Second),
+		Dial: func(string) (net.Conn, error) {
+			close(dialStarted)
+			<-releaseDial
+			return nil, errors.New("stop dial")
+		},
+	}
+	hc.connsCount = 1
+
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	req.SetTimeout(testTimeout(100 * time.Millisecond))
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.Do(&req, nil)
+	}()
+
+	waitForConnectionQueue(t, hc)
+	hc.decConnsCount()
+	<-dialStarted
+	if err := waitContextResult(t, result); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("legacy waiter dial did not preserve request timeout: %v", err)
+	}
+	close(releaseDial)
+	waitForConnectionCount(t, hc, 0)
+}
+
+func TestDoContextCancelsDialContext(t *testing.T) {
+	t.Parallel()
+
+	dialStarted := make(chan struct{})
+	hc := &HostClient{
+		Addr: "example.com:80",
+		DialContext: func(ctx context.Context, _ string) (net.Conn, error) {
+			close(dialStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+	<-dialStarted
+	cancel()
+
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected dial cancellation error: %v", err)
+	}
+}
+
+func TestDialContextHonorsRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	capturedTimeout := make(chan time.Duration, 1)
+	hc := &HostClient{
+		Addr:                      "example.com:80",
+		MaxIdemponentCallAttempts: 1,
+		DialContext: func(ctx context.Context, _ string) (net.Conn, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return nil, errors.New("dial context has no deadline")
+			}
+			capturedTimeout <- time.Until(deadline)
+			return nil, errors.New("stop dial")
+		},
+	}
+
+	requestTimeout := testTimeout(500 * time.Millisecond)
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	req.SetTimeout(requestTimeout)
+	if err := hc.Do(&req, nil); err == nil {
+		t.Fatal("expected dial error")
+	}
+
+	gotTimeout := <-capturedTimeout
+	if gotTimeout <= 0 || gotTimeout > requestTimeout {
+		t.Fatalf("DialContext did not receive request timeout: got %s, want at most %s", gotTimeout, requestTimeout)
+	}
+}
+
+func TestRequestTimeoutCoversAllDialAddresses(t *testing.T) {
+	t.Parallel()
+
+	var dialCalls atomic.Int32
+	hc := &HostClient{
+		Addr:                      "first.example.com:80,second.example.com:80",
+		MaxIdemponentCallAttempts: 1,
+		DialContext: func(ctx context.Context, _ string) (net.Conn, error) {
+			dialCalls.Add(1)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	var req Request
+	req.SetRequestURI("http://first.example.com/")
+	req.SetTimeout(testTimeout(100 * time.Millisecond))
+	if err := hc.Do(&req, nil); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("unexpected multi-address timeout error: %v", err)
+	}
+	if got := dialCalls.Load(); got != 1 {
+		t.Fatalf("request timeout was restarted for another address: got %d dial attempts, want 1", got)
+	}
+}
+
+type signalWriteConn struct {
+	net.Conn
+
+	started chan struct{}
+	once    sync.Once
+}
+
+func (c *signalWriteConn) Write(p []byte) (int, error) {
+	c.once.Do(func() { close(c.started) })
+	return c.Conn.Write(p)
+}
+
+func TestDoContextCancelsBlockedWrite(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	writeStarted := make(chan struct{})
+	hc := &HostClient{
+		Addr: "example.com:80",
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return &signalWriteConn{Conn: clientConn, started: writeStarted}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+	<-writeStarted
+	cancel()
+
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected write cancellation error: %v", err)
+	}
+}
+
+type cancelableBlockingRequestBody struct {
+	readStarted chan struct{}
+	closed      chan struct{}
+	readOnce    sync.Once
+	closeOnce   sync.Once
+	closeCalls  atomic.Int32
+}
+
+func (b *cancelableBlockingRequestBody) Read([]byte) (int, error) {
+	b.readOnce.Do(func() { close(b.readStarted) })
+	<-b.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (b *cancelableBlockingRequestBody) Close() error {
+	b.closeCalls.Add(1)
+	b.closeOnce.Do(func() { close(b.closed) })
+	return nil
+}
+
+func TestDoContextCancelsBlockedRequestBodyRead(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	hc := &HostClient{
+		Addr: "example.com:80",
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+	body := &cancelableBlockingRequestBody{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	req.Header.SetMethod(MethodPost)
+	req.SetBodyStream(body, 1)
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+	<-body.readStarted
+	cancel()
+
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected request-body cancellation error: %v", err)
+	}
+	if got := body.closeCalls.Load(); got != 1 {
+		t.Fatalf("request body close calls: got %d, want 1", got)
+	}
+	if req.IsBodyStream() {
+		t.Fatal("canceled request retained its body stream")
+	}
+}
+
+func TestRequestTimeoutCancelsBlockedRequestBodyRead(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	hc := &HostClient{
+		Addr: "example.com:80",
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+	body := &cancelableBlockingRequestBody{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout(5*time.Second))
+	defer cancel()
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	req.Header.SetMethod(MethodPost)
+	req.SetBodyStream(body, 1)
+	req.SetTimeout(testTimeout(100 * time.Millisecond))
+	if err := hc.DoContext(ctx, &req, nil); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("unexpected request-body timeout error: %v", err)
+	}
+	if got := body.closeCalls.Load(); got != 1 {
+		t.Fatalf("request body close calls: got %d, want 1", got)
+	}
+	if req.IsBodyStream() {
+		t.Fatal("timed-out request retained its body stream")
+	}
+}
+
+type blockingWriteDeadlineConn struct {
+	net.Conn
+
+	setStarted chan struct{}
+	closed     chan struct{}
+	setOnce    sync.Once
+	closeOnce  sync.Once
+}
+
+func (c *blockingWriteDeadlineConn) SetWriteDeadline(time.Time) error {
+	c.setOnce.Do(func() { close(c.setStarted) })
+	<-c.closed
+	return net.ErrClosed
+}
+
+func (c *blockingWriteDeadlineConn) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+		_ = c.Conn.Close()
+	})
+	return nil
+}
+
+func TestDoContextCancellationBeforeBodyWriteClosesBodyOnce(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	conn := &blockingWriteDeadlineConn{
+		Conn:       clientConn,
+		setStarted: make(chan struct{}),
+		closed:     make(chan struct{}),
+	}
+	hc := &HostClient{
+		Addr: "example.com:80",
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return conn, nil
+		},
+	}
+	body := &cancelableBlockingRequestBody{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	req.Header.SetMethod(MethodPost)
+	req.SetBodyStream(body, 1)
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+	<-conn.setStarted
+	cancel()
+
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected pre-write cancellation error: %v", err)
+	}
+	if got := body.closeCalls.Load(); got != 1 {
+		t.Fatalf("request body close calls: got %d, want 1", got)
+	}
+	if req.IsBodyStream() {
+		t.Fatal("pre-write cancellation retained its body stream")
+	}
+}
+
+func TestDoContextCancelsTLSHandshake(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	handshakeStarted := make(chan struct{})
+	hc := &HostClient{
+		Addr:  "example.com:443",
+		IsTLS: true,
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return &signalWriteConn{Conn: clientConn, started: handshakeStarted}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("https://example.com/")
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+	<-handshakeStarted
+	cancel()
+
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected TLS handshake cancellation error: %v", err)
+	}
+}
+
+func TestRequestTimeoutInterruptsTLSHandshake(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	hc := &HostClient{
+		Addr:         "example.com:443",
+		IsTLS:        true,
+		WriteTimeout: testTimeout(5 * time.Second),
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+
+	var req Request
+	req.SetRequestURI("https://example.com/")
+	req.SetTimeout(testTimeout(100 * time.Millisecond))
+	if err := hc.Do(&req, nil); !errors.Is(err, ErrTimeout) {
+		t.Fatalf("unexpected TLS request-timeout error: %v", err)
+	}
+}
+
+type signalReadConn struct {
+	net.Conn
+
+	started chan struct{}
+	once    sync.Once
+}
+
+func (c *signalReadConn) Read(p []byte) (int, error) {
+	c.once.Do(func() { close(c.started) })
+	return c.Conn.Read(p)
+}
+
+func TestDoContextCancelsBlockedRead(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	readStarted := make(chan struct{})
+	hc := &HostClient{
+		Addr: "example.com:80",
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return &signalReadConn{Conn: clientConn, started: readStarted}, nil
+		},
+	}
+
+	serverRead := make(chan error, 1)
+	go func() {
+		serverRead <- readRequestHeader(serverConn)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	result := make(chan error, 1)
+	go func() {
+		result <- hc.DoContext(ctx, &req, nil)
+	}()
+	if err := waitContextResult(t, serverRead); err != nil {
+		t.Fatalf("server could not read request: %v", err)
+	}
+	<-readStarted
+	cancel()
+
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected read cancellation error: %v", err)
+	}
+}
+
+func TestDoContextCancellationDoesNotCloseReleasedConnection(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	serverDone := make(chan error, 1)
+	go func() {
+		for range 2 {
+			if err := readRequestHeader(serverConn); err != nil {
+				serverDone <- err
+				return
+			}
+			if _, err := io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"); err != nil {
+				serverDone <- err
+				return
+			}
+		}
+		serverDone <- nil
+	}()
+
+	var dialCount atomic.Int32
+	hc := &HostClient{
+		Addr: "example.com:80",
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			if dialCount.Add(1) != 1 {
+				return nil, errors.New("unexpected second dial")
+			}
+			return clientConn, nil
+		},
+	}
+	t.Cleanup(hc.CloseIdleConnections)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/first")
+	var resp Response
+	if err := hc.DoContext(ctx, &req, &resp); err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	cancel()
+
+	req.Reset()
+	req.SetRequestURI("http://example.com/second")
+	if err := hc.Do(&req, &resp); err != nil {
+		t.Fatalf("released connection was closed by late cancellation: %v", err)
+	}
+	if err := waitContextResult(t, serverDone); err != nil {
+		t.Fatalf("server failed: %v", err)
+	}
+	if got := dialCount.Load(); got != 1 {
+		t.Fatalf("connection was not reused: got %d dials", got)
+	}
+}
+
+type cancelOnHeaderConn struct {
+	net.Conn
+
+	cancel     context.CancelFunc
+	firstClose chan struct{}
+	readOnce   sync.Once
+	closeCalls atomic.Int32
+}
+
+func (c *cancelOnHeaderConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.readOnce.Do(func() {
+			c.cancel()
+			<-c.firstClose
+		})
+	}
+	return n, err
+}
+
+func (c *cancelOnHeaderConn) Close() error {
+	if c.closeCalls.Add(1) == 1 {
+		close(c.firstClose)
+		return nil
+	}
+	return c.Conn.Close()
+}
+
+func TestDoContextCleansStreamingResponseCanceledDuringHeaderTransfer(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	wrappedConn := &cancelOnHeaderConn{
+		Conn:       clientConn,
+		cancel:     cancel,
+		firstClose: make(chan struct{}),
+	}
+	hc := &HostClient{
+		Addr:               "example.com:80",
+		StreamResponseBody: true,
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return wrappedConn, nil
+		},
+	}
+
+	serverDone := make(chan error, 1)
+	go func() {
+		if err := readRequestHeader(serverConn); err != nil {
+			serverDone <- err
+			return
+		}
+		_, err := io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nabc")
+		serverDone <- err
+	}()
+
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	var resp Response
+	if err := hc.DoContext(ctx, &req, &resp); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected header-transfer cancellation error: %v", err)
+	}
+	if resp.BodyStream() != nil {
+		t.Fatal("canceled header transfer retained a response body stream")
+	}
+	if got := hc.ConnsCount(); got != 0 {
+		t.Fatalf("canceled header transfer retained a connection slot: %d", got)
+	}
+	if err := waitContextResult(t, serverDone); err != nil && !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("unexpected server error: %v", err)
+	}
+}
+
+func TestDoContextCancelsStreamingResponseRead(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	serverDone := make(chan error, 1)
+	go func() {
+		if err := readRequestHeader(serverConn); err != nil {
+			serverDone <- err
+			return
+		}
+		_, err := io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nabc")
+		serverDone <- err
+	}()
+
+	hc := &HostClient{
+		Addr:               "example.com:80",
+		StreamResponseBody: true,
+		DialContext: func(context.Context, string) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var req Request
+	req.SetRequestURI("http://example.com/")
+	var resp Response
+	if err := hc.DoContext(ctx, &req, &resp); err != nil {
+		t.Fatalf("request failed before streaming: %v", err)
+	}
+	if err := waitContextResult(t, serverDone); err != nil {
+		t.Fatalf("server failed: %v", err)
+	}
+
+	buf := make([]byte, 3)
+	if n, err := io.ReadFull(resp.BodyStream(), buf); n != len(buf) || err != nil || string(buf) != "abc" {
+		t.Fatalf("unexpected initial stream read: n=%d err=%v body=%q", n, err, buf[:n])
+	}
+	readResult := make(chan error, 1)
+	go func() {
+		_, err := resp.BodyStream().Read(make([]byte, 1))
+		readResult <- err
+	}()
+	cancel()
+
+	if err := waitContextResult(t, readResult); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected stream cancellation error: %v", err)
+	}
+	if err := resp.CloseBodyStream(); err != nil {
+		t.Fatalf("unexpected body close error: %v", err)
+	}
+	if got := hc.ConnsCount(); got != 0 {
+		t.Fatalf("canceled streaming connection was retained: %d", got)
+	}
+}
+
+type blockingContextResolver struct {
+	started chan struct{}
+}
+
+func (r *blockingContextResolver) LookupIPAddr(ctx context.Context, _ string) ([]net.IPAddr, error) {
+	close(r.started)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestTCPDialerContextCancelsDNSResolution(t *testing.T) {
+	t.Parallel()
+
+	resolver := &blockingContextResolver{started: make(chan struct{})}
+	dialer := &TCPDialer{Resolver: resolver}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := dialer.dialContext(ctx, "example.com:80", false, testTimeout(5*time.Second))
+		result <- err
+	}()
+	<-resolver.started
+	cancel()
+
+	if err := waitContextResult(t, result); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected DNS cancellation error: %v", err)
+	}
+}
+
+func readRequestHeader(conn net.Conn) error {
+	reader := bufio.NewReader(conn)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if line == "\r\n" {
+			return nil
+		}
+	}
+}
+
+func waitContextResult(t *testing.T, result <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(testTimeout(2 * time.Second)):
+		t.Fatal("timed out waiting for context-aware operation")
+		return nil
+	}
+}
+
+func waitForConnectionQueue(t *testing.T, hc *HostClient) {
+	t.Helper()
+	deadline := time.Now().Add(testTimeout(time.Second))
+	for {
+		hc.connsLock.Lock()
+		queued := hc.connsWait != nil && hc.connsWait.len() > 0
+		hc.connsLock.Unlock()
+		if queued {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("request did not enter the connection wait queue")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func waitForConnectionCount(t *testing.T, hc *HostClient, want int) {
+	t.Helper()
+	deadline := time.Now().Add(testTimeout(time.Second))
+	for {
+		if got := hc.ConnsCount(); got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("connection count did not reach %d: got %d", want, hc.ConnsCount())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/client_context_test.go
+++ b/client_context_test.go
@@ -6,11 +6,57 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestDoTimeoutClosableBodyAllocations(t *testing.T) {
+	client := &HostClient{
+		Addr: "example.com:80",
+		Dial: func(string) (net.Conn, error) {
+			return &fakeClientConn{
+				ch: make(chan struct{}, 1),
+				s:  []byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"),
+			}, nil
+		},
+	}
+	defer client.CloseIdleConnections()
+
+	var req Request
+	var resp Response
+	defer req.Reset()
+	defer resp.Reset()
+	req.SetRequestURI("http://example.com/")
+	req.Header.SetMethod(MethodPost)
+
+	reader := strings.NewReader("body")
+	body := io.NopCloser(reader)
+	allocs := func(timeout time.Duration) float64 {
+		return testing.AllocsPerRun(100, func() {
+			reader.Reset("body")
+			req.SetBodyStream(body, 4)
+			var err error
+			if timeout == 0 {
+				err = client.Do(&req, &resp)
+			} else {
+				err = client.DoTimeout(&req, &resp, timeout)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+	withoutTimeout := allocs(0)
+	withTimeout := allocs(time.Second)
+	if withTimeout > withoutTimeout {
+		t.Fatalf("timeout adds %.0f allocations per request (without: %.0f, with: %.0f)",
+			withTimeout-withoutTimeout, withoutTimeout, withTimeout)
+	}
+}
 
 type contextRoundTripperFunc func(context.Context, *HostClient, *Request, *Response) (bool, error)
 

--- a/http.go
+++ b/http.go
@@ -1800,6 +1800,10 @@ func (req *Request) onlyMultipartForm() bool {
 //
 // See also WriteTo.
 func (req *Request) Write(w *bufio.Writer) error {
+	return req.write(w, nil)
+}
+
+func (req *Request) write(w *bufio.Writer, closeBodyStream func() error) error {
 	if len(req.Header.Host()) == 0 || req.parsedURI {
 		uri := req.URI()
 		host := uri.Host()
@@ -1834,7 +1838,7 @@ func (req *Request) Write(w *bufio.Writer) error {
 	}
 
 	if req.bodyStream != nil {
-		return req.writeBodyStream(w)
+		return req.writeBodyStream(w, closeBodyStream)
 	}
 
 	body := req.bodyBytes()
@@ -2301,7 +2305,7 @@ func (resp *Response) Write(w *bufio.Writer) error {
 	return nil
 }
 
-func (req *Request) writeBodyStream(w *bufio.Writer) error {
+func (req *Request) writeBodyStream(w *bufio.Writer, closeBodyStream func() error) error {
 	var err error
 
 	contentLength := req.Header.ContentLength()
@@ -2331,7 +2335,12 @@ func (req *Request) writeBodyStream(w *bufio.Writer) error {
 			err = req.Header.writeTrailer(w)
 		}
 	}
-	errc := req.closeBodyStream()
+	var errc error
+	if closeBodyStream == nil {
+		errc = req.closeBodyStream()
+	} else {
+		errc = closeBodyStream()
+	}
 	if err == nil {
 		err = errc
 	}

--- a/tcpdialer.go
+++ b/tcpdialer.go
@@ -289,6 +289,12 @@ func FlushDNSCache() {
 }
 
 func (d *TCPDialer) dial(addr string, dualStack bool, timeout time.Duration) (net.Conn, error) {
+	return d.dialContext(context.Background(), addr, dualStack, timeout)
+}
+
+func (d *TCPDialer) dialContext(
+	ctx context.Context, addr string, dualStack bool, timeout time.Duration,
+) (net.Conn, error) {
 	d.once.Do(func() {
 		if d.Concurrency > 0 {
 			d.concurrencyCh = make(chan struct{}, d.Concurrency)
@@ -298,15 +304,21 @@ func (d *TCPDialer) dial(addr string, dualStack bool, timeout time.Duration) (ne
 			d.DNSCacheDuration = DefaultDNSCacheDuration
 		}
 	})
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	deadline := time.Now().Add(timeout)
+	if contextDeadline, ok := ctx.Deadline(); ok && contextDeadline.Before(deadline) {
+		deadline = contextDeadline
+	}
 	network := "tcp4"
 	if dualStack {
 		network = "tcp"
 	}
 	if d.DisableDNSResolution {
-		return d.tryDial(network, addr, deadline, d.concurrencyCh)
+		return d.tryDialContext(ctx, network, addr, deadline, d.concurrencyCh)
 	}
-	addrs, idx, err := d.getTCPAddrs(addr, dualStack, deadline)
+	addrs, idx, err := d.getTCPAddrsContext(ctx, addr, dualStack, deadline)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +326,7 @@ func (d *TCPDialer) dial(addr string, dualStack bool, timeout time.Duration) (ne
 	var conn net.Conn
 	n := uint32(len(addrs)) // #nosec G115
 	for range n {
-		conn, err = d.tryDial(network, addrs[idx%n].String(), deadline, d.concurrencyCh)
+		conn, err = d.tryDialContext(ctx, network, addrs[idx%n].String(), deadline, d.concurrencyCh)
 		if err == nil {
 			return conn, nil
 		}
@@ -326,8 +338,8 @@ func (d *TCPDialer) dial(addr string, dualStack bool, timeout time.Duration) (ne
 	return nil, err
 }
 
-func (d *TCPDialer) tryDial(
-	network string, addr string, deadline time.Time, concurrencyCh chan struct{},
+func (d *TCPDialer) tryDialContext(
+	ctx context.Context, network string, addr string, deadline time.Time, concurrencyCh chan struct{},
 ) (net.Conn, error) {
 	timeout := time.Until(deadline)
 	if timeout <= 0 {
@@ -342,6 +354,9 @@ func (d *TCPDialer) tryDial(
 			isTimeout := false
 			select {
 			case concurrencyCh <- struct{}{}:
+			case <-ctx.Done():
+				ReleaseTimer(tc)
+				return nil, wrapDialWithUpstream(ctx.Err(), addr)
 			case <-tc.C:
 				isTimeout = true
 			}
@@ -358,11 +373,14 @@ func (d *TCPDialer) tryDial(
 		dialer.LocalAddr = d.LocalAddr
 	}
 
-	ctx, cancelCtx := context.WithDeadline(context.Background(), deadline)
+	dialCtx, cancelCtx := context.WithDeadline(ctx, deadline)
 	defer cancelCtx()
-	conn, err := dialer.DialContext(ctx, network, addr)
+	conn, err := dialer.DialContext(dialCtx, network, addr)
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, wrapDialWithUpstream(contextErr, addr)
+		}
+		if dialCtx.Err() == context.DeadlineExceeded {
 			return nil, wrapDialWithUpstream(ErrDialTimeout, addr)
 		}
 		return nil, wrapDialWithUpstream(err, addr)
@@ -476,7 +494,9 @@ func (d *TCPDialer) tcpAddrsClean() {
 	}
 }
 
-func (d *TCPDialer) getTCPAddrs(addr string, dualStack bool, deadline time.Time) ([]net.TCPAddr, uint32, error) {
+func (d *TCPDialer) getTCPAddrsContext(
+	ctx context.Context, addr string, dualStack bool, deadline time.Time,
+) ([]net.TCPAddr, uint32, error) {
 	item, exist := d.tcpAddrsMap.Load(addr)
 	e, ok := item.(*tcpAddrEntry)
 	if exist && ok && e != nil && time.Since(e.resolveTime) > d.DNSCacheDuration {
@@ -487,7 +507,7 @@ func (d *TCPDialer) getTCPAddrs(addr string, dualStack bool, deadline time.Time)
 	}
 
 	if e == nil {
-		addrs, err := resolveTCPAddrs(addr, dualStack, d.Resolver, deadline)
+		addrs, err := resolveTCPAddrsContext(ctx, addr, dualStack, d.Resolver, deadline)
 		if err != nil {
 			item, exist := d.tcpAddrsMap.Load(addr)
 			e, ok = item.(*tcpAddrEntry)
@@ -509,7 +529,9 @@ func (d *TCPDialer) getTCPAddrs(addr string, dualStack bool, deadline time.Time)
 	return e.addrs, idx, nil
 }
 
-func resolveTCPAddrs(addr string, dualStack bool, resolver Resolver, deadline time.Time) ([]net.TCPAddr, error) {
+func resolveTCPAddrsContext(
+	ctx context.Context, addr string, dualStack bool, resolver Resolver, deadline time.Time,
+) ([]net.TCPAddr, error) {
 	host, portS, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
@@ -523,7 +545,7 @@ func resolveTCPAddrs(addr string, dualStack bool, resolver Resolver, deadline ti
 		resolver = net.DefaultResolver
 	}
 
-	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 	ipaddrs, err := resolver.LookupIPAddr(ctx, host)
 	if err != nil {


### PR DESCRIPTION
Fixes #2198.

## What

- add package-level, `Client`, and `HostClient` `DoContext` entry points
- add optional context-aware dialer and transport interfaces while preserving legacy `Do` dispatch
- propagate cancellation through connection-pool waits, default DNS/dial, TLS, request writes, closable request streams, response reads, and streamed responses
- preserve the earlier of the request timeout and context deadline, including existing `ErrTimeout` semantics
- keep ordinary buffered `DoTimeout` / `DoDeadline` requests on the existing no-watcher hot path

## Why

Copying a context deadline into the request timeout is not enough to interrupt pool waits, dialing, TLS negotiation, blocked I/O, or streamed response reads. This change carries cancellation through those blocking boundaries while retaining compatibility for callers that use the existing dialer and transport interfaces.

## Verification

- `go vet ./...` with Go 1.25.0
- `go test -count=1 -shuffle=on ./...` with Go 1.25.0 and Go 1.26.7
- `go test -race -count=1 -shuffle=on ./...` with Go 1.25.0 and Go 1.26.7
- focused context tests under `-race -count=10`
- focused context and stream-close tests under `-count=20` with Go 1.25.0 on Windows/amd64
- request-body cancellation/timeout/early-exit regressions under `-race -count=100`
- golangci-lint v2.10.1 in a clean LF checkout: 0 issues
- `BenchmarkClientGetTimeoutFastServer`, 5 runs at 2s with `-benchmem`: HEAD and this branch both report 230 B/op and 7 allocs/op; timing distributions overlap
- `git diff --check`

## Compatibility and boundaries

- legacy `Dial`, `DialTimeout`, and custom `RoundTripper` implementations cannot be forcibly interrupted; callers that need cancellation should use `DialContext` and `RoundTripperWithContext`
- cancellation calls `Close` on a request body stream when it implements `io.Closer`; a non-interruptible reader must return on its own
- full and race validation was run on Linux/amd64; Windows/amd64 received the focused 20-run context suite, while the full Windows suite, Windows race mode, and macOS remain unverified locally and are left to CI

## AI assistance

I used AI tools to help trace blocking paths, draft implementation and tests, and review the final diff. I manually reviewed every change, reproduced the identified edge cases, and ran all verification listed above.
