### PR TITLE
avoid race condition for closing the streaming connection at EOF

### DIFF
--- a/streaming.go
+++ b/streaming.go
@@ -22,11 +22,22 @@ type requestStream struct {
 	totalBytesRead  int
 	chunkLeft       int
 	strictEOF       bool
+	eof             bool
 }
 
 func (rs *requestStream) Read(p []byte) (int, error) {
 	if rs.reader == nil {
 		panic("BUG: reading released body stream")
+	}
+
+	// The stream is terminal once the body has ended. Without this, a chunked
+	// stream re-enters parseChunkSize on the next Read and blocks waiting for a
+	// chunk header that is never coming: a keep-alive connection stays open
+	// after the body ends, so nothing wakes the read. Any caller that reads a
+	// streamed body to EOF and then reads again - draining before release is the
+	// common case - would park a goroutine and never release the connection.
+	if rs.eof {
+		return 0, io.EOF
 	}
 
 	var (
@@ -45,6 +56,7 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 				if err != nil && err != io.EOF {
 					return 0, err
 				}
+				rs.eof = true
 				return 0, io.EOF
 			}
 			rs.chunkLeft = chunkSize
@@ -62,6 +74,7 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 		return n, err
 	}
 	if rs.totalBytesRead == contentLength {
+		rs.eof = true
 		return 0, io.EOF
 	}
 	prefetchedSize := int(rs.prefetchedBytes.Size())
@@ -73,6 +86,7 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 		n, err := rs.prefetchedBytes.Read(p)
 		rs.totalBytesRead += n
 		if rs.totalBytesRead == contentLength {
+			rs.eof = true
 			return n, io.EOF
 		}
 		return n, err
@@ -87,10 +101,14 @@ func (rs *requestStream) Read(p []byte) (int, error) {
 		err = io.ErrUnexpectedEOF
 	}
 	if err != nil {
+		if err == io.EOF {
+			rs.eof = true
+		}
 		return n, err
 	}
 
 	if rs.totalBytesRead == contentLength {
+		rs.eof = true
 		err = io.EOF
 	}
 	return n, err
@@ -118,6 +136,7 @@ func releaseRequestStream(rs *requestStream) {
 	rs.reader = nil
 	rs.header = nil
 	rs.contentLength = 0
+	rs.eof = false
 	rs.strictEOF = false
 	requestStreamPool.Put(rs)
 }

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -3,6 +3,7 @@ package fasthttp
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasthttp/fasthttputil"
 )
 
@@ -263,4 +265,59 @@ func BenchmarkRequestStreamE2E(b *testing.B) {
 	}
 
 	wg.Wait()
+}
+
+// TestRequestStreamStaysAtEOF verifies that a chunked requestStream keeps
+// returning io.EOF once the terminating chunk has been consumed.
+//
+// Without a terminal state, a second Read re-enters parseChunkSize and waits for
+// another chunk header that is never coming. On a keep-alive connection, which
+// stays open after the response body ends, that read blocks for as long as the
+// peer holds the socket open. Any caller that reads a streamed body to EOF and
+// then reads again - draining before release is the common case - parks a
+// goroutine and never releases the connection.
+func TestRequestStreamStaysAtEOF(t *testing.T) {
+	t.Parallel()
+
+	body := createFixedBody(10)
+	chunked := createChunkedBody(body, nil, true)
+
+	// A pipe that is never closed models a keep-alive connection: the body ends,
+	// but the peer keeps the socket open and sends nothing more.
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = pw.Write(chunked)
+	}()
+	t.Cleanup(func() { _ = pr.Close() })
+
+	var h ResponseHeader
+	h.SetContentLength(-1)
+
+	bb := bytebufferpool.Get()
+	defer bytebufferpool.Put(bb)
+	rs := acquireRequestStream(bb, bufio.NewReader(pr), &h)
+	defer releaseRequestStream(rs)
+
+	got, err := io.ReadAll(rs)
+	if err != nil {
+		t.Fatalf("unexpected error reading body: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("unexpected body %q. Expecting %q", got, body)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, readErr := rs.Read(make([]byte, 1))
+		done <- readErr
+	}()
+
+	select {
+	case readErr := <-done:
+		if !errors.Is(readErr, io.EOF) {
+			t.Fatalf("unexpected error on read after EOF: %v. Expecting io.EOF", readErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Read after EOF blocked waiting for another chunk header")
+	}
 }


### PR DESCRIPTION
`requestStream` has no terminal state, so after it returns io.EOF for a chunked body the next Read re-enters parseChunkSize and waits for a chunk header that never comes, because a keep-alive connection stays open after the body ends. Any caller that reads a streamed body to EOF and then reads again, which is what draining before release does, parks a goroutine and never releases the connection, leaking one per affected response until the process restarts. This is separate from the pooled-resource race fixed in #2353: that made closing safe while a read is in flight, this is about a read issued after the body has legitimately ended. The fix records EOF on the stream and returns io.EOF immediately on subsequent reads, clearing the flag in releaseRequestStream so pooled instances start clean; the fixed-length paths were already re-checking totalBytesRead against contentLength and are unaffected, and strictEOF still converts a short read to io.ErrUnexpectedEOF without marking the stream terminal. TestRequestStreamStaysAtEOF reads a chunked body to EOF over a deliberately open pipe and then reads again, failing before with Read after EOF blocked waiting for another chunk header and passing after. Full suite green with and without -race (1171 tests, 16 packages), no existing test changed or removed.
