### PR TITLE
fix: write trailers for buffered bodies in Request.Write and Response.Write

### DIFF
--- a/http.go
+++ b/http.go
@@ -1856,6 +1856,9 @@ func (req *Request) Write(w *bufio.Writer) error {
 		req.Header.SetContentLength(len(body))
 	}
 	if hasBody && len(req.Header.trailer) > 0 && req.Header.IsHTTP11() {
+		if len(body) > 0 && !req.Header.noDefaultContentType && len(req.Header.ContentType()) == 0 {
+			req.Header.SetContentTypeBytes(strDefaultContentType)
+		}
 		req.Header.SetContentLength(-1)
 		if err = req.Header.Write(w); err != nil {
 			return err

--- a/http.go
+++ b/http.go
@@ -1855,12 +1855,12 @@ func (req *Request) Write(w *bufio.Writer) error {
 		hasBody = true
 		req.Header.SetContentLength(len(body))
 	}
-	if hasBody && len(req.Header.trailer) > 0 {
+	if hasBody && len(req.Header.trailer) > 0 && req.Header.IsHTTP11() {
 		req.Header.SetContentLength(-1)
 		if err = req.Header.Write(w); err != nil {
 			return err
 		}
-		if err = writeBodyChunked(w, bytes.NewReader(body)); err != nil {
+		if err = writeBufferedBodyChunked(w, body); err != nil {
 			return err
 		}
 		return req.Header.writeTrailer(w)
@@ -2300,12 +2300,12 @@ func (resp *Response) Write(w *bufio.Writer) error {
 	if sendBody || bodyLen > 0 {
 		resp.Header.SetContentLength(bodyLen)
 	}
-	if sendBody && len(resp.Header.trailer) > 0 {
+	if sendBody && len(resp.Header.trailer) > 0 && resp.Header.IsHTTP11() {
 		resp.Header.SetContentLength(-1)
 		if err := resp.Header.Write(w); err != nil {
 			return err
 		}
-		if err := writeBodyChunked(w, bytes.NewReader(body)); err != nil {
+		if err := writeBufferedBodyChunked(w, body); err != nil {
 			return err
 		}
 		return resp.Header.writeTrailer(w)
@@ -2803,6 +2803,13 @@ var copyBufPool = sync.Pool{
 }
 
 func writeChunk(w *bufio.Writer, b []byte) error {
+	if err := writeChunkNoFlush(w, b); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func writeChunkNoFlush(w *bufio.Writer, b []byte) error {
 	n := len(b)
 	if err := writeHexInt(w, n); err != nil {
 		return err
@@ -2819,7 +2826,16 @@ func writeChunk(w *bufio.Writer, b []byte) error {
 			return err
 		}
 	}
-	return w.Flush()
+	return nil
+}
+
+func writeBufferedBodyChunked(w *bufio.Writer, body []byte) error {
+	if len(body) > 0 {
+		if err := writeChunkNoFlush(w, body); err != nil {
+			return err
+		}
+	}
+	return writeChunkNoFlush(w, nil)
 }
 
 // ErrBodyTooLarge is returned if either request or response body exceeds

--- a/http.go
+++ b/http.go
@@ -1855,6 +1855,16 @@ func (req *Request) Write(w *bufio.Writer) error {
 		hasBody = true
 		req.Header.SetContentLength(len(body))
 	}
+	if hasBody && len(req.Header.trailer) > 0 {
+		req.Header.SetContentLength(-1)
+		if err = req.Header.Write(w); err != nil {
+			return err
+		}
+		if err = writeBodyChunked(w, bytes.NewReader(body)); err != nil {
+			return err
+		}
+		return req.Header.writeTrailer(w)
+	}
 	if err = req.Header.Write(w); err != nil {
 		return err
 	}
@@ -2289,6 +2299,16 @@ func (resp *Response) Write(w *bufio.Writer) error {
 	bodyLen := len(body)
 	if sendBody || bodyLen > 0 {
 		resp.Header.SetContentLength(bodyLen)
+	}
+	if sendBody && len(resp.Header.trailer) > 0 {
+		resp.Header.SetContentLength(-1)
+		if err := resp.Header.Write(w); err != nil {
+			return err
+		}
+		if err := writeBodyChunked(w, bytes.NewReader(body)); err != nil {
+			return err
+		}
+		return resp.Header.writeTrailer(w)
 	}
 	if err := resp.Header.Write(w); err != nil {
 		return err

--- a/http_test.go
+++ b/http_test.go
@@ -298,6 +298,131 @@ func testResponseBodyStreamWithTrailer(t *testing.T, body []byte, disableNormali
 	}
 }
 
+func TestRequestBufferedBodyWithTrailer(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{"", "data"} {
+		var req1 Request
+		req1.Header.SetMethod(MethodPost)
+		req1.SetRequestURI("http://example.com/upload")
+		req1.SetBodyString(body)
+		if err := req1.Header.AddTrailer("Foo"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		req1.Header.Set("Foo", "testfoo")
+
+		w := &bytes.Buffer{}
+		bw := bufio.NewWriter(w)
+		if err := req1.Write(bw); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := bw.Flush(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wire := w.String()
+		if !strings.Contains(wire, "Transfer-Encoding: chunked\r\n") {
+			t.Fatalf("expected chunked transfer encoding, got:\n%q", wire)
+		}
+		if strings.Contains(wire, "Content-Length:") {
+			t.Fatalf("expected no content length, got:\n%q", wire)
+		}
+		if !strings.Contains(wire, "Trailer: Foo\r\n") {
+			t.Fatalf("expected the Trailer header, got:\n%q", wire)
+		}
+		if !strings.HasSuffix(wire, "0\r\nFoo: testfoo\r\n\r\n") {
+			t.Fatalf("expected the trailer after the last chunk, got:\n%q", wire)
+		}
+
+		var req2 Request
+		if err := req2.Read(bufio.NewReader(w)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(req2.Body()) != body {
+			t.Fatalf("unexpected body: %q. Expecting %q", req2.Body(), body)
+		}
+		if got := string(req2.Header.Peek("Foo")); got != "testfoo" {
+			t.Fatalf("unexpected trailer header %q. Expecting %q", got, "testfoo")
+		}
+	}
+}
+
+func TestResponseBufferedBodyWithTrailer(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{"", "data"} {
+		var resp1 Response
+		resp1.SetBodyString(body)
+		if err := resp1.Header.AddTrailer("Foo"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		resp1.Header.Set("Foo", "testfoo")
+
+		w := &bytes.Buffer{}
+		bw := bufio.NewWriter(w)
+		if err := resp1.Write(bw); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := bw.Flush(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wire := w.String()
+		if !strings.Contains(wire, "Transfer-Encoding: chunked\r\n") {
+			t.Fatalf("expected chunked transfer encoding, got:\n%q", wire)
+		}
+		if strings.Contains(wire, "Content-Length:") {
+			t.Fatalf("expected no content length, got:\n%q", wire)
+		}
+		if !strings.Contains(wire, "Trailer: Foo\r\n") {
+			t.Fatalf("expected the Trailer header, got:\n%q", wire)
+		}
+		if !strings.HasSuffix(wire, "0\r\nFoo: testfoo\r\n\r\n") {
+			t.Fatalf("expected the trailer after the last chunk, got:\n%q", wire)
+		}
+
+		var resp2 Response
+		if err := resp2.Read(bufio.NewReader(w)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(resp2.Body()) != body {
+			t.Fatalf("unexpected body: %q. Expecting %q", resp2.Body(), body)
+		}
+		if got := string(resp2.Header.Peek("Foo")); got != "testfoo" {
+			t.Fatalf("unexpected trailer header %q. Expecting %q", got, "testfoo")
+		}
+	}
+}
+
+func TestResponseBufferedBodyWithTrailerSkipBody(t *testing.T) {
+	t.Parallel()
+
+	var resp Response
+	resp.SkipBody = true
+	resp.SetBodyString("data")
+	if err := resp.Header.AddTrailer("Foo"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Header.Set("Foo", "testfoo")
+
+	w := &bytes.Buffer{}
+	bw := bufio.NewWriter(w)
+	if err := resp.Write(bw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wire := w.String()
+	if strings.Contains(wire, "Transfer-Encoding: chunked\r\n") {
+		t.Fatalf("expected no chunked transfer encoding without a sent body, got:\n%q", wire)
+	}
+	if !strings.HasSuffix(wire, "\r\n\r\n") || strings.HasSuffix(wire, "Foo: testfoo\r\n\r\n") {
+		t.Fatalf("expected no body and no trailer values on the wire, got:\n%q", wire)
+	}
+}
+
 func TestResponseBodyStreamDeflate(t *testing.T) {
 	t.Parallel()
 

--- a/http_test.go
+++ b/http_test.go
@@ -423,6 +423,162 @@ func TestResponseBufferedBodyWithTrailerSkipBody(t *testing.T) {
 	}
 }
 
+func TestRequestBufferedBodyWithTrailerHTTP10(t *testing.T) {
+	t.Parallel()
+
+	var req1 Request
+	req1.Header.SetMethod(MethodPost)
+	req1.Header.SetProtocol("HTTP/1.0")
+	req1.SetRequestURI("http://example.com/upload")
+	req1.SetBodyString("data")
+	if err := req1.Header.AddTrailer("Foo"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req1.Header.Set("Foo", "testfoo")
+
+	w := &bytes.Buffer{}
+	bw := bufio.NewWriter(w)
+	if err := req1.Write(bw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// HTTP/1.0 doesn't support chunked encoding, so the body keeps
+	// Content-Length framing.
+	wire := w.String()
+	if !strings.HasPrefix(wire, "POST /upload HTTP/1.0\r\n") {
+		t.Fatalf("unexpected request line, got:\n%q", wire)
+	}
+	if strings.Contains(wire, "Transfer-Encoding:") {
+		t.Fatalf("expected no transfer encoding for HTTP/1.0, got:\n%q", wire)
+	}
+	if !strings.Contains(wire, "Content-Length: 4\r\n") {
+		t.Fatalf("expected content length, got:\n%q", wire)
+	}
+	if !strings.HasSuffix(wire, "\r\n\r\ndata") {
+		t.Fatalf("expected a plain body, got:\n%q", wire)
+	}
+
+	var req2 Request
+	if err := req2.Read(bufio.NewReader(w)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(req2.Body()) != "data" {
+		t.Fatalf("unexpected body: %q. Expecting %q", req2.Body(), "data")
+	}
+}
+
+func TestResponseBufferedBodyWithTrailerHTTP10(t *testing.T) {
+	t.Parallel()
+
+	// Only parsing marks a ResponseHeader as HTTP/1.0, so start from a
+	// parsed HTTP/1.0 response, like a proxy forwarding an upstream response.
+	var resp1 Response
+	br := bufio.NewReader(strings.NewReader("HTTP/1.0 200 OK\r\nContent-Length: 4\r\n\r\ndata"))
+	if err := resp1.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp1.Header.IsHTTP11() {
+		t.Fatal("expected an HTTP/1.0 response header")
+	}
+	if err := resp1.Header.AddTrailer("Foo"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp1.Header.Set("Foo", "testfoo")
+
+	w := &bytes.Buffer{}
+	bw := bufio.NewWriter(w)
+	if err := resp1.Write(bw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wire := w.String()
+	if !strings.HasPrefix(wire, "HTTP/1.0 200 OK\r\n") {
+		t.Fatalf("unexpected status line, got:\n%q", wire)
+	}
+	if strings.Contains(wire, "Transfer-Encoding:") {
+		t.Fatalf("expected no transfer encoding for HTTP/1.0, got:\n%q", wire)
+	}
+	if !strings.Contains(wire, "Content-Length: 4\r\n") {
+		t.Fatalf("expected content length, got:\n%q", wire)
+	}
+	if !strings.HasSuffix(wire, "\r\n\r\ndata") {
+		t.Fatalf("expected a plain body, got:\n%q", wire)
+	}
+
+	var resp2 Response
+	if err := resp2.Read(bufio.NewReader(w)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(resp2.Body()) != "data" {
+		t.Fatalf("unexpected body: %q. Expecting %q", resp2.Body(), "data")
+	}
+}
+
+// writeCounter counts the writes reaching the underlying writer, which is
+// how often a bufio.Writer wrapping it was flushed.
+type writeCounter struct {
+	n int
+}
+
+func (wc *writeCounter) Write(p []byte) (int, error) {
+	wc.n++
+	return len(p), nil
+}
+
+func TestRequestBufferedBodyWithTrailerNoFlush(t *testing.T) {
+	t.Parallel()
+
+	var req Request
+	req.Header.SetMethod(MethodPost)
+	req.SetRequestURI("http://example.com/upload")
+	req.SetBodyString("data")
+	if err := req.Header.AddTrailer("Foo"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req.Header.Set("Foo", "testfoo")
+
+	var wc writeCounter
+	bw := bufio.NewWriter(&wc)
+	if err := req.Write(bw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wc.n != 0 {
+		t.Fatalf("Write flushed %d times, expecting none", wc.n)
+	}
+	if bw.Buffered() == 0 {
+		t.Fatal("expected the request to be buffered")
+	}
+}
+
+func TestResponseBufferedBodyWithTrailerNoFlush(t *testing.T) {
+	t.Parallel()
+
+	var resp Response
+	resp.SetBodyString("data")
+	if err := resp.Header.AddTrailer("Foo"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Header.Set("Foo", "testfoo")
+
+	var wc writeCounter
+	bw := bufio.NewWriter(&wc)
+	if err := resp.Write(bw); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wc.n != 0 {
+		t.Fatalf("Write flushed %d times, expecting none", wc.n)
+	}
+	if bw.Buffered() == 0 {
+		t.Fatal("expected the response to be buffered")
+	}
+}
+
 func TestResponseBodyStreamDeflate(t *testing.T) {
 	t.Parallel()
 

--- a/http_test.go
+++ b/http_test.go
@@ -394,6 +394,69 @@ func TestResponseBufferedBodyWithTrailer(t *testing.T) {
 	}
 }
 
+func TestRequestBufferedBodyWithTrailerContentType(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		body        string
+		contentType string
+		noDefault   bool
+		expected    string
+	}{
+		// Switching to chunked encoding must keep the default
+		// Content-Type that a Content-Length framed body gets.
+		{name: "default", body: "data", expected: "application/octet-stream"},
+		{name: "explicit", body: "data", contentType: "text/plain", expected: "text/plain"},
+		{name: "no default", body: "data", noDefault: true, expected: ""},
+		{name: "empty body", body: "", expected: ""},
+	} {
+		var req1 Request
+		req1.Header.SetMethod(MethodPost)
+		req1.SetRequestURI("http://example.com/upload")
+		req1.SetBodyString(tc.body)
+		if tc.contentType != "" {
+			req1.Header.SetContentType(tc.contentType)
+		}
+		req1.Header.SetNoDefaultContentType(tc.noDefault)
+		if err := req1.Header.AddTrailer("Foo"); err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		req1.Header.Set("Foo", "testfoo")
+
+		w := &bytes.Buffer{}
+		bw := bufio.NewWriter(w)
+		if err := req1.Write(bw); err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if err := bw.Flush(); err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+
+		wire := w.String()
+		if !strings.Contains(wire, "Transfer-Encoding: chunked\r\n") {
+			t.Fatalf("%s: expected chunked transfer encoding, got:\n%q", tc.name, wire)
+		}
+		if tc.expected == "" {
+			if strings.Contains(wire, "Content-Type:") {
+				t.Fatalf("%s: expected no content type, got:\n%q", tc.name, wire)
+			}
+			continue
+		}
+		if !strings.Contains(wire, "Content-Type: "+tc.expected+"\r\n") {
+			t.Fatalf("%s: expected content type %q, got:\n%q", tc.name, tc.expected, wire)
+		}
+
+		var req2 Request
+		if err := req2.Read(bufio.NewReader(w)); err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if got := string(req2.Header.ContentType()); got != tc.expected {
+			t.Fatalf("%s: unexpected content type %q. Expecting %q", tc.name, got, tc.expected)
+		}
+	}
+}
+
 func TestResponseBufferedBodyWithTrailerSkipBody(t *testing.T) {
 	t.Parallel()
 

--- a/server.go
+++ b/server.go
@@ -2395,6 +2395,7 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		hijackNoResponse bool
 
 		connectionClose bool
+		isHTTP11        bool
 
 		continueReadingRequest = true
 	)
@@ -2641,6 +2642,10 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 			s.Handler(ctx)
 		}
 
+		// Remember the request version before ctx may be replaced with a
+		// fresh one below, whose request defaults to HTTP/1.1.
+		isHTTP11 = ctx.Request.Header.IsHTTP11()
+
 		timeoutResponse = ctx.timeoutResponse
 		if timeoutResponse != nil {
 			// Acquire a new ctx because the old one will still be in use by the timeout out handler.
@@ -2676,13 +2681,13 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 			(s.CloseOnShutdown && s.stop.Load() == 1)
 		if connectionClose {
 			ctx.Response.Header.SetConnectionClose()
-		} else if !ctx.Request.Header.IsHTTP11() {
+		} else if !isHTTP11 {
 			// Set 'Connection: keep-alive' response header for HTTP/1.0 request.
 			// There is no need in setting this header for http/1.1, since in http/1.1
 			// connections are keep-alive by default.
 			ctx.Response.Header.setNonSpecial(strConnection, strKeepAlive)
 		}
-		if !ctx.Request.Header.IsHTTP11() {
+		if !isHTTP11 {
 			// HTTP/1.0 clients can't read chunked encoding, so let
 			// Response.Write keep Content-Length framing for them.
 			ctx.Response.Header.noHTTP11 = true

--- a/server.go
+++ b/server.go
@@ -2682,6 +2682,11 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 			// connections are keep-alive by default.
 			ctx.Response.Header.setNonSpecial(strConnection, strKeepAlive)
 		}
+		if !ctx.Request.Header.IsHTTP11() {
+			// HTTP/1.0 clients can't read chunked encoding, so let
+			// Response.Write keep Content-Length framing for them.
+			ctx.Response.Header.noHTTP11 = true
+		}
 
 		if serverName != "" && len(ctx.Response.Header.Server()) == 0 {
 			ctx.Response.Header.SetServer(serverName)

--- a/server.go
+++ b/server.go
@@ -2630,6 +2630,10 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		// Preserve connectionClose if already set (e.g., by ExpectHandler).
 		connectionClose = connectionClose || s.DisableKeepalive || ctx.Request.Header.ConnectionClose()
 
+		// Remember the request version before ctx may be replaced with a
+		// fresh one below, whose request defaults to HTTP/1.1.
+		isHTTP11 = ctx.Request.Header.IsHTTP11()
+
 		if serverName != "" {
 			ctx.Response.Header.SetServer(serverName)
 		}
@@ -2641,10 +2645,6 @@ func (s *Server) serveConnCounted(c net.Conn, countConcurrency bool) error {
 		if continueReadingRequest {
 			s.Handler(ctx)
 		}
-
-		// Remember the request version before ctx may be replaced with a
-		// fresh one below, whose request defaults to HTTP/1.1.
-		isHTTP11 = ctx.Request.Header.IsHTTP11()
 
 		timeoutResponse = ctx.timeoutResponse
 		if timeoutResponse != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -2790,6 +2790,59 @@ func TestRequestCtxWriteString(t *testing.T) {
 	}
 }
 
+func TestServeConnBufferedBodyWithTrailer(t *testing.T) {
+	t.Parallel()
+
+	handler := func(ctx *RequestCtx) {
+		if err := ctx.Response.Header.AddTrailer("Foo"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		ctx.Response.Header.Set("Foo", "testfoo")
+		ctx.SetBodyString("data")
+	}
+
+	for _, tc := range []struct {
+		proto   string
+		chunked bool
+	}{
+		// HTTP/1.0 clients can't read chunked encoding, so the
+		// buffered body keeps Content-Length framing.
+		{proto: "HTTP/1.0", chunked: false},
+		{proto: "HTTP/1.1", chunked: true},
+	} {
+		rw := &readWriter{}
+		rw.r.WriteString("GET / " + tc.proto + "\r\nHost: example.com\r\n\r\n")
+
+		ch := make(chan struct{})
+		go func() {
+			if err := ServeConn(rw, handler); err != nil {
+				t.Errorf("unexpected error in ServeConn: %v", err)
+			}
+			close(ch)
+		}()
+
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
+
+		wire := rw.w.String()
+		if chunked := strings.Contains(wire, "Transfer-Encoding: chunked\r\n"); chunked != tc.chunked {
+			t.Fatalf("%s: chunked=%v, expecting %v, got:\n%q", tc.proto, chunked, tc.chunked, wire)
+		}
+		if tc.chunked {
+			if !strings.HasSuffix(wire, "0\r\nFoo: testfoo\r\n\r\n") {
+				t.Fatalf("%s: expected the trailer after the last chunk, got:\n%q", tc.proto, wire)
+			}
+			continue
+		}
+		if !strings.Contains(wire, "Content-Length: 4\r\n") || !strings.HasSuffix(wire, "\r\n\r\ndata") {
+			t.Fatalf("%s: expected a Content-Length framed body, got:\n%q", tc.proto, wire)
+		}
+	}
+}
+
 func TestServeConnKeepRequestAndResponseUntilResetUserValues(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -2843,6 +2843,66 @@ func TestServeConnBufferedBodyWithTrailer(t *testing.T) {
 	}
 }
 
+func TestServeConnTimeoutErrorWithResponseBufferedBodyWithTrailer(t *testing.T) {
+	t.Parallel()
+
+	handler := func(ctx *RequestCtx) {
+		var resp Response
+		if err := resp.Header.AddTrailer("Foo"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		resp.Header.Set("Foo", "testfoo")
+		resp.SetBodyString("data")
+		ctx.TimeoutErrorWithResponse(&resp)
+	}
+
+	for _, tc := range []struct {
+		proto   string
+		chunked bool
+	}{
+		// The timeout response is written from a fresh ctx, so the framing
+		// and the Connection header must still follow the original request.
+		{proto: "HTTP/1.0", chunked: false},
+		{proto: "HTTP/1.1", chunked: true},
+	} {
+		rw := &readWriter{}
+		rw.r.WriteString("GET / ")
+		rw.r.WriteString(tc.proto)
+		rw.r.WriteString("\r\nHost: example.com\r\nConnection: keep-alive\r\n\r\n")
+
+		ch := make(chan struct{})
+		go func() {
+			if err := ServeConn(rw, handler); err != nil {
+				t.Errorf("unexpected error in ServeConn: %v", err)
+			}
+			close(ch)
+		}()
+
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
+
+		wire := rw.w.String()
+		if chunked := strings.Contains(wire, "Transfer-Encoding: chunked\r\n"); chunked != tc.chunked {
+			t.Fatalf("%s: chunked=%v, expecting %v, got:\n%q", tc.proto, chunked, tc.chunked, wire)
+		}
+		if tc.chunked {
+			if !strings.HasSuffix(wire, "0\r\nFoo: testfoo\r\n\r\n") {
+				t.Fatalf("%s: expected the trailer after the last chunk, got:\n%q", tc.proto, wire)
+			}
+			continue
+		}
+		if !strings.Contains(wire, "Content-Length: 4\r\n") || !strings.HasSuffix(wire, "\r\n\r\ndata") {
+			t.Fatalf("%s: expected a Content-Length framed body, got:\n%q", tc.proto, wire)
+		}
+		if !strings.Contains(wire, "Connection: keep-alive\r\n") {
+			t.Fatalf("%s: expected a keep-alive header for an HTTP/1.0 request, got:\n%q", tc.proto, wire)
+		}
+	}
+}
+
 func TestServeConnKeepRequestAndResponseUntilResetUserValues(t *testing.T) {
 	t.Parallel()
 

--- a/server_test.go
+++ b/server_test.go
@@ -3671,6 +3671,75 @@ func TestTimeoutHandlerTimeout(t *testing.T) {
 	}
 }
 
+func TestTimeoutHandlerSetProtocolRace(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		proto        string
+		handlerProto string
+		keepAlive    bool
+	}{
+		// TimeoutHandler returns while h keeps running on its own goroutine,
+		// so the request version used for the timeout response must be read
+		// before the handler is called instead of after it returns.
+		{proto: "HTTP/1.0", handlerProto: "HTTP/1.1", keepAlive: true},
+		{proto: "HTTP/1.1", handlerProto: "HTTP/1.0", keepAlive: false},
+	} {
+		release := make(chan struct{})
+		done := make(chan struct{})
+		h := func(ctx *RequestCtx) {
+			ctx.Request.Header.SetProtocol(tc.handlerProto)
+			<-release
+			close(done)
+		}
+
+		ln := fasthttputil.NewInmemoryListener()
+		s := &Server{
+			Handler: TimeoutHandler(h, 20*time.Millisecond, "timeout"),
+		}
+		serverCh := make(chan struct{})
+		go func() {
+			if err := s.Serve(ln); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			close(serverCh)
+		}()
+
+		conn, err := ln.Dial()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, err = conn.Write([]byte("GET / " + tc.proto + "\r\nHost: example.com\r\nConnection: keep-alive\r\n\r\n")); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		br := bufio.NewReader(conn)
+		resp := verifyResponse(t, br, StatusRequestTimeout, string(defaultContentType), "timeout")
+		if keepAlive := bytes.Equal(resp.Header.Peek(HeaderConnection), strKeepAlive); keepAlive != tc.keepAlive {
+			t.Fatalf("%s: keep-alive header=%v, expecting %v, got:\n%s", tc.proto, keepAlive, tc.keepAlive, resp.Header.String())
+		}
+		if err = conn.Close(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Let the handler goroutine finish only after the response was read.
+		close(release)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
+
+		if err = ln.Close(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		select {
+		case <-serverCh:
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
+	}
+}
+
 func TestTimeoutHandlerTimeoutReuse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
@erikdubbelboer `writeTrailer` is only called from the streamed body paths, so writing a request/response with a buffered body and registered trailers produces `Content-Length` framing with a dangling `Trailer:` header and the values are never written.

Found while working on #2104, split out as requested there.

[RFC 9112 7.1.2](https://datatracker.ietf.org/doc/html/rfc9112#name-chunked-trailer-section)