### PR TITLE
fix: prevent stale query string after clearing query args

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -762,9 +762,11 @@ func (u *URI) RequestURI() []byte {
 	} else {
 		dst = appendQuotedPath(u.requestURI[:0], u.Path())
 	}
-	if u.parsedQueryArgs && u.queryArgs.Len() > 0 {
-		dst = append(dst, '?')
-		dst = u.queryArgs.AppendBytes(dst)
+	if u.parsedQueryArgs {
+		if u.queryArgs.Len() > 0 {
+			dst = append(dst, '?')
+			dst = u.queryArgs.AppendBytes(dst)
+		}
 	} else if len(u.queryString) > 0 {
 		dst = append(dst, '?')
 		dst = append(dst, u.queryString...)

--- a/uri_test.go
+++ b/uri_test.go
@@ -638,3 +638,33 @@ func TestURIRequestURIEmptyPathWithQuery(t *testing.T) {
 		t.Fatalf("unexpected RequestURI with DisablePathNormalizing %q. Expecting %q", got, "/?foo=bar")
 	}
 }
+
+func TestURIRequestURIAfterDeletingAllQueryArgs(t *testing.T) {
+	t.Parallel()
+
+	var u URI
+	if err := u.Parse(nil, []byte("http://example.com/path?a=1")); err != nil {
+		t.Fatal(err)
+	}
+
+	u.QueryArgs().Del("a")
+
+	if got := string(u.RequestURI()); got != "/path" {
+		t.Fatalf("unexpected RequestURI %q; want %q", got, "/path")
+	}
+}
+
+func TestURIRequestURIAfterResettingQueryArgs(t *testing.T) {
+	t.Parallel()
+
+	var u URI
+	if err := u.Parse(nil, []byte("http://example.com/path?a=1&b=2")); err != nil {
+		t.Fatal(err)
+	}
+
+	u.QueryArgs().Reset()
+
+	if got := string(u.RequestURI()); got != "/path" {
+		t.Fatalf("unexpected RequestURI %q; want %q", got, "/path")
+	}
+}


### PR DESCRIPTION

When a URI is parsed, `QueryArgs()` sets `parsedQueryArgs` to true while the original raw query remains in `queryString`.

If all query arguments are subsequently removed with `QueryArgs().Del()` or `QueryArgs().Reset()`, `queryArgs.Len()` becomes zero. `URI.RequestURI()` then incorrectly falls back to the stale `queryString`, causing the removed query to reappear.

For example:

```go
var u URI
if err := u.Parse(nil, []byte("http://example.com/path?a=1")); err != nil {
    panic(err)
}

u.QueryArgs().Del("a")
fmt.Println(string(u.RequestURI()))
```

Before this change:

```text
/path?a=1
```

Expected:

```text
/path
```

Treat `parsedQueryArgs` as the source of truth once query arguments have been parsed. If the parsed arguments are empty, omit the query string instead of falling back to the original raw query.
