### PR TITLE
fix: preserve redirect path normalization setting in Request.CopyTo

### DIFF
--- a/http.go
+++ b/http.go
@@ -1015,6 +1015,7 @@ func (req *Request) copyToSkipBody(dst *Request) {
 	dst.isTLS = req.isTLS
 
 	dst.UseHostHeader = req.UseHostHeader
+	dst.DisableRedirectPathNormalizing = req.DisableRedirectPathNormalizing
 
 	// do not copy multipartForm - it will be automatically
 	// re-created on the first call to MultipartForm.

--- a/http_test.go
+++ b/http_test.go
@@ -147,6 +147,18 @@ func TestRequestCopyTo(t *testing.T) {
 	testRequestCopyTo(t, &req)
 }
 
+func TestRequestCopyToDisableRedirectPathNormalizing(t *testing.T) {
+	t.Parallel()
+
+	var src, dst Request
+	src.DisableRedirectPathNormalizing = true
+	src.CopyTo(&dst)
+
+	if !dst.DisableRedirectPathNormalizing {
+		t.Fatal("DisableRedirectPathNormalizing wasn't copied")
+	}
+}
+
 func TestResponseCopyTo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION

`Request.CopyTo` does not preserve `DisableRedirectPathNormalizing`.

This field controls redirect path normalization in `DoRedirects`. Since `copyToSkipBody()` copies the other request-level behavior flags, omitting this field causes a copied request to behave differently from the source request during redirects.

For example:

```go
var src, dst Request

src.DisableRedirectPathNormalizing = true
src.CopyTo(&dst)
```

Before this change, `dst.DisableRedirectPathNormalizing` remained `false`.

Copy `DisableRedirectPathNormalizing` in `copyToSkipBody()` so `Request.CopyTo` preserves the request's redirect behavior.

